### PR TITLE
refactor: extract shared helpers from app.py to helpers/

### DIFF
--- a/app.py
+++ b/app.py
@@ -75,97 +75,9 @@ from helpers.auth import is_authenticated, cd_auth_required
 from helpers.git import get_git_status, perform_git_ops
 
 
-# ---- COMMS HELPERS ----
+# ---- COMMS HELPERS ---- (moved to helpers/comms.py)
 
-def get_active_tags():
-	pa_tz = pytz.timezone('America/New_York')
-	now = datetime.now(pa_tz)
-	hour = now.hour
-	tags = ["ALL"]
-
-	tags.append(now.strftime("%A").upper())
-
-	if 5 <= hour < 12:
-		tags.append("AM")
-	if 12 <= hour < 24:
-		tags.append("PM")
-	if hour >= 17 or hour < 5:
-		tags.append("EVE")
-
-	day_type = "WEEKEND" if now.weekday() >= 5 else "WEEKDAY"
-	tags.append(day_type)
-
-	date_str = now.strftime("%m/%d")
-	if date_str == "12/25": tags.append("CHRISTMAS")
-	if date_str == "03/11": tags.append("BIRTHDAY")
-	if date_str == "04/05": tags.append("EASTER")
-
-	return tags
-
-
-def get_valid_comms():
-	active_tags = get_active_tags()
-	valid_comms = []
-
-	try:
-		with open('static/comms.txt', 'r') as f:
-			for line in f:
-				clean_line = line.strip()
-				if not clean_line:
-					continue
-
-				if "|" not in clean_line:
-					valid_comms.append(clean_line)
-					continue
-
-				parts = clean_line.split("|")
-				message = parts[-1].strip()
-				required_tags = [p.strip().upper() for p in parts[:-1] if p.strip()]
-
-				if all(tag in active_tags for tag in required_tags):
-					weight = 10 ** len(required_tags)
-					for _ in range(weight):
-						valid_comms.append(message)
-
-	except FileNotFoundError:
-		return ["Secure line cut."]
-
-	return valid_comms if valid_comms else ["Scanning..."]
-
-def get_after_dark_comms():
-    """
-    Load after_dark_comms.txt — same tag/pipe format as comms.txt.
-    Returns a deduplicated list of currently valid lines.
-    Silently returns [] if the file doesn't exist yet.
-    """
-    active_tags = get_active_tags()
-    valid = []
-    try:
-        with open(AFTER_DARK_COMMS_FILE, 'r') as f:
-            for line in f:
-                clean = line.strip()
-                if not clean:
-                    continue
-                if '|' not in clean:
-                    valid.append(clean)
-                    continue
-                parts = clean.split('|')
-                message = parts[-1].strip()
-                required_tags = [p.strip().upper() for p in parts[:-1] if p.strip()]
-                if all(tag in active_tags for tag in required_tags):
-                    weight = 10 ** len(required_tags)
-                    for _ in range(weight):
-                        valid.append(message)
-    except FileNotFoundError:
-        return []
-    # Deduplicate preserving order
-    seen = set()
-    unique = []
-    for m in valid:
-        if m not in seen:
-            seen.add(m)
-            unique.append(m)
-    return unique
+from helpers.comms import get_active_tags, get_valid_comms, get_after_dark_comms
 
 
 def load_scratch_work():

--- a/app.py
+++ b/app.py
@@ -80,34 +80,7 @@ from helpers.git import get_git_status, perform_git_ops
 from helpers.comms import get_active_tags, get_valid_comms, get_after_dark_comms
 
 
-def load_scratch_work():
-    """Load work scratchpad content."""
-    try:
-        with open(SCRATCH_WORK_FILE, 'r') as f:
-            data = json.load(f)
-        return data.get('content', ''), data.get('last_modified', None)
-    except FileNotFoundError:
-        return '', None
-
-
-def save_scratch_work(content, force=False):
-    """Persist work scratchpad content."""
-    if not content and not force:
-        try:
-            with open(SCRATCH_WORK_FILE, 'r') as f:
-                existing = json.load(f)
-            if existing.get('content', ''):
-                return existing.get('last_modified')
-        except FileNotFoundError:
-            pass
-    pa_tz = pytz.timezone('America/New_York')
-    last_modified = datetime.now(pa_tz).isoformat()
-    os.makedirs(os.path.dirname(SCRATCH_WORK_FILE), exist_ok=True)
-    tmp = SCRATCH_WORK_FILE + '.tmp'
-    with open(tmp, 'w') as f:
-        json.dump({'content': content, 'last_modified': last_modified}, f)
-    os.replace(tmp, SCRATCH_WORK_FILE)
-    return last_modified
+from helpers.scratch import load_scratch_work, save_scratch_work
 
 
 def list_bunny_ad_folder(subfolder):

--- a/app.py
+++ b/app.py
@@ -158,20 +158,9 @@ def upload_status_image_to_bunny(image_bytes, filename):
     return f"{BUNNY_STATUS_CDN_URL}/status/{filename}"
 
 
-# ---- TASKS HELPERS ----
+# ---- TASKS HELPERS ---- (load/save to helpers/tasks_json.py; post_task_status stays for cockpit blueprint)
 
-def load_tasks():
-	try:
-		with open(TASKS_FILE, 'r') as f:
-			return json.load(f)
-	except FileNotFoundError:
-		return {"tasks": []}
-
-
-def save_tasks(data):
-	os.makedirs(os.path.dirname(TASKS_FILE), exist_ok=True)
-	with open(TASKS_FILE, 'w') as f:
-		json.dump(data, f, indent=2)
+from helpers.tasks_json import load_tasks, save_tasks
 
 
 def post_task_status(title):

--- a/app.py
+++ b/app.py
@@ -69,10 +69,9 @@ _comms_cache = {'data': None, 'timestamp': 0}
 COMMS_CACHE_TTL = 300  # 5 minutes
 
 
-# ---- AUTH ----
+# ---- AUTH ---- (moved to helpers/auth.py)
 
-def is_authenticated():
-	return request.cookies.get('auth_token') == 'authenticated_user'
+from helpers.auth import is_authenticated, cd_auth_required
 
 
 # ---- GIT / COMMS HELPERS ----
@@ -1524,14 +1523,6 @@ def task_assign(task_id):
 	return jsonify({'success': True})
 
 # ---- COMMAND DECK ROUTES ----
-
-def cd_auth_required(f):
-	@wraps(f)
-	def decorated(*args, **kwargs):
-		if not is_authenticated():
-			return redirect(url_for('login'))
-		return f(*args, **kwargs)
-	return decorated
 
 @app.route('/command-deck/verify-pin', methods=['POST'])
 @cd_auth_required

--- a/app.py
+++ b/app.py
@@ -1052,48 +1052,9 @@ def today_complete():
 	conn.close()
 	return jsonify({'success': True})
 
-# ---- COMMAND DECK HELPERS ----
+# ---- COMMAND DECK HELPERS ---- (moved to helpers/db.py)
 
-def get_db():
-	"""Open a SQLite connection with WAL mode and foreign keys on."""
-	conn = sqlite3.connect(DB_FILE)
-	conn.row_factory = sqlite3.Row
-	conn.execute("PRAGMA foreign_keys = ON")
-	conn.execute("PRAGMA journal_mode = WAL")
-	return conn
-
-
-def slugify(text):
-	"""Turn a project title into a URL-safe slug."""
-	text = text.lower().strip()
-	text = re.sub(r'[^\w\s-]', '', text)
-	text = re.sub(r'[\s_-]+', '-', text)
-	text = re.sub(r'^-+|-+$', '', text)
-	return text or 'project'
-
-
-def unique_slug(title, conn, exclude_id=None):
-	"""Generate a unique slug, appending -2, -3 etc. if needed."""
-	base = slugify(title)
-	slug = base
-	n = 2
-	while True:
-		if exclude_id:
-			row = conn.execute(
-				'SELECT id FROM projects WHERE slug = ? AND id != ?', (slug, exclude_id)
-			).fetchone()
-		else:
-			row = conn.execute('SELECT id FROM projects WHERE slug = ?', (slug,)).fetchone()
-		if not row:
-			return slug
-		slug = f'{base}-{n}'
-		n += 1
-
-
-def et_now():
-	"""Current time as ISO string in US/Eastern."""
-	eastern = pytz.timezone('US/Eastern')
-	return datetime.now(eastern).isoformat()
+from helpers.db import get_db, slugify, unique_slug, et_now
 
 # ---- EXISTING ROUTES ----
 

--- a/app.py
+++ b/app.py
@@ -72,24 +72,10 @@ COMMS_CACHE_TTL = 300  # 5 minutes
 # ---- AUTH ---- (moved to helpers/auth.py)
 
 from helpers.auth import is_authenticated, cd_auth_required
+from helpers.git import get_git_status, perform_git_ops
 
 
-# ---- GIT / COMMS HELPERS ----
-
-def get_git_status():
-	try:
-		subprocess.run(["git", "fetch"], check=True, capture_output=True, timeout=5)
-		status = subprocess.check_output(["git", "status", "-sb"], encoding='utf-8')
-		if "ahead" in status:
-			return "syncing"
-		elif "behind" in status:
-			return "offline"
-		else:
-			return "online"
-	except Exception as e:
-		print(f"Git Status Error: {e}")
-		return False
-
+# ---- COMMS HELPERS ----
 
 def get_active_tags():
 	pa_tz = pytz.timezone('America/New_York')
@@ -258,22 +244,6 @@ def post_to_omg_lol(text):
 		payload["emoji"] = found[0]['emoji']
 		payload["content"] = text[len(found[0]['emoji']):].strip()
 	requests.post(url, json=payload, headers={"Authorization": f"Bearer {api}"})
-
-
-def perform_git_ops(filename):
-	stash = subprocess.run(
-		["git", "stash"], capture_output=True, encoding='utf-8'
-	)
-	stashed = "No local changes" not in stash.stdout
-
-	subprocess.run(["git", "pull", "--rebase", "origin", "main"], check=True)
-
-	if stashed:
-		subprocess.run(["git", "stash", "pop"], check=True)
-
-	subprocess.run(["git", "add", "."], check=True)
-	subprocess.run(["git", "commit", "-m", "update from cockpit"], check=True)
-	subprocess.run(["git", "push", "origin", "main"], check=True)
 
 
 def optimize_image(input_path, max_width=1200):

--- a/app.py
+++ b/app.py
@@ -83,41 +83,6 @@ from helpers.comms import get_active_tags, get_valid_comms, get_after_dark_comms
 from helpers.scratch import load_scratch_work, save_scratch_work
 
 
-def list_bunny_ad_folder(subfolder):
-    """
-    List files in a Bunny After Dark storage zone subfolder.
-    subfolder: 'videos', 'music', or 'ani'
-    Returns list of dicts: {name, url, ext}
-    Returns [] on any error.
-    """
-    if not BUNNY_AD_STORAGE_ZONE or not BUNNY_AD_API_KEY or not BUNNY_AD_CDN_URL:
-        return []
-    list_url = f"https://ny.storage.bunnycdn.com/{BUNNY_AD_STORAGE_ZONE}/{subfolder}/"
-    try:
-        resp = req_lib.get(
-            list_url,
-            headers={'AccessKey': BUNNY_AD_API_KEY, 'Accept': 'application/json'},
-            timeout=10
-        )
-        if resp.status_code != 200:
-            return []
-        items = resp.json()
-        result = []
-        for item in items:
-            if item.get('IsDirectory'):
-                continue
-            name = item.get('ObjectName', '')
-            ext = name.rsplit('.', 1)[-1].lower() if '.' in name else ''
-            result.append({
-                'name': name,
-                'url': f"{BUNNY_AD_CDN_URL}/{subfolder}/{name}",
-                'ext': ext,
-            })
-        return result
-    except Exception as e:
-        app.logger.error(f"Bunny AD list error ({subfolder}): {e}")
-        return []
-
 def post_to_omg_lol(text):
 	api, addr = os.environ.get('OMG_LOL_API_KEY'), os.environ.get('OMG_LOL_ADDRESS')
 	if not api or not addr: return
@@ -131,31 +96,13 @@ def post_to_omg_lol(text):
 	requests.post(url, json=payload, headers={"Authorization": f"Bearer {api}"})
 
 
-def optimize_image(input_path, max_width=1200):
-	with Image.open(input_path) as img:
-		if img.mode in ("RGBA", "P"):
-			img = img.convert("RGB")
-		w_percent = (max_width / float(img.size[0]))
-		if w_percent < 1.0:
-			h_size = int((float(img.size[1]) * float(w_percent)))
-			img = img.resize((max_width, h_size), Image.Resampling.LANCZOS)
-		img.save(input_path, "JPEG", optimize=True, quality=85)
-
-def upload_status_image_to_bunny(image_bytes, filename):
-    """Upload a processed status image to Bunny storage zone. Returns CDN URL."""
-    upload_url = f"https://ny.storage.bunnycdn.com/{BUNNY_STATUS_STORAGE_ZONE}/status/{filename}"
-    response = req_lib.put(
-        upload_url,
-        data=image_bytes,
-        headers={
-            'AccessKey': BUNNY_STATUS_API_KEY,
-            'Content-Type': 'image/jpeg',
-        },
-        timeout=60
-    )
-    if response.status_code != 201:
-        raise Exception(f"Bunny status upload failed: {response.status_code} {response.text}")
-    return f"{BUNNY_STATUS_CDN_URL}/status/{filename}"
+from helpers.bunny import (
+	list_bunny_ad_folder,
+	optimize_image,
+	upload_status_image_to_bunny,
+	_allowed_file,
+	_upload_to_bunny,
+)
 
 
 # ---- TASKS HELPERS ---- (load/save to helpers/tasks_json.py; post_task_status stays for cockpit blueprint)
@@ -1818,28 +1765,7 @@ def cd_promote_task():
 	return jsonify({'success': True, 'slug': slug})
 
 
-# --- File uploads (Bunny.net) ---
-
-def _allowed_file(filename):
-	return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_FILE_EXTENSIONS
-
-
-def _upload_to_bunny(file_obj, filename, content_type):
-	"""Upload a file to Bunny.net storage. Returns CDN URL or raises."""
-	upload_url = f"https://ny.storage.bunnycdn.com/{BUNNY_STORAGE_ZONE}/{filename}"
-	response = req_lib.put(
-		upload_url,
-		data=file_obj,
-		headers={
-			'AccessKey': BUNNY_API_KEY,
-			'Content-Type': content_type,
-		},
-		timeout=60
-	)
-	if response.status_code != 201:
-		raise Exception(f"Bunny upload failed: {response.status_code} {response.text}")
-	return f"{BUNNY_CDN_URL}/{filename}"
-
+# --- File uploads (Bunny.net) --- (moved to helpers/bunny.py, imported above)
 
 @app.route('/command-deck/projects/<slug>/upload', methods=['POST'])
 @cd_auth_required

--- a/helpers/auth.py
+++ b/helpers/auth.py
@@ -1,0 +1,16 @@
+"""Auth helpers — cookie check + Command Deck gate decorator."""
+from functools import wraps
+from flask import request, redirect, url_for
+
+
+def is_authenticated():
+	return request.cookies.get('auth_token') == 'authenticated_user'
+
+
+def cd_auth_required(f):
+	@wraps(f)
+	def decorated(*args, **kwargs):
+		if not is_authenticated():
+			return redirect(url_for('login'))
+		return f(*args, **kwargs)
+	return decorated

--- a/helpers/bunny.py
+++ b/helpers/bunny.py
@@ -1,0 +1,114 @@
+"""Bunny.net storage helpers — image optimization + uploads to status/projects/after-dark zones."""
+import os
+import logging
+import requests as req_lib
+from PIL import Image
+
+
+logger = logging.getLogger(__name__)
+
+
+# Storage zone constants — read from env at import time, mirror what app.py does.
+BUNNY_STORAGE_ZONE = os.environ.get('BUNNY_STORAGE_ZONE')
+BUNNY_API_KEY      = os.environ.get('BUNNY_API_KEY')
+BUNNY_CDN_URL      = os.environ.get('BUNNY_CDN_URL', '').rstrip('/')
+
+BUNNY_STATUS_STORAGE_ZONE = os.environ.get('BUNNY_STATUS_STORAGE_ZONE')
+BUNNY_STATUS_API_KEY      = os.environ.get('BUNNY_STATUS_API_KEY')
+BUNNY_STATUS_CDN_URL      = os.environ.get('BUNNY_STATUS_CDN_URL', '').rstrip('/')
+
+BUNNY_AD_STORAGE_ZONE = os.environ.get('BUNNY_AFTER_DARK_STORAGE_ZONE', '')
+BUNNY_AD_API_KEY      = os.environ.get('BUNNY_AFTER_DARK_API_KEY', '')
+BUNNY_AD_CDN_URL      = os.environ.get('BUNNY_AFTER_DARK_CDN_URL', '').rstrip('/')
+
+ALLOWED_FILE_EXTENSIONS = {
+	'jpg', 'jpeg', 'png', 'gif', 'webp',
+	'pdf', 'txt', 'md',
+	'doc', 'docx', 'xls', 'xlsx',
+	'zip', 'mp4', 'mov'
+}
+
+
+def list_bunny_ad_folder(subfolder):
+	"""
+	List files in a Bunny After Dark storage zone subfolder.
+	subfolder: 'videos', 'music', or 'ani'
+	Returns list of dicts: {name, url, ext}
+	Returns [] on any error.
+	"""
+	if not BUNNY_AD_STORAGE_ZONE or not BUNNY_AD_API_KEY or not BUNNY_AD_CDN_URL:
+		return []
+	list_url = f"https://ny.storage.bunnycdn.com/{BUNNY_AD_STORAGE_ZONE}/{subfolder}/"
+	try:
+		resp = req_lib.get(
+			list_url,
+			headers={'AccessKey': BUNNY_AD_API_KEY, 'Accept': 'application/json'},
+			timeout=10
+		)
+		if resp.status_code != 200:
+			return []
+		items = resp.json()
+		result = []
+		for item in items:
+			if item.get('IsDirectory'):
+				continue
+			name = item.get('ObjectName', '')
+			ext = name.rsplit('.', 1)[-1].lower() if '.' in name else ''
+			result.append({
+				'name': name,
+				'url': f"{BUNNY_AD_CDN_URL}/{subfolder}/{name}",
+				'ext': ext,
+			})
+		return result
+	except Exception as e:
+		logger.error(f"Bunny AD list error ({subfolder}): {e}")
+		return []
+
+
+def optimize_image(input_path, max_width=1200):
+	with Image.open(input_path) as img:
+		if img.mode in ("RGBA", "P"):
+			img = img.convert("RGB")
+		w_percent = (max_width / float(img.size[0]))
+		if w_percent < 1.0:
+			h_size = int((float(img.size[1]) * float(w_percent)))
+			img = img.resize((max_width, h_size), Image.Resampling.LANCZOS)
+		img.save(input_path, "JPEG", optimize=True, quality=85)
+
+
+def upload_status_image_to_bunny(image_bytes, filename):
+	"""Upload a processed status image to Bunny storage zone. Returns CDN URL."""
+	upload_url = f"https://ny.storage.bunnycdn.com/{BUNNY_STATUS_STORAGE_ZONE}/status/{filename}"
+	response = req_lib.put(
+		upload_url,
+		data=image_bytes,
+		headers={
+			'AccessKey': BUNNY_STATUS_API_KEY,
+			'Content-Type': 'image/jpeg',
+		},
+		timeout=60
+	)
+	if response.status_code != 201:
+		raise Exception(f"Bunny status upload failed: {response.status_code} {response.text}")
+	return f"{BUNNY_STATUS_CDN_URL}/status/{filename}"
+
+
+def _allowed_file(filename):
+	return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_FILE_EXTENSIONS
+
+
+def _upload_to_bunny(file_obj, filename, content_type):
+	"""Upload a file to Bunny.net storage. Returns CDN URL or raises."""
+	upload_url = f"https://ny.storage.bunnycdn.com/{BUNNY_STORAGE_ZONE}/{filename}"
+	response = req_lib.put(
+		upload_url,
+		data=file_obj,
+		headers={
+			'AccessKey': BUNNY_API_KEY,
+			'Content-Type': content_type,
+		},
+		timeout=60
+	)
+	if response.status_code != 201:
+		raise Exception(f"Bunny upload failed: {response.status_code} {response.text}")
+	return f"{BUNNY_CDN_URL}/{filename}"

--- a/helpers/comms.py
+++ b/helpers/comms.py
@@ -1,0 +1,99 @@
+"""Comms helpers — time-of-day tagging + tagged-message file readers."""
+from datetime import datetime
+import pytz
+
+
+COMMS_FILE = 'static/comms.txt'
+AFTER_DARK_COMMS_FILE = 'static/after_dark_comms.txt'
+
+
+def get_active_tags():
+	pa_tz = pytz.timezone('America/New_York')
+	now = datetime.now(pa_tz)
+	hour = now.hour
+	tags = ["ALL"]
+
+	tags.append(now.strftime("%A").upper())
+
+	if 5 <= hour < 12:
+		tags.append("AM")
+	if 12 <= hour < 24:
+		tags.append("PM")
+	if hour >= 17 or hour < 5:
+		tags.append("EVE")
+
+	day_type = "WEEKEND" if now.weekday() >= 5 else "WEEKDAY"
+	tags.append(day_type)
+
+	date_str = now.strftime("%m/%d")
+	if date_str == "12/25": tags.append("CHRISTMAS")
+	if date_str == "03/11": tags.append("BIRTHDAY")
+	if date_str == "04/05": tags.append("EASTER")
+
+	return tags
+
+
+def get_valid_comms():
+	active_tags = get_active_tags()
+	valid_comms = []
+
+	try:
+		with open(COMMS_FILE, 'r') as f:
+			for line in f:
+				clean_line = line.strip()
+				if not clean_line:
+					continue
+
+				if "|" not in clean_line:
+					valid_comms.append(clean_line)
+					continue
+
+				parts = clean_line.split("|")
+				message = parts[-1].strip()
+				required_tags = [p.strip().upper() for p in parts[:-1] if p.strip()]
+
+				if all(tag in active_tags for tag in required_tags):
+					weight = 10 ** len(required_tags)
+					for _ in range(weight):
+						valid_comms.append(message)
+
+	except FileNotFoundError:
+		return ["Secure line cut."]
+
+	return valid_comms if valid_comms else ["Scanning..."]
+
+
+def get_after_dark_comms():
+	"""
+	Load after_dark_comms.txt — same tag/pipe format as comms.txt.
+	Returns a deduplicated list of currently valid lines.
+	Silently returns [] if the file doesn't exist yet.
+	"""
+	active_tags = get_active_tags()
+	valid = []
+	try:
+		with open(AFTER_DARK_COMMS_FILE, 'r') as f:
+			for line in f:
+				clean = line.strip()
+				if not clean:
+					continue
+				if '|' not in clean:
+					valid.append(clean)
+					continue
+				parts = clean.split('|')
+				message = parts[-1].strip()
+				required_tags = [p.strip().upper() for p in parts[:-1] if p.strip()]
+				if all(tag in active_tags for tag in required_tags):
+					weight = 10 ** len(required_tags)
+					for _ in range(weight):
+						valid.append(message)
+	except FileNotFoundError:
+		return []
+	# Deduplicate preserving order
+	seen = set()
+	unique = []
+	for m in valid:
+		if m not in seen:
+			seen.add(m)
+			unique.append(m)
+	return unique

--- a/helpers/db.py
+++ b/helpers/db.py
@@ -1,0 +1,54 @@
+"""Database + URL slug + ET timestamp helpers."""
+import os
+import re
+import sqlite3
+from datetime import datetime
+import pytz
+
+
+DB_FILE = os.path.join(
+	os.environ.get('COCKPIT_REPO_ROOT', '/home/aaronaiken/status_update'),
+	'assets/data/command_deck.db'
+)
+
+
+def get_db():
+	"""Open a SQLite connection with WAL mode and foreign keys on."""
+	conn = sqlite3.connect(DB_FILE)
+	conn.row_factory = sqlite3.Row
+	conn.execute("PRAGMA foreign_keys = ON")
+	conn.execute("PRAGMA journal_mode = WAL")
+	return conn
+
+
+def slugify(text):
+	"""Turn a project title into a URL-safe slug."""
+	text = text.lower().strip()
+	text = re.sub(r'[^\w\s-]', '', text)
+	text = re.sub(r'[\s_-]+', '-', text)
+	text = re.sub(r'^-+|-+$', '', text)
+	return text or 'project'
+
+
+def unique_slug(title, conn, exclude_id=None):
+	"""Generate a unique slug, appending -2, -3 etc. if needed."""
+	base = slugify(title)
+	slug = base
+	n = 2
+	while True:
+		if exclude_id:
+			row = conn.execute(
+				'SELECT id FROM projects WHERE slug = ? AND id != ?', (slug, exclude_id)
+			).fetchone()
+		else:
+			row = conn.execute('SELECT id FROM projects WHERE slug = ?', (slug,)).fetchone()
+		if not row:
+			return slug
+		slug = f'{base}-{n}'
+		n += 1
+
+
+def et_now():
+	"""Current time as ISO string in US/Eastern."""
+	eastern = pytz.timezone('US/Eastern')
+	return datetime.now(eastern).isoformat()

--- a/helpers/git.py
+++ b/helpers/git.py
@@ -1,0 +1,33 @@
+"""Git helpers — status indicator + stash-safe pull/commit/push for status updates."""
+import subprocess
+
+
+def get_git_status():
+	try:
+		subprocess.run(["git", "fetch"], check=True, capture_output=True, timeout=5)
+		status = subprocess.check_output(["git", "status", "-sb"], encoding='utf-8')
+		if "ahead" in status:
+			return "syncing"
+		elif "behind" in status:
+			return "offline"
+		else:
+			return "online"
+	except Exception as e:
+		print(f"Git Status Error: {e}")
+		return False
+
+
+def perform_git_ops(filename):
+	stash = subprocess.run(
+		["git", "stash"], capture_output=True, encoding='utf-8'
+	)
+	stashed = "No local changes" not in stash.stdout
+
+	subprocess.run(["git", "pull", "--rebase", "origin", "main"], check=True)
+
+	if stashed:
+		subprocess.run(["git", "stash", "pop"], check=True)
+
+	subprocess.run(["git", "add", "."], check=True)
+	subprocess.run(["git", "commit", "-m", "update from cockpit"], check=True)
+	subprocess.run(["git", "push", "origin", "main"], check=True)

--- a/helpers/scratch.py
+++ b/helpers/scratch.py
@@ -1,0 +1,38 @@
+"""Scratch pad (DESK tab) JSON storage helpers."""
+import os
+import json
+from datetime import datetime
+import pytz
+
+
+SCRATCH_WORK_FILE = 'assets/data/scratch_work.json'
+
+
+def load_scratch_work():
+	"""Load work scratchpad content."""
+	try:
+		with open(SCRATCH_WORK_FILE, 'r') as f:
+			data = json.load(f)
+		return data.get('content', ''), data.get('last_modified', None)
+	except FileNotFoundError:
+		return '', None
+
+
+def save_scratch_work(content, force=False):
+	"""Persist work scratchpad content."""
+	if not content and not force:
+		try:
+			with open(SCRATCH_WORK_FILE, 'r') as f:
+				existing = json.load(f)
+			if existing.get('content', ''):
+				return existing.get('last_modified')
+		except FileNotFoundError:
+			pass
+	pa_tz = pytz.timezone('America/New_York')
+	last_modified = datetime.now(pa_tz).isoformat()
+	os.makedirs(os.path.dirname(SCRATCH_WORK_FILE), exist_ok=True)
+	tmp = SCRATCH_WORK_FILE + '.tmp'
+	with open(tmp, 'w') as f:
+		json.dump({'content': content, 'last_modified': last_modified}, f)
+	os.replace(tmp, SCRATCH_WORK_FILE)
+	return last_modified

--- a/helpers/tasks_json.py
+++ b/helpers/tasks_json.py
@@ -1,0 +1,20 @@
+"""Legacy public-tasks JSON storage (assets/data/tasks.json)."""
+import os
+import json
+
+
+TASKS_FILE = 'assets/data/tasks.json'
+
+
+def load_tasks():
+	try:
+		with open(TASKS_FILE, 'r') as f:
+			return json.load(f)
+	except FileNotFoundError:
+		return {"tasks": []}
+
+
+def save_tasks(data):
+	os.makedirs(os.path.dirname(TASKS_FILE), exist_ok=True)
+	with open(TASKS_FILE, 'w') as f:
+		json.dump(data, f, indent=2)


### PR DESCRIPTION
## Summary
- Moves 20 non-route helper functions out of `app.py` into a new `helpers/` package across 7 files. `app.py` shrinks from 2,606 → 2,328 lines (~278 lines moved). No route changes, no behavior changes — pure function relocation.
- Done in **7 sub-phase commits**, one per helper file, each smoke-tested against an isolated Flask process. **Please rebase-merge or fast-forward, not squash** — the per-phase commits are intentional rollback points.
- Sets up the import structure for the next phase (Flask Blueprints split). `helpers/` is a leaf in the import graph: `app.py` imports from `helpers/`, helpers never import from `app.py` or each other (one internal cross-reference inside `helpers/comms.py` only).

## Files added
| File | Lines | Functions |
|---|---|---|
| `helpers/__init__.py` | 0 | (package marker) |
| `helpers/auth.py` | 16 | `is_authenticated`, `cd_auth_required` |
| `helpers/db.py` | 54 | `get_db`, `slugify`, `unique_slug`, `et_now` |
| `helpers/git.py` | 33 | `get_git_status`, `perform_git_ops` |
| `helpers/comms.py` | 99 | `get_active_tags`, `get_valid_comms`, `get_after_dark_comms` |
| `helpers/scratch.py` | 38 | `load_scratch_work`, `save_scratch_work` |
| `helpers/tasks_json.py` | 20 | `load_tasks`, `save_tasks` |
| `helpers/bunny.py` | 114 | `list_bunny_ad_folder`, `optimize_image`, `upload_status_image_to_bunny`, `_allowed_file`, `_upload_to_bunny` |

## Constants strategy
Each helper file redefines the constants it needs from `os.environ` directly (e.g. `helpers/db.py` redefines `DB_FILE`, `helpers/bunny.py` redefines `BUNNY_*` and `ALLOWED_FILE_EXTENSIONS`). The fallback chain is identical to `app.py` — production unaffected, local dev still honors `COCKPIT_REPO_ROOT`. Each helper is therefore self-sufficient, no circular imports, ~5 lines of duplication per file. Centralizing into a `helpers/config.py` is deferred to the blueprint phase, where a `create_app()` factory makes that the natural moment.

## Other surface changes
- `app.logger.error(...)` in `list_bunny_ad_folder` swapped to `logging.getLogger(__name__).error(...)` so the helper doesn't import `app`. Functionally equivalent.
- Bucket of helpers **deferred to the blueprint phase** (not in this PR): all ~30 Ani helpers (move with the Ani blueprint), 2 Huyang helpers (Command Deck blueprint), `_today_autoclear` (today blueprint), `post_to_omg_lol` and `post_task_status` (cockpit blueprint per original KT prompt's "git ops, omg.lol" line).

## Test plan
- [x] Sub-phase 1 (auth): `/login` POST → 302, authed `/publish`/`/below-deck`/`/command-deck/` → 200 (last exercises `cd_auth_required`)
- [x] Sub-phase 2 (db): `/below-deck`, `/command-deck/`, `/command-deck/projects/` → 200 (all open SQLite via `get_db`)
- [x] Sub-phase 3 (git): `/publish` → 200 (HUD shield indicator calls `get_git_status`); `perform_git_ops` not exercised locally (would push)
- [x] Sub-phase 4 (comms): `/publish` → 200 (Jinja receives `comms_list` and `after_dark_comms_list` from extracted helpers)
- [x] Sub-phase 5 (scratch): `/scratch/work` GET → 200, POST with JSON body → 200 (load + save round-trip)
- [x] Sub-phase 6 (tasks_json): `/publish` → 200 (`load_tasks` fires when rendering tasks section)
- [x] Sub-phase 7 (bunny): `/publish`, `/command-deck/`, `/cockpit/after-dark/library` → 200 (last calls `list_bunny_ad_folder` which returns `[]` locally without Bunny AD env vars; route returns 200 cleanly)
- [x] Browser-side verification: `/publish` renders, work mode (PIN-unlocked) renders, scratch DESK tab persists. Below Deck badge correctly hidden when count=0 (local DB empty).

## Deploy notes
- PA needs `git pull` + WSGI reload to pick up the new code. The `helpers/` package will appear at `/home/aaronaiken/status_update/helpers/` and `app.py`'s imports resolve from there.
- No database migrations, no template changes, no static asset changes — pure Python surgery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)