### PR TITLE
feat: Improve status page layout on smaller devices

### DIFF
--- a/_layouts/status_update.html
+++ b/_layouts/status_update.html
@@ -23,32 +23,13 @@
           </div>
         </div>
       </div>
+      <div id="side" class="mobile-content">
+        {% include twitter-bio.html %}
+      </div>
       {% include footer.html %}
     </div>
-    <div id="side">
-    {% assign author_data = site.data.people[page.author] %}
-    {% if author_data %}
-      <div class="msg">
-        <h3>About</h3>
-        {{ author_data.name }}
-      </div><!--div.msg-->
-      <ul id="author-details">
-        {% if author_data.status-bio %}
-        <li>Bio: {{ author_data.status-bio }}</li>
-        {% endif %}
-        {% if author_data.location %}
-        <li>Location: {{ author_data.location }}</li>
-        {% endif %}
-        {% if author_data.author-page %}
-        <li>Web: <a href="{{ site.url }}{{ author_data.author-page }}">{{ site.url }}{{ author_data.author-page | truncate: 30 }}</a></li>
-        {% endif %}
-        {% else %}
-      </ul>
-      <p>About Aaron Aiken</p>
-      <p>Bio: Founder of Obvious</p>
-      <p>Location: Harrisburg, PA</p>
-      <p>Web: {{ site.url }}</p>
-    {% endif %}
+    <div id="side" class="desktop-content">
+    {% include twitter-bio.html %}
     </div>
   </body>
   <a class="u-url" href="{{ page.url | relative_url }}" hidden></a>


### PR DESCRIPTION
For the Rebellion to communicate effectively, our messages must be clear on all devices. This update ensures the sidebar bio is displayed logically beneath the status when viewed on smaller screens. No more awkward scrolling! May the Force (and responsive design) be with us.

closes #81 