### PR TITLE
Time tracking — Phase 1 (Work/Personal restructure + multi-timer + Huyang search-work)

### DIFF
--- a/app.py
+++ b/app.py
@@ -134,6 +134,7 @@ from blueprints.ani import ani_bp
 from blueprints.cockpit import cockpit_bp
 from blueprints.command_deck import command_deck_bp
 from blueprints.mozzie import mozzie_bp
+from blueprints.time_tracking import time_tracking_bp
 app.register_blueprint(tasks_bp)
 app.register_blueprint(today_bp)
 app.register_blueprint(below_deck_bp)
@@ -141,6 +142,7 @@ app.register_blueprint(ani_bp)
 app.register_blueprint(cockpit_bp)
 app.register_blueprint(command_deck_bp)
 app.register_blueprint(mozzie_bp)
+app.register_blueprint(time_tracking_bp)
 
 
 if __name__ == "__main__": app.run(debug=True)

--- a/blueprints/below_deck.py
+++ b/blueprints/below_deck.py
@@ -4,7 +4,7 @@ import pytz
 from flask import Blueprint, request, redirect, url_for, jsonify, render_template
 
 from helpers.auth import is_authenticated
-from helpers.db import get_db, et_now
+from helpers.db import get_db, et_now, fetch_assign_picker_groups
 
 
 below_deck_bp = Blueprint('below_deck', __name__)
@@ -47,11 +47,12 @@ def below_deck():
 		ORDER BY completed_date DESC
 	''').fetchall()
 
-	# Projects for the assign-to-project picker
-	# Only show non-private projects (or all if PIN not configured)
-	projects = conn.execute(
-		"SELECT id, title FROM projects WHERE is_private = 0 OR is_private IS NULL ORDER BY title ASC"
-	).fetchall()
+	# Projects for the assign-to-project picker — work sub-projects grouped
+	# under their area, personal projects in their own group, work_areas
+	# excluded (containers, not assignable). Same shape used by the dashboard
+	# sidebar BD panel.
+	picker_groups = fetch_assign_picker_groups(conn)
+	flat_projects = [p for g in picker_groups for p in g['projects']]
 
 	conn.close()
 
@@ -59,7 +60,8 @@ def below_deck():
 		'below_deck.html',
 		tasks=[dict(t) for t in open_tasks],
 		completed_tasks=[dict(t) for t in completed_tasks],
-		projects=[dict(p) for p in projects]
+		projects=flat_projects,
+		picker_groups=picker_groups,
 	)
 
 

--- a/blueprints/command_deck.py
+++ b/blueprints/command_deck.py
@@ -222,6 +222,16 @@ def cd_project(slug):
 
 	project = dict(project)
 
+	# Parent area (for breadcrumb + per-area styling on sub-projects)
+	parent_area = None
+	if project.get('project_type') == 'work_subproject' and project.get('parent_project_id'):
+		parent_row = conn.execute(
+			"SELECT id, title, slug, area_color FROM projects WHERE id = ?",
+			(project['parent_project_id'],)
+		).fetchone()
+		if parent_row:
+			parent_area = dict(parent_row)
+
 	blocks_raw = conn.execute('''
 		SELECT * FROM blocks WHERE project_id = ? ORDER BY "order" ASC, id ASC
 	''', (project['id'],)).fetchall()
@@ -261,6 +271,7 @@ def cd_project(slug):
 	return render_template(
 		'command_deck_project.html',
 		project=project,
+		parent_area=parent_area,
 		blocks=blocks,
 		project_tasks=[dict(t) for t in project_tasks],
 		files=[dict(f) for f in files],
@@ -306,6 +317,57 @@ def cd_project_delete(slug):
 		conn.commit()
 	conn.close()
 	return redirect(url_for('cd_projects'))
+
+
+@command_deck_bp.route('/command-deck/areas/<slug>/')
+@command_deck_bp.route('/command-deck/areas/<slug>')
+@cd_auth_required
+def cd_area(slug):
+	conn = get_db()
+	area = conn.execute(
+		"SELECT * FROM projects WHERE slug = ? AND project_type = 'work_area'",
+		(slug,)
+	).fetchone()
+	if not area:
+		conn.close()
+		return "Area not found", 404
+	area = dict(area)
+
+	subprojects = [dict(s) for s in _fetch_subprojects(conn, area_id=area['id'])]
+
+	chat_history = conn.execute('''
+		SELECT * FROM chat_messages
+		WHERE project_id = ?
+		ORDER BY id ASC
+		LIMIT 50
+	''', (area['id'],)).fetchall()
+
+	active_timer_count = conn.execute('''
+		SELECT COUNT(*) AS cnt
+		FROM time_entries te
+		JOIN projects sp ON te.project_id = sp.id
+		WHERE sp.parent_project_id = ? AND te.ended_at IS NULL
+	''', (area['id'],)).fetchone()['cnt']
+
+	# Lifetime time-entry count for the PennDOT mile-marker easter egg
+	# (computed for all areas, harmless to over-fetch)
+	lifetime_entry_count = conn.execute('''
+		SELECT COUNT(*) AS cnt
+		FROM time_entries te
+		JOIN projects sp ON te.project_id = sp.id
+		WHERE sp.parent_project_id = ?
+	''', (area['id'],)).fetchone()['cnt']
+
+	conn.close()
+	return render_template(
+		'command_deck_area.html',
+		area=area,
+		subprojects=subprojects,
+		chat_history=[dict(m) for m in chat_history],
+		active_timer_count=active_timer_count,
+		lifetime_entry_count=lifetime_entry_count,
+		private_projects_enabled=bool(PRIVATE_PROJECTS_PIN),
+	)
 
 
 @command_deck_bp.route('/command-deck/projects/<slug>/favorite', methods=['POST'])
@@ -855,6 +917,71 @@ def _huyang_build_system_with_content(project, blocks, project_tasks, files):
 	return system
 
 
+def _huyang_load_project_content(conn, project_id):
+	"""Blocks (with checklist items), open tasks, files for a single project."""
+	blocks_raw = conn.execute(
+		'SELECT * FROM blocks WHERE project_id = ? ORDER BY "order" ASC', (project_id,)
+	).fetchall()
+	blocks = []
+	for b in blocks_raw:
+		block = dict(b)
+		if block['type'] == 'checklist':
+			items = conn.execute(
+				'SELECT * FROM checklist_items WHERE block_id = ? ORDER BY id ASC',
+				(block['id'],)
+			).fetchall()
+			block['items'] = [dict(i) for i in items]
+		blocks.append(block)
+	project_tasks = [dict(t) for t in conn.execute(
+		'SELECT * FROM tasks WHERE project_id = ? AND status = "open"', (project_id,)
+	).fetchall()]
+	files = [dict(f) for f in conn.execute(
+		'SELECT * FROM files WHERE project_id = ?', (project_id,)
+	).fetchall()]
+	return blocks, project_tasks, files
+
+
+def _huyang_load_area_content(conn, area_id):
+	"""
+	Aggregate blocks, open tasks, files across all (non-private) sub-projects
+	under a work area. Used for area-scoped Huyang chat.
+	"""
+	sub_ids = [r['id'] for r in conn.execute(
+		'SELECT id FROM projects WHERE parent_project_id = ? AND is_private = 0',
+		(area_id,)
+	).fetchall()]
+	if not sub_ids:
+		return [], [], []
+	placeholders = ','.join('?' * len(sub_ids))
+	blocks_raw = conn.execute(
+		f'SELECT b.*, p.title AS project_title FROM blocks b '
+		f'JOIN projects p ON b.project_id = p.id '
+		f'WHERE b.project_id IN ({placeholders}) ORDER BY p.title, b."order"',
+		sub_ids
+	).fetchall()
+	blocks = []
+	for b in blocks_raw:
+		bd = dict(b)
+		if bd['type'] == 'checklist':
+			items = conn.execute(
+				'SELECT * FROM checklist_items WHERE block_id = ? ORDER BY id ASC',
+				(bd['id'],)
+			).fetchall()
+			bd['items'] = [dict(i) for i in items]
+		blocks.append(bd)
+	project_tasks = [dict(t) for t in conn.execute(
+		f'SELECT t.*, p.title AS project_title FROM tasks t '
+		f'JOIN projects p ON t.project_id = p.id '
+		f'WHERE t.project_id IN ({placeholders}) AND t.status = "open" ORDER BY p.title',
+		sub_ids
+	).fetchall()]
+	files = [dict(f) for f in conn.execute(
+		f'SELECT * FROM files WHERE project_id IN ({placeholders})',
+		sub_ids
+	).fetchall()]
+	return blocks, project_tasks, files
+
+
 def _huyang_search_work_content(query, k=5):
 	"""
 	Search work areas + sub-projects for keyword matches in titles, descriptions,
@@ -1053,29 +1180,10 @@ def cd_chat():
 		project = conn.execute('SELECT * FROM projects WHERE id = ?', (project_id,)).fetchone()
 		if project:
 			project = dict(project)
-			blocks_raw = conn.execute(
-				'SELECT * FROM blocks WHERE project_id = ? ORDER BY "order" ASC', (project_id,)
-			).fetchall()
-			blocks = []
-			for b in blocks_raw:
-				block = dict(b)
-				if block['type'] == 'checklist':
-					items = conn.execute(
-						'SELECT * FROM checklist_items WHERE block_id = ? ORDER BY id ASC',
-						(block['id'],)
-					).fetchall()
-					block['items'] = [dict(i) for i in items]
-				blocks.append(block)
-			project_tasks = [
-				dict(t) for t in conn.execute(
-					'SELECT * FROM tasks WHERE project_id = ? AND status = "open"', (project_id,)
-				).fetchall()
-			]
-			files = [
-				dict(f) for f in conn.execute(
-					'SELECT * FROM files WHERE project_id = ?', (project_id,)
-				).fetchall()
-			]
+			if project.get('project_type') == 'work_area':
+				blocks, project_tasks, files = _huyang_load_area_content(conn, project['id'])
+			else:
+				blocks, project_tasks, files = _huyang_load_project_content(conn, project['id'])
 			system = _huyang_build_system_with_content(project, blocks, project_tasks, files)
 		else:
 			system = _huyang_build_context()

--- a/blueprints/command_deck.py
+++ b/blueprints/command_deck.py
@@ -855,12 +855,184 @@ def _huyang_build_system_with_content(project, blocks, project_tasks, files):
 	return system
 
 
+def _huyang_search_work_content(query, k=5):
+	"""
+	Search work areas + sub-projects for keyword matches in titles, descriptions,
+	note blocks, open task titles, and checklist items. Excludes private projects
+	(per spec §9.4). Token-AND-ish ranking — more matched tokens = higher score;
+	title hits weighted 2x.
+
+	Returns up to k items with shape:
+	  {breadcrumb, source_type, content_snippet, project_slug}
+	"""
+	tokens = [t.lower() for t in re.split(r'\s+', (query or '').strip()) if t and len(t) >= 2]
+	if not tokens:
+		return []
+
+	def score(text):
+		if not text:
+			return 0
+		tl = text.lower()
+		return sum(1 for t in tokens if t in tl)
+
+	def snippet(text, n=160):
+		if not text:
+			return ''
+		tl = text.lower()
+		hits = [tl.find(t) for t in tokens if t in tl]
+		pos = min(hits) if hits else -1
+		if pos == -1:
+			return text[:n] + ('...' if len(text) > n else '')
+		start = max(0, pos - n // 2)
+		end = min(len(text), pos + n // 2)
+		s = text[start:end].strip()
+		if start > 0:
+			s = '...' + s
+		if end < len(text):
+			s = s + '...'
+		return s
+
+	def crumb(area_title, project_title, ptype, source_type=None):
+		"""area_title is the parent for sub-projects; the project's own title for areas."""
+		if ptype == 'work_area':
+			parts = [project_title]
+		else:
+			parts = [area_title, project_title]
+		if source_type:
+			parts.append(source_type)
+		return ' > '.join(p for p in parts if p)
+
+	conn = get_db()
+	matches = []
+
+	# 1. Work project titles + descriptions
+	for row in conn.execute('''
+		SELECT p.id, p.title, p.slug, p.description, p.project_type AS ptype,
+		       parent.title AS area_title
+		FROM projects p
+		LEFT JOIN projects parent ON p.parent_project_id = parent.id
+		WHERE p.project_type IN ('work_area', 'work_subproject')
+		  AND p.is_private = 0
+	''').fetchall():
+		ts = score(row['title'])
+		if ts > 0:
+			matches.append({
+				'breadcrumb': crumb(row['area_title'], row['title'], row['ptype']),
+				'source_type': 'title',
+				'content_snippet': row['title'],
+				'project_slug': row['slug'],
+				'score': ts * 2,
+			})
+		ds = score(row['description'])
+		if ds > 0:
+			matches.append({
+				'breadcrumb': crumb(row['area_title'], row['title'], row['ptype'], 'description'),
+				'source_type': 'description',
+				'content_snippet': snippet(row['description']),
+				'project_slug': row['slug'],
+				'score': ds,
+			})
+
+	# 2. Note blocks
+	for row in conn.execute('''
+		SELECT b.content,
+		       p.title AS project_title, p.slug AS project_slug,
+		       p.project_type AS ptype,
+		       parent.title AS area_title
+		FROM blocks b
+		JOIN projects p ON b.project_id = p.id
+		LEFT JOIN projects parent ON p.parent_project_id = parent.id
+		WHERE b.type = 'note'
+		  AND p.project_type IN ('work_area', 'work_subproject')
+		  AND p.is_private = 0
+	''').fetchall():
+		s = score(row['content'])
+		if s > 0:
+			matches.append({
+				'breadcrumb': crumb(row['area_title'], row['project_title'], row['ptype'], 'note'),
+				'source_type': 'note',
+				'content_snippet': snippet(row['content']),
+				'project_slug': row['project_slug'],
+				'score': s,
+			})
+
+	# 3. Open task titles
+	for row in conn.execute('''
+		SELECT t.title AS task_title,
+		       p.title AS project_title, p.slug AS project_slug,
+		       p.project_type AS ptype,
+		       parent.title AS area_title
+		FROM tasks t
+		JOIN projects p ON t.project_id = p.id
+		LEFT JOIN projects parent ON p.parent_project_id = parent.id
+		WHERE t.status = 'open'
+		  AND p.project_type IN ('work_area', 'work_subproject')
+		  AND p.is_private = 0
+	''').fetchall():
+		s = score(row['task_title'])
+		if s > 0:
+			matches.append({
+				'breadcrumb': crumb(row['area_title'], row['project_title'], row['ptype'], 'task'),
+				'source_type': 'task',
+				'content_snippet': row['task_title'],
+				'project_slug': row['project_slug'],
+				'score': s,
+			})
+
+	# 4. Checklist items
+	for row in conn.execute('''
+		SELECT ci.text AS item_text,
+		       p.title AS project_title, p.slug AS project_slug,
+		       p.project_type AS ptype,
+		       parent.title AS area_title
+		FROM checklist_items ci
+		JOIN blocks b ON ci.block_id = b.id
+		JOIN projects p ON b.project_id = p.id
+		LEFT JOIN projects parent ON p.parent_project_id = parent.id
+		WHERE p.project_type IN ('work_area', 'work_subproject')
+		  AND p.is_private = 0
+	''').fetchall():
+		s = score(row['item_text'])
+		if s > 0:
+			matches.append({
+				'breadcrumb': crumb(row['area_title'], row['project_title'], row['ptype'], 'checklist'),
+				'source_type': 'checklist',
+				'content_snippet': row['item_text'],
+				'project_slug': row['project_slug'],
+				'score': s,
+			})
+
+	conn.close()
+	matches.sort(key=lambda m: m['score'], reverse=True)
+	return matches[:k]
+
+
+def _huyang_build_search_work_system(matches):
+	"""System prompt for search_work mode, with matched excerpts injected (§9.3)."""
+	base = _huyang_build_context()
+	preamble = (
+		"\n\nThe user is searching across their work archive. Below are the "
+		"relevant excerpts found. Cite the project breadcrumb when you reference "
+		"content. If no excerpts match the question, say so plainly."
+	)
+	if not matches:
+		return base + preamble + "\n\nSEARCH RESULTS: (none)"
+
+	lines = [base + preamble, '', f"SEARCH RESULTS (top {len(matches)} matches across work projects):", '']
+	for i, m in enumerate(matches, 1):
+		lines.append(f"{i}. [{m['breadcrumb']}]")
+		lines.append(f'   "{m["content_snippet"]}"')
+		lines.append('')
+	return '\n'.join(lines)
+
+
 @command_deck_bp.route('/command-deck/chat', methods=['POST'])
 @cd_auth_required
 def cd_chat():
 	data = request.get_json()
 	message = (data.get('message') or '').strip()
 	project_id = data.get('project_id')  # int or None
+	mode = data.get('mode')  # 'search_work' (Phase 1), or absent/'general'/'project'
 
 	if not message:
 		return jsonify({'error': 'message required'}), 400
@@ -869,9 +1041,15 @@ def cd_chat():
 		return jsonify({'error': 'Anthropic API key not configured'}), 500
 
 	conn = get_db()
+	persist_mode = None
 
-	# Build system prompt
-	if project_id:
+	# Build system prompt — mode wins over project_id
+	if mode == 'search_work':
+		matches = _huyang_search_work_content(message, k=5)
+		system = _huyang_build_search_work_system(matches)
+		persist_mode = 'search_work'
+		project_id = None  # search_work history is dashboard-bound
+	elif project_id:
 		project = conn.execute('SELECT * FROM projects WHERE id = ?', (project_id,)).fetchone()
 		if project:
 			project = dict(project)
@@ -930,15 +1108,15 @@ def cd_chat():
 		conn.close()
 		return jsonify({'error': 'Huyang is unavailable right now.'}), 500
 
-	# Save both messages
+	# Save both messages — mode tags search_work turns (§0a.2 #5)
 	now = et_now()
 	conn.execute(
-		'INSERT INTO chat_messages (role, content, project_id, created) VALUES (?, ?, ?, ?)',
-		('user', message, project_id, now)
+		'INSERT INTO chat_messages (role, content, project_id, created, mode) VALUES (?, ?, ?, ?, ?)',
+		('user', message, project_id, now, persist_mode)
 	)
 	conn.execute(
-		'INSERT INTO chat_messages (role, content, project_id, created) VALUES (?, ?, ?, ?)',
-		('assistant', reply, project_id, now)
+		'INSERT INTO chat_messages (role, content, project_id, created, mode) VALUES (?, ?, ?, ?, ?)',
+		('assistant', reply, project_id, now, persist_mode)
 	)
 	conn.commit()
 	conn.close()

--- a/blueprints/command_deck.py
+++ b/blueprints/command_deck.py
@@ -42,6 +42,55 @@ MAX_FILE_SIZE_MB = 25
 command_deck_bp = Blueprint('command_deck', __name__)
 
 
+# ---- Project-query helpers (Phase 1 time-tracking) ----
+
+def _fetch_work_areas(conn):
+	"""Work areas with sub-project, open-task, and active-timer counts."""
+	return conn.execute('''
+		SELECT a.id, a.title, a.slug, a.description, a.area_color,
+		       a.is_private, a.created, a.updated, a.is_favorite,
+		       (SELECT COUNT(*) FROM projects sp
+		        WHERE sp.parent_project_id = a.id
+		          AND sp.project_type = 'work_subproject') AS subproject_count,
+		       (SELECT COUNT(*) FROM tasks t
+		        JOIN projects sp ON t.project_id = sp.id
+		        WHERE sp.parent_project_id = a.id
+		          AND t.status = 'open') AS open_task_count,
+		       (SELECT COUNT(*) FROM time_entries te
+		        JOIN projects sp ON te.project_id = sp.id
+		        WHERE sp.parent_project_id = a.id
+		          AND te.ended_at IS NULL) AS active_timer_count
+		FROM projects a
+		WHERE a.project_type = 'work_area'
+		ORDER BY a.title ASC
+	''').fetchall()
+
+
+def _fetch_subprojects(conn, area_id=None, favorites_only=False):
+	"""Sub-projects with parent area joined. Optional filters by area or favorite."""
+	sql = '''
+		SELECT sp.*,
+		       parent.id         AS area_id,
+		       parent.title      AS area_title,
+		       parent.slug       AS area_slug,
+		       parent.area_color AS area_color,
+		       (SELECT COUNT(*) FROM tasks t WHERE t.project_id = sp.id AND t.status = 'open') AS open_task_count,
+		       (SELECT COUNT(*) FROM blocks b WHERE b.project_id = sp.id) AS block_count,
+		       (SELECT id FROM time_entries WHERE project_id = sp.id AND ended_at IS NULL LIMIT 1) AS active_timer_id
+		FROM projects sp
+		LEFT JOIN projects parent ON sp.parent_project_id = parent.id
+		WHERE sp.project_type = 'work_subproject'
+	'''
+	args = []
+	if area_id is not None:
+		sql += ' AND sp.parent_project_id = ?'
+		args.append(area_id)
+	if favorites_only:
+		sql += ' AND sp.is_favorite = 1'
+	sql += ' ORDER BY sp.updated DESC'
+	return conn.execute(sql, args).fetchall()
+
+
 # ---- COMMAND DECK ROUTES ----
 
 @command_deck_bp.route('/command-deck/verify-pin', methods=['POST'])
@@ -67,14 +116,20 @@ def cd_dashboard():
 		ORDER BY "order" ASC, id ASC
 	''').fetchall()
 
-	# All projects, most recently updated first
+	# Personal projects only — work areas + sub-projects flow through
+	# work_areas / favorited_subprojects below. (§3.2 partitioning)
 	projects = conn.execute('''
-        SELECT p.*,
-               (SELECT COUNT(*) FROM tasks t WHERE t.project_id = p.id AND t.status = 'open') AS open_task_count,
-               (SELECT COUNT(*) FROM blocks b WHERE b.project_id = p.id) AS block_count
-        FROM projects p
-        ORDER BY p.updated DESC
-    ''').fetchall()
+		SELECT p.*,
+		       (SELECT COUNT(*) FROM tasks t WHERE t.project_id = p.id AND t.status = 'open') AS open_task_count,
+		       (SELECT COUNT(*) FROM blocks b WHERE b.project_id = p.id) AS block_count,
+		       (SELECT id FROM time_entries WHERE project_id = p.id AND ended_at IS NULL LIMIT 1) AS active_timer_id
+		FROM projects p
+		WHERE p.project_type = 'personal'
+		ORDER BY p.updated DESC
+	''').fetchall()
+
+	work_areas = _fetch_work_areas(conn)
+	favorited_subprojects = _fetch_subprojects(conn, favorites_only=True)
 
 	# Recent chat messages (last 3 — dashboard preview)
 	recent_chat = conn.execute('''
@@ -93,6 +148,8 @@ def cd_dashboard():
 		'command_deck_dashboard.html',
 		bd_tasks=[dict(t) for t in bd_tasks],
 		projects=[dict(p) for p in projects],
+		work_areas=[dict(a) for a in work_areas],
+		favorited_subprojects=[dict(s) for s in favorited_subprojects],
 		recent_chat=[dict(m) for m in reversed(recent_chat)],
 		private_projects_enabled=bool(PRIVATE_PROJECTS_PIN),
 		today_count=today_count
@@ -108,14 +165,24 @@ def cd_projects():
 	conn = get_db()
 	projects = conn.execute('''
 		SELECT p.*,
-			   (SELECT COUNT(*) FROM tasks t WHERE t.project_id = p.id AND t.status = 'open') AS open_task_count,
-			   (SELECT COUNT(*) FROM blocks b WHERE b.project_id = p.id) AS block_count,
-			   (SELECT COUNT(*) FROM files f WHERE f.project_id = p.id) AS file_count
+		       (SELECT COUNT(*) FROM tasks t WHERE t.project_id = p.id AND t.status = 'open') AS open_task_count,
+		       (SELECT COUNT(*) FROM blocks b WHERE b.project_id = p.id) AS block_count,
+		       (SELECT COUNT(*) FROM files f WHERE f.project_id = p.id) AS file_count,
+		       (SELECT id FROM time_entries WHERE project_id = p.id AND ended_at IS NULL LIMIT 1) AS active_timer_id
 		FROM projects p
+		WHERE p.project_type = 'personal'
 		ORDER BY p.updated DESC
 	''').fetchall()
+	work_areas = _fetch_work_areas(conn)
+	subprojects = _fetch_subprojects(conn)
 	conn.close()
-	return render_template('command_deck_projects.html', projects=[dict(p) for p in projects], private_projects_enabled=bool(PRIVATE_PROJECTS_PIN))
+	return render_template(
+		'command_deck_projects.html',
+		projects=[dict(p) for p in projects],
+		work_areas=[dict(a) for a in work_areas],
+		subprojects=[dict(s) for s in subprojects],
+		private_projects_enabled=bool(PRIVATE_PROJECTS_PIN),
+	)
 
 
 @command_deck_bp.route('/command-deck/projects/new', methods=['POST'])
@@ -239,6 +306,99 @@ def cd_project_delete(slug):
 		conn.commit()
 	conn.close()
 	return redirect(url_for('cd_projects'))
+
+
+@command_deck_bp.route('/command-deck/projects/<slug>/favorite', methods=['POST'])
+@cd_auth_required
+def cd_project_favorite(slug):
+	conn = get_db()
+	project = conn.execute('SELECT * FROM projects WHERE slug = ?', (slug,)).fetchone()
+	if not project:
+		conn.close()
+		return jsonify({'error': 'not_found'}), 404
+	new_state = 0 if project['is_favorite'] else 1
+	conn.execute(
+		'UPDATE projects SET is_favorite = ?, updated = ? WHERE id = ?',
+		(new_state, et_now(), project['id'])
+	)
+	conn.commit()
+	conn.close()
+	return jsonify({'success': True, 'is_favorite': bool(new_state)})
+
+
+@command_deck_bp.route('/command-deck/projects/<slug>/tracking', methods=['POST'])
+@cd_auth_required
+def cd_project_tracking(slug):
+	conn = get_db()
+	project = conn.execute('SELECT * FROM projects WHERE slug = ?', (slug,)).fetchone()
+	if not project:
+		conn.close()
+		return jsonify({'error': 'not_found'}), 404
+	# tracking_enabled only meaningful on work_subproject + personal (§2.1)
+	if project['project_type'] not in ('work_subproject', 'personal'):
+		conn.close()
+		return jsonify({
+			'error': 'project_not_trackable',
+			'project_type': project['project_type'],
+		}), 400
+	new_state = 0 if project['tracking_enabled'] else 1
+	conn.execute(
+		'UPDATE projects SET tracking_enabled = ?, updated = ? WHERE id = ?',
+		(new_state, et_now(), project['id'])
+	)
+	conn.commit()
+	conn.close()
+	return jsonify({'success': True, 'tracking_enabled': bool(new_state)})
+
+
+@command_deck_bp.route('/command-deck/areas/<slug>/subprojects/new', methods=['POST'])
+@cd_auth_required
+def cd_area_subproject_new(slug):
+	data = request.get_json(silent=True) or request.form
+	title = (data.get('title') or '').strip()
+	description = (data.get('description') or '').strip() or None
+	tracking_enabled = 1 if data.get('tracking_enabled') in (True, '1', 1, 'true', 'True') else 0
+	if not title:
+		return jsonify({'error': 'title required'}), 400
+
+	conn = get_db()
+	area = conn.execute(
+		"SELECT * FROM projects WHERE slug = ? AND project_type = 'work_area'",
+		(slug,)
+	).fetchone()
+	if not area:
+		conn.close()
+		return jsonify({'error': 'area_not_found'}), 404
+
+	new_slug = unique_slug(title, conn)
+	now = et_now()
+	cur = conn.execute('''
+		INSERT INTO projects
+			(title, slug, description, is_private,
+			 project_type, parent_project_id, tracking_enabled,
+			 is_favorite, area_color, created, updated)
+		VALUES (?, ?, ?, 0, 'work_subproject', ?, ?, 0, NULL, ?, ?)
+	''', (title, new_slug, description, area['id'], tracking_enabled, now, now))
+	new_id = cur.lastrowid
+	conn.commit()
+	sp = conn.execute('SELECT * FROM projects WHERE id = ?', (new_id,)).fetchone()
+	conn.close()
+	return jsonify({
+		'success': True,
+		'subproject': {
+			'id': sp['id'],
+			'title': sp['title'],
+			'slug': sp['slug'],
+			'description': sp['description'],
+			'parent_project_id': sp['parent_project_id'],
+			'area_id': area['id'],
+			'area_title': area['title'],
+			'area_slug': area['slug'],
+			'area_color': area['area_color'],
+			'tracking_enabled': bool(sp['tracking_enabled']),
+			'is_favorite': bool(sp['is_favorite']),
+		}
+	})
 
 
 # --- Blocks ---

--- a/blueprints/command_deck.py
+++ b/blueprints/command_deck.py
@@ -21,7 +21,7 @@ from flask import (
 from werkzeug.utils import secure_filename
 
 from helpers.auth import is_authenticated, cd_auth_required
-from helpers.db import get_db, slugify, unique_slug, et_now
+from helpers.db import get_db, slugify, unique_slug, et_now, fetch_assign_picker_groups
 from helpers.bunny import (
 	_allowed_file, _upload_to_bunny,
 	BUNNY_STORAGE_ZONE, BUNNY_API_KEY, BUNNY_CDN_URL,
@@ -130,6 +130,9 @@ def cd_dashboard():
 
 	work_areas = _fetch_work_areas(conn)
 	favorited_subprojects = _fetch_subprojects(conn, favorites_only=True)
+	# BD assign picker — same shape as standalone /below-deck so sub-projects
+	# show up grouped under their area, not buried in a flat personal list.
+	picker_groups = fetch_assign_picker_groups(conn)
 
 	# Recent chat messages (last 3 — dashboard preview)
 	recent_chat = conn.execute('''
@@ -150,6 +153,7 @@ def cd_dashboard():
 		projects=[dict(p) for p in projects],
 		work_areas=[dict(a) for a in work_areas],
 		favorited_subprojects=[dict(s) for s in favorited_subprojects],
+		picker_groups=picker_groups,
 		recent_chat=[dict(m) for m in reversed(recent_chat)],
 		private_projects_enabled=bool(PRIVATE_PROJECTS_PIN),
 		today_count=today_count
@@ -191,20 +195,22 @@ def cd_project_new():
 	title = request.form.get('title', '').strip()
 	description = request.form.get('description', '').strip() or None
 	is_private = 1 if request.form.get('is_private') == '1' else 0
+	tracking_enabled = 1 if request.form.get('tracking_enabled') in ('1', 'true', 'on') else 0
 
 	if not title:
-		return redirect(url_for('cd_projects'))
+		return redirect(url_for('command_deck.cd_projects'))
 
 	conn = get_db()
 	slug = unique_slug(title, conn)
 	now = et_now()
 	conn.execute('''
-		INSERT INTO projects (title, slug, description, is_private, created, updated)
-		VALUES (?, ?, ?, ?, ?, ?)
-	''', (title, slug, description, is_private, now, now))
+		INSERT INTO projects (title, slug, description, is_private,
+		                      project_type, tracking_enabled, created, updated)
+		VALUES (?, ?, ?, ?, 'personal', ?, ?, ?)
+	''', (title, slug, description, is_private, tracking_enabled, now, now))
 	conn.commit()
 	conn.close()
-	return redirect(url_for('cd_project', slug=slug))
+	return redirect(url_for('command_deck.cd_project', slug=slug))
 
 
 # --- Individual project ---
@@ -287,7 +293,7 @@ def cd_project_update(slug):
 	is_private = 1 if request.form.get('is_private') == '1' else 0
 
 	if not title:
-		return redirect(url_for('cd_project', slug=slug))
+		return redirect(url_for('command_deck.cd_project', slug=slug))
 
 	conn = get_db()
 	project = conn.execute('SELECT * FROM projects WHERE slug = ?', (slug,)).fetchone()
@@ -302,7 +308,7 @@ def cd_project_update(slug):
 	''', (title, new_slug, description, is_private, et_now(), project['id']))
 	conn.commit()
 	conn.close()
-	return redirect(url_for('cd_project', slug=new_slug))
+	return redirect(url_for('command_deck.cd_project', slug=new_slug))
 
 
 @command_deck_bp.route('/command-deck/projects/<slug>/delete', methods=['POST'])
@@ -316,7 +322,7 @@ def cd_project_delete(slug):
 		conn.execute('DELETE FROM projects WHERE id = ?', (project['id'],))
 		conn.commit()
 	conn.close()
-	return redirect(url_for('cd_projects'))
+	return redirect(url_for('command_deck.cd_projects'))
 
 
 @command_deck_bp.route('/command-deck/areas/<slug>/')

--- a/blueprints/time_tracking.py
+++ b/blueprints/time_tracking.py
@@ -1,0 +1,309 @@
+"""
+Time tracking blueprint — multi-timer back end.
+
+Phase 1 of .kt/spec-time-tracking-phase-1.md.
+
+Storage convention:
+  started_at, ended_at, created, updated are stored as ISO 8601 UTC strings
+  in the canonical format '%Y-%m-%dT%H:%M:%S.%fZ' (microseconds, Z suffix).
+  Clients may send Z or +00:00; server normalizes before storing.
+
+Day-boundary timezone for the /time/today route is America/New_York
+(per spec §0a.2 #4). Storage stays UTC; only the day-window math is ET.
+"""
+from datetime import datetime, timedelta
+import pytz
+from flask import Blueprint, request, jsonify
+
+from helpers.auth import is_authenticated
+from helpers.db import get_db
+
+
+time_tracking_bp = Blueprint('time_tracking', __name__)
+
+
+_UTC_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
+_TRACKABLE_TYPES = ('work_subproject', 'personal')
+
+
+# ---- Time helpers (module-private) ----
+
+
+def _utc_now_iso():
+	return datetime.now(pytz.UTC).strftime(_UTC_FORMAT)
+
+
+def _parse_iso_utc(s):
+	"""Parse an ISO 8601 string (Z or +00:00 or naive) to a UTC-aware datetime."""
+	if not s:
+		return None
+	s = s.strip()
+	if s.endswith('Z'):
+		s = s[:-1] + '+00:00'
+	dt = datetime.fromisoformat(s)
+	if dt.tzinfo is None:
+		dt = pytz.UTC.localize(dt)
+	return dt.astimezone(pytz.UTC)
+
+
+def _normalize_iso_utc(s):
+	"""Round-trip an ISO string to canonical Z-suffix microsecond UTC for storage."""
+	dt = _parse_iso_utc(s)
+	return dt.strftime(_UTC_FORMAT) if dt else None
+
+
+def _et_today_bounds_utc():
+	"""Return (start_utc_iso, end_utc_iso) for the current ET day (00:00–24:00 ET)."""
+	eastern = pytz.timezone('US/Eastern')
+	today_et = datetime.now(eastern).date()
+	start_et = eastern.localize(datetime.combine(today_et, datetime.min.time()))
+	end_et = start_et + timedelta(days=1)
+	return (
+		start_et.astimezone(pytz.UTC).strftime(_UTC_FORMAT),
+		end_et.astimezone(pytz.UTC).strftime(_UTC_FORMAT),
+	)
+
+
+# ---- Serializers ----
+
+
+def _serialize_active_entry(row):
+	"""Active-entry shape per spec §3.1."""
+	started = _parse_iso_utc(row['started_at'])
+	elapsed = int((datetime.now(pytz.UTC) - started).total_seconds()) if started else 0
+	return {
+		'id': row['id'],
+		'project_id': row['project_id'],
+		'project_title': row['project_title'],
+		'area_id': row['area_id'],
+		'area_title': row['area_title'],
+		'area_color': row['area_color'],
+		'description': row['description'],
+		'started_at': row['started_at'],
+		'elapsed_seconds': max(0, elapsed),
+	}
+
+
+def _serialize_entry(row):
+	"""Full entry shape — for start/stop/update/today responses."""
+	return {
+		'id': row['id'],
+		'project_id': row['project_id'],
+		'task_id': row['task_id'],
+		'description': row['description'],
+		'started_at': row['started_at'],
+		'ended_at': row['ended_at'],
+		'duration_seconds': row['duration_seconds'],
+		'created': row['created'],
+		'updated': row['updated'],
+	}
+
+
+# ---- Routes ----
+
+
+@time_tracking_bp.route('/time/active', methods=['GET'])
+def time_active():
+	if not is_authenticated():
+		return jsonify({'error': 'unauthorized'}), 403
+	conn = get_db()
+	rows = conn.execute('''
+		SELECT te.id, te.project_id, te.description, te.started_at,
+		       p.title             AS project_title,
+		       p.parent_project_id,
+		       parent.id           AS area_id,
+		       parent.title        AS area_title,
+		       parent.area_color   AS area_color
+		FROM time_entries te
+		JOIN projects p ON te.project_id = p.id
+		LEFT JOIN projects parent ON p.parent_project_id = parent.id
+		WHERE te.ended_at IS NULL
+		ORDER BY te.started_at ASC
+	''').fetchall()
+	conn.close()
+	return jsonify({'active': [_serialize_active_entry(r) for r in rows]})
+
+
+@time_tracking_bp.route('/time/start', methods=['POST'])
+def time_start():
+	if not is_authenticated():
+		return jsonify({'error': 'unauthorized'}), 403
+	data = request.get_json(silent=True) or request.form
+	project_id = data.get('project_id')
+	description = (data.get('description') or '').strip()
+	if not project_id:
+		return jsonify({'error': 'project_id required'}), 400
+
+	conn = get_db()
+	project = conn.execute(
+		'SELECT id, project_type FROM projects WHERE id = ?', (project_id,)
+	).fetchone()
+	if not project:
+		conn.close()
+		return jsonify({'error': 'project_not_found'}), 404
+	if project['project_type'] not in _TRACKABLE_TYPES:
+		conn.close()
+		return jsonify({
+			'error': 'project_not_trackable',
+			'project_type': project['project_type'],
+		}), 400
+
+	# §0a.2 #3 — 409 on concurrent same-project timer
+	existing = conn.execute(
+		'SELECT id FROM time_entries WHERE project_id = ? AND ended_at IS NULL',
+		(project_id,)
+	).fetchone()
+	if existing:
+		conn.close()
+		return jsonify({
+			'error': 'already_running',
+			'existing_id': existing['id'],
+		}), 409
+
+	now = _utc_now_iso()
+	cur = conn.execute('''
+		INSERT INTO time_entries
+			(project_id, description, started_at, created, updated)
+		VALUES (?, ?, ?, ?, ?)
+	''', (project_id, description, now, now, now))
+	new_id = cur.lastrowid
+	conn.commit()
+	row = conn.execute('SELECT * FROM time_entries WHERE id = ?', (new_id,)).fetchone()
+	conn.close()
+	return jsonify({'success': True, 'entry': _serialize_entry(row)})
+
+
+@time_tracking_bp.route('/time/<int:entry_id>/stop', methods=['POST'])
+def time_stop(entry_id):
+	if not is_authenticated():
+		return jsonify({'error': 'unauthorized'}), 403
+	conn = get_db()
+	row = conn.execute('SELECT * FROM time_entries WHERE id = ?', (entry_id,)).fetchone()
+	if not row:
+		conn.close()
+		return jsonify({'error': 'not_found'}), 404
+	if row['ended_at']:
+		conn.close()
+		return jsonify({
+			'error': 'already_stopped',
+			'entry': _serialize_entry(row),
+		}), 409
+
+	now_dt = datetime.now(pytz.UTC)
+	now_iso = now_dt.strftime(_UTC_FORMAT)
+	started = _parse_iso_utc(row['started_at'])
+	duration = int((now_dt - started).total_seconds()) if started else 0
+	conn.execute('''
+		UPDATE time_entries
+		SET ended_at = ?, duration_seconds = ?, updated = ?
+		WHERE id = ?
+	''', (now_iso, max(0, duration), now_iso, entry_id))
+	conn.commit()
+	row = conn.execute('SELECT * FROM time_entries WHERE id = ?', (entry_id,)).fetchone()
+	conn.close()
+	return jsonify({'success': True, 'entry': _serialize_entry(row)})
+
+
+@time_tracking_bp.route('/time/<int:entry_id>/update', methods=['POST'])
+def time_update(entry_id):
+	"""
+	Update description, started_at, and/or ended_at on an entry (running or stopped).
+	Per §0a.2 #2 — recomputes duration_seconds when ended_at is set.
+	"""
+	if not is_authenticated():
+		return jsonify({'error': 'unauthorized'}), 403
+	data = request.get_json(silent=True) or request.form
+	conn = get_db()
+	row = conn.execute('SELECT * FROM time_entries WHERE id = ?', (entry_id,)).fetchone()
+	if not row:
+		conn.close()
+		return jsonify({'error': 'not_found'}), 404
+
+	new_description = row['description']
+	new_started = row['started_at']
+	new_ended = row['ended_at']
+
+	if 'description' in data:
+		new_description = (data.get('description') or '').strip()
+
+	if 'started_at' in data:
+		val = data.get('started_at')
+		if not val:
+			conn.close()
+			return jsonify({'error': 'started_at_required'}), 400
+		try:
+			new_started = _normalize_iso_utc(val)
+		except (ValueError, TypeError):
+			conn.close()
+			return jsonify({'error': 'invalid_started_at'}), 400
+
+	if 'ended_at' in data:
+		val = data.get('ended_at')
+		if val in (None, '', 'null'):
+			new_ended = None
+		else:
+			try:
+				new_ended = _normalize_iso_utc(val)
+			except (ValueError, TypeError):
+				conn.close()
+				return jsonify({'error': 'invalid_ended_at'}), 400
+
+	if new_ended:
+		try:
+			s = _parse_iso_utc(new_started)
+			e = _parse_iso_utc(new_ended)
+			new_duration = max(0, int((e - s).total_seconds()))
+		except (ValueError, TypeError):
+			conn.close()
+			return jsonify({'error': 'invalid_timestamps'}), 400
+	else:
+		new_duration = None
+
+	now_iso = _utc_now_iso()
+	conn.execute('''
+		UPDATE time_entries
+		SET description = ?, started_at = ?, ended_at = ?,
+		    duration_seconds = ?, updated = ?
+		WHERE id = ?
+	''', (new_description, new_started, new_ended, new_duration, now_iso, entry_id))
+	conn.commit()
+	row = conn.execute('SELECT * FROM time_entries WHERE id = ?', (entry_id,)).fetchone()
+	conn.close()
+	return jsonify({'success': True, 'entry': _serialize_entry(row)})
+
+
+@time_tracking_bp.route('/time/<int:entry_id>/delete', methods=['POST'])
+def time_delete(entry_id):
+	if not is_authenticated():
+		return jsonify({'error': 'unauthorized'}), 403
+	conn = get_db()
+	row = conn.execute('SELECT id FROM time_entries WHERE id = ?', (entry_id,)).fetchone()
+	if not row:
+		conn.close()
+		return jsonify({'error': 'not_found'}), 404
+	conn.execute('DELETE FROM time_entries WHERE id = ?', (entry_id,))
+	conn.commit()
+	conn.close()
+	return jsonify({'success': True, 'deleted_id': entry_id})
+
+
+@time_tracking_bp.route('/time/today/<int:project_id>', methods=['GET'])
+def time_today(project_id):
+	if not is_authenticated():
+		return jsonify({'error': 'unauthorized'}), 403
+	start_utc, end_utc = _et_today_bounds_utc()
+	conn = get_db()
+	rows = conn.execute('''
+		SELECT * FROM time_entries
+		WHERE project_id = ?
+		  AND started_at >= ?
+		  AND started_at <  ?
+		ORDER BY started_at ASC
+	''', (project_id, start_utc, end_utc)).fetchall()
+	conn.close()
+	return jsonify({
+		'project_id': project_id,
+		'day_start_utc': start_utc,
+		'day_end_utc': end_utc,
+		'entries': [_serialize_entry(r) for r in rows],
+	})

--- a/blueprints/time_tracking.py
+++ b/blueprints/time_tracking.py
@@ -287,6 +287,53 @@ def time_delete(entry_id):
 	return jsonify({'success': True, 'deleted_id': entry_id})
 
 
+@time_tracking_bp.route('/time/projects', methods=['GET'])
+def time_projects():
+	"""
+	Project list for the timer panel's picker. Returns work areas with their
+	sub-projects, plus tracking-enabled personal projects. Excludes private.
+	Not in spec §3.1, added to support the floating-panel picker (§5.5).
+	"""
+	if not is_authenticated():
+		return jsonify({'error': 'unauthorized'}), 403
+	conn = get_db()
+	areas = conn.execute('''
+		SELECT id, title, slug, area_color
+		FROM projects
+		WHERE project_type = 'work_area'
+		  AND is_private = 0
+		ORDER BY title ASC
+	''').fetchall()
+	out = {'areas': [], 'personal': []}
+	for a in areas:
+		subs = conn.execute('''
+			SELECT id, title, slug, tracking_enabled
+			FROM projects
+			WHERE project_type = 'work_subproject'
+			  AND parent_project_id = ?
+			  AND is_private = 0
+			ORDER BY updated DESC, title ASC
+		''', (a['id'],)).fetchall()
+		out['areas'].append({
+			'id': a['id'],
+			'title': a['title'],
+			'slug': a['slug'],
+			'area_color': a['area_color'],
+			'subprojects': [dict(s) for s in subs],
+		})
+	personals = conn.execute('''
+		SELECT id, title, slug, tracking_enabled
+		FROM projects
+		WHERE project_type = 'personal'
+		  AND is_private = 0
+		  AND tracking_enabled = 1
+		ORDER BY updated DESC, title ASC
+	''').fetchall()
+	out['personal'] = [dict(p) for p in personals]
+	conn.close()
+	return jsonify(out)
+
+
 @time_tracking_bp.route('/time/today/<int:project_id>', methods=['GET'])
 def time_today(project_id):
 	if not is_authenticated():

--- a/helpers/db.py
+++ b/helpers/db.py
@@ -52,3 +52,36 @@ def et_now():
 	"""Current time as ISO string in US/Eastern."""
 	eastern = pytz.timezone('US/Eastern')
 	return datetime.now(eastern).isoformat()
+
+
+def fetch_assign_picker_groups(conn):
+	"""
+	Project list for the Below Deck assign-to-project picker.
+	Returns a list of {label, projects} groups:
+	  - one group per work area (label = area title), containing its sub-projects
+	  - one final 'Personal' group, when there are personal projects
+	Excludes private projects and work_area rows (containers, not assignable).
+	Same shape used by the dashboard sidebar BD panel and the standalone
+	/below-deck page.
+	"""
+	rows = conn.execute('''
+		SELECT p.id, p.title, p.project_type,
+		       parent.title AS area_title
+		FROM projects p
+		LEFT JOIN projects parent ON p.parent_project_id = parent.id
+		WHERE p.is_private = 0
+		  AND p.project_type IN ('personal', 'work_subproject')
+		ORDER BY p.project_type ASC, parent.title ASC, p.title ASC
+	''').fetchall()
+	work_groups = {}
+	personal = []
+	for r in rows:
+		entry = {'id': r['id'], 'title': r['title']}
+		if r['project_type'] == 'work_subproject':
+			work_groups.setdefault(r['area_title'] or 'Work', []).append(entry)
+		else:
+			personal.append(entry)
+	return (
+		[{'label': area, 'projects': work_groups[area]} for area in sorted(work_groups)] +
+		([{'label': 'Personal', 'projects': personal}] if personal else [])
+	)

--- a/migrate_add_time_tracking.py
+++ b/migrate_add_time_tracking.py
@@ -1,0 +1,186 @@
+"""
+migrate_add_time_tracking.py
+Phase 1 of the time-tracking spec — see .kt/spec-time-tracking-phase-1.md.
+
+What it does (idempotent — safe to run multiple times):
+  1. Adds 5 columns to projects: project_type, parent_project_id,
+     tracking_enabled, is_favorite, area_color
+  2. Creates time_entries table (with task_id insurance col per §0a.2 #1)
+     plus three indexes incl. partial active-entry index
+  3. Creates settings table + seeds the single row (id=1, defaults)
+  4. Adds 'mode' column to chat_messages (per §0a.2 #5)
+  5. Seeds the three Work Areas (Corporate, PennDOT, FDOT) with the
+     locked area colors from §0a.3
+
+Prints a clear summary of what was added vs. what was already in place.
+Running it again prints "no changes."
+
+Run from PythonAnywhere bash:
+    cd /home/aaronaiken/status_update
+    python migrate_add_time_tracking.py
+"""
+
+import sqlite3
+import os
+from datetime import datetime
+import pytz
+
+DB_FILE = os.path.join(
+	os.environ.get('COCKPIT_REPO_ROOT', '/home/aaronaiken/status_update'),
+	'assets/data/command_deck.db'
+)
+
+# Locked area colors per .kt/spec-time-tracking-phase-1.md §0a.3
+WORK_AREAS = [
+	{'title': 'Corporate', 'slug': 'corporate', 'area_color': '#5b7a99'},
+	{'title': 'PennDOT',   'slug': 'penndot',   'area_color': '#1f3a5f'},
+	{'title': 'FDOT',      'slug': 'fdot',      'area_color': '#e07050'},
+]
+
+PROJECTS_NEW_COLS = [
+	('project_type',      "TEXT NOT NULL DEFAULT 'personal'"),
+	('parent_project_id', "INTEGER REFERENCES projects(id) ON DELETE CASCADE"),
+	('tracking_enabled',  "INTEGER NOT NULL DEFAULT 0"),
+	('is_favorite',       "INTEGER NOT NULL DEFAULT 0"),
+	('area_color',        "TEXT"),
+]
+
+
+def et_now():
+	return datetime.now(pytz.timezone('US/Eastern')).isoformat()
+
+
+def table_exists(cur, name):
+	row = cur.execute(
+		"SELECT name FROM sqlite_master WHERE type='table' AND name=?", (name,)
+	).fetchone()
+	return row is not None
+
+
+def column_exists(cur, table, col):
+	cols = [row[1] for row in cur.execute(f"PRAGMA table_info({table})").fetchall()]
+	return col in cols
+
+
+def add_column_if_missing(cur, table, col_name, col_def, added, skipped):
+	if column_exists(cur, table, col_name):
+		skipped.append(f"{table}.{col_name}")
+		return False
+	cur.execute(f"ALTER TABLE {table} ADD COLUMN {col_name} {col_def}")
+	added.append(f"{table}.{col_name}")
+	return True
+
+
+def run():
+	if not os.path.exists(DB_FILE):
+		print(f"× DB not found at {DB_FILE}")
+		print("  Run migrate_to_sqlite.py first.")
+		return
+
+	conn = sqlite3.connect(DB_FILE)
+	conn.execute("PRAGMA foreign_keys = ON")
+	cur = conn.cursor()
+	added = []
+	skipped = []
+
+	# 1. ALTER projects — 5 new columns
+	for col_name, col_def in PROJECTS_NEW_COLS:
+		add_column_if_missing(cur, 'projects', col_name, col_def, added, skipped)
+
+	# 2. CREATE time_entries
+	te_existed = table_exists(cur, 'time_entries')
+	cur.execute("""
+		CREATE TABLE IF NOT EXISTS time_entries (
+			id               INTEGER PRIMARY KEY AUTOINCREMENT,
+			project_id       INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+			task_id          INTEGER,
+			description      TEXT NOT NULL DEFAULT '',
+			started_at       TEXT NOT NULL,
+			ended_at         TEXT,
+			duration_seconds INTEGER,
+			created          TEXT NOT NULL,
+			updated          TEXT NOT NULL
+		)
+	""")
+	cur.execute(
+		"CREATE INDEX IF NOT EXISTS idx_time_entries_project_id ON time_entries(project_id)"
+	)
+	cur.execute(
+		"CREATE INDEX IF NOT EXISTS idx_time_entries_started_at ON time_entries(started_at)"
+	)
+	cur.execute(
+		"CREATE INDEX IF NOT EXISTS idx_time_entries_active "
+		"ON time_entries(ended_at) WHERE ended_at IS NULL"
+	)
+	(skipped if te_existed else added).append("time_entries (table + indexes)")
+
+	# 3. CREATE settings + seed row
+	settings_existed = table_exists(cur, 'settings')
+	cur.execute("""
+		CREATE TABLE IF NOT EXISTS settings (
+			id                       INTEGER PRIMARY KEY CHECK (id = 1),
+			idle_threshold_minutes   INTEGER NOT NULL DEFAULT 15,
+			reimbursement_rate_cents INTEGER NOT NULL DEFAULT 67,
+			vehicle_a_label          TEXT NOT NULL DEFAULT 'Vehicle A',
+			vehicle_b_label          TEXT NOT NULL DEFAULT 'Vehicle B',
+			default_vehicle          TEXT NOT NULL DEFAULT 'a',
+			created                  TEXT NOT NULL,
+			updated                  TEXT NOT NULL
+		)
+	""")
+	(skipped if settings_existed else added).append("settings (table)")
+
+	now = et_now()
+	row_existed = cur.execute("SELECT id FROM settings WHERE id = 1").fetchone() is not None
+	cur.execute(
+		"INSERT OR IGNORE INTO settings (id, created, updated) VALUES (1, ?, ?)",
+		(now, now)
+	)
+	(skipped if row_existed else added).append("settings row id=1")
+
+	# 4. ALTER chat_messages — add 'mode'
+	if table_exists(cur, 'chat_messages'):
+		add_column_if_missing(cur, 'chat_messages', 'mode', 'TEXT', added, skipped)
+	else:
+		print("⚠  chat_messages table not found — run migrate_to_sqlite.py first.")
+		print("   Skipping chat_messages.mode for now.")
+
+	# 5. Seed Work Areas (idempotent on slug)
+	for area in WORK_AREAS:
+		row = cur.execute(
+			"SELECT id FROM projects WHERE slug = ?", (area['slug'],)
+		).fetchone()
+		if row:
+			skipped.append(f"work area '{area['title']}'")
+			continue
+		cur.execute("""
+			INSERT INTO projects
+				(title, slug, description, is_private,
+				 project_type, parent_project_id, tracking_enabled,
+				 is_favorite, area_color, created, updated)
+			VALUES (?, ?, '', 0, 'work_area', NULL, 0, 0, ?, ?, ?)
+		""", (area['title'], area['slug'], area['area_color'], now, now))
+		added.append(f"work area '{area['title']}'")
+
+	conn.commit()
+	conn.close()
+
+	print()
+	print(f"Migration: migrate_add_time_tracking.py")
+	print(f"DB:        {DB_FILE}")
+	print()
+	if added:
+		print(f"✓ Added ({len(added)}):")
+		for item in added:
+			print(f"    + {item}")
+	if skipped:
+		print(f"— Already in place ({len(skipped)}):")
+		for item in skipped:
+			print(f"    · {item}")
+	if not added:
+		print("No changes — schema already up to date.")
+	print()
+
+
+if __name__ == '__main__':
+	run()

--- a/static/area_easter_eggs.js
+++ b/static/area_easter_eggs.js
@@ -1,0 +1,129 @@
+/* area_easter_eggs.js
+ *
+ * Per-area easter eggs for Corporate / PennDOT / FDOT (§0a.3).
+ * Activated by the body[data-area="..."] attribute set on area pages
+ * and on sub-project pages whose parent area is one of these.
+ *
+ * Universal rules (§0a.3):
+ *   - All animations <1s, position:absolute, pointer-events:none — never block clicks.
+ *   - Frequencies 1-in-20 to 1-in-30 — surprise lands instead of going numb.
+ *   - prefers-reduced-motion respected via CSS (animations collapse to instant or skip).
+ *
+ * All copy + frequencies live as constants below so tuning is one place.
+ */
+(function () {
+	'use strict';
+
+	if (window.AreaEasterEggsLoaded) return;
+	window.AreaEasterEggsLoaded = true;
+
+	var area = document.body && document.body.getAttribute('data-area');
+	if (!area) return;
+
+	// Skip animations entirely when reduced motion is preferred (CSS already
+	// neutralises animations, but JS-driven inserts can be skipped too)
+	var reducedMotion = window.matchMedia
+		&& window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+	var FREQ = {
+		corporate_stamp: 20,    // 1-in-N page loads, a card gets a CARGO/CLASSIFIED stamp
+		fdot_palm:       30,    // 1-in-N area-page loads, palm tree drifts across
+	};
+
+	var STAMPS_CORPORATE = ['cd-cargo-stamp', 'cd-classified-stamp'];
+
+	function rand(n) { return Math.floor(Math.random() * n); }
+
+	// ---- Corporate: CARGO / CLASSIFIED stamp on a random sub-project card ----
+	function maybeCorporateStamp() {
+		if (reducedMotion) return;
+		if (rand(FREQ.corporate_stamp) !== 0) return;
+		var cards = document.querySelectorAll('.cd-subproject-card');
+		if (!cards.length) return;
+		var card = cards[rand(cards.length)];
+		card.classList.add(STAMPS_CORPORATE[rand(STAMPS_CORPORATE.length)]);
+	}
+
+	// ---- Corporate: ✓ INVENTORIED flash on first task creation in a sub-project ----
+	// Hook: command_deck_project.html dispatches a 'cd-task-created' event after a
+	// successful task add. We listen and emit a brief overlay above the task list.
+	function bindInventoriedFlash() {
+		document.addEventListener('cd-task-created-first', function (ev) {
+			var anchor = ev.detail && ev.detail.anchor;
+			if (!anchor || reducedMotion) return;
+			anchor.style.position = anchor.style.position || 'relative';
+			var flash = document.createElement('div');
+			flash.className = 'cd-inventoried-flash';
+			flash.textContent = '✓ INVENTORIED';
+			anchor.appendChild(flash);
+			setTimeout(function () { if (flash.parentNode) flash.parentNode.removeChild(flash); }, 700);
+		});
+	}
+
+	// ---- PennDOT: MILE MARKER N flash every 10th time entry on this area ----
+	function maybePenndotMileMarker() {
+		var lifetimeAttr = document.body.getAttribute('data-lifetime-entries');
+		if (lifetimeAttr == null) return;  // only on area page
+		var n = parseInt(lifetimeAttr, 10) || 0;
+		if (n <= 0 || n % 10 !== 0) return;
+		if (reducedMotion) return;
+		var marker = document.createElement('div');
+		marker.className = 'cd-mile-marker';
+		marker.textContent = 'MILE MARKER ' + n;
+		document.body.appendChild(marker);
+		setTimeout(function () { if (marker.parentNode) marker.parentNode.removeChild(marker); }, 1600);
+	}
+
+	// ---- FDOT: hurricane-season pill (Jun 1 – Nov 30) ----
+	function maybeFdotHurricanePill() {
+		var now = new Date();
+		var month = now.getMonth() + 1; // 1-12
+		var inSeason = month >= 6 && month <= 11;
+		if (!inSeason) return;
+		var titleEl = document.querySelector('.cd-area-page-title-text')
+			|| document.querySelector('.cd-area-page-title');
+		if (!titleEl) return;
+		var pill = document.createElement('span');
+		pill.className = 'cd-fdot-hurricane-pill';
+		pill.title = 'Atlantic hurricane season runs Jun 1 – Nov 30';
+		pill.textContent = '🌀 SEASON ACTIVE';
+		titleEl.parentNode.appendChild(pill);
+	}
+
+	// ---- FDOT: console.log signature ----
+	function fdotConsoleSignature() {
+		try {
+			console.log(
+				'%cFlorida Man arrives at the workstation. — aaronaiken.me',
+				'color:#e07050;font-style:italic;font-family:serif;font-size:13px;'
+			);
+		} catch (e) { /* no-op */ }
+	}
+
+	// ---- FDOT: 1-in-N — palm tree silhouette drifts across area card ----
+	function maybeFdotPalm() {
+		if (reducedMotion) return;
+		// Only on the area page (where the area-page-header exists)
+		if (!document.querySelector('.cd-area-page-header')) return;
+		if (rand(FREQ.fdot_palm) !== 0) return;
+		var palm = document.createElement('div');
+		palm.className = 'cd-fdot-palm';
+		palm.setAttribute('aria-hidden', 'true');
+		palm.textContent = '🌴';
+		document.body.appendChild(palm);
+		setTimeout(function () { if (palm.parentNode) palm.parentNode.removeChild(palm); }, 1300);
+	}
+
+	// ---- Dispatch ----
+
+	if (area === 'corporate') {
+		maybeCorporateStamp();
+		bindInventoriedFlash();
+	} else if (area === 'penndot') {
+		maybePenndotMileMarker();
+	} else if (area === 'fdot') {
+		maybeFdotHurricanePill();
+		fdotConsoleSignature();
+		maybeFdotPalm();
+	}
+})();

--- a/static/cockpit_modes.js
+++ b/static/cockpit_modes.js
@@ -1239,6 +1239,11 @@
 		{ icon: '⏎', label: 'Refresh',        hint: '',               action: () => window.location.reload() },
 	];
 
+	function getAllCmdItems() {
+		const timerItems = (typeof window.getTimerCmdItems === 'function') ? window.getTimerCmdItems() : [];
+		return CMD_ITEMS.concat(timerItems);
+	}
+
 	let cmdFiltered = [...CMD_ITEMS];
 	let cmdSelected = 0;
 
@@ -1252,7 +1257,7 @@
 	function cmdOpen() {
 		const overlay = document.getElementById('cmd-palette-overlay');
 		overlay.classList.add('is-open');
-		cmdFiltered = [...CMD_ITEMS];
+		cmdFiltered = getAllCmdItems();
 		cmdSelected = 0;
 		cmdRender();
 		setTimeout(function() {
@@ -1273,7 +1278,7 @@
 
 	function cmdFilter() {
 		const q = document.getElementById('cmd-palette-input').value.toLowerCase();
-		cmdFiltered = CMD_ITEMS.filter(item => item.label.toLowerCase().includes(q));
+		cmdFiltered = getAllCmdItems().filter(item => item.label.toLowerCase().includes(q));
 		cmdSelected = 0;
 		cmdRender();
 	}

--- a/static/cockpit_time_tracker.css
+++ b/static/cockpit_time_tracker.css
@@ -1,0 +1,266 @@
+/* cockpit_time_tracker.css
+ * Floating timer panel — Cockpit only.
+ * Spec: .kt/spec-time-tracking-phase-1.md §5.
+ *
+ * Z-index sits above music player (10001) and below video player (10003).
+ */
+
+#ttp {
+	position: fixed;
+	right: 20px;
+	bottom: 24px;
+	width: 320px;
+	max-width: calc(100vw - 32px);
+	z-index: 10002;
+	background: #0a0a08;
+	border: 1px solid #2e1e08;
+	border-radius: 4px;
+	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+	font-family: 'Share Tech Mono', 'Courier New', monospace;
+	font-size: 0.7rem;
+	color: #d4880a;
+	user-select: none;
+	-webkit-user-select: none;
+	display: none;
+}
+#ttp.ttp-open { display: block; }
+#ttp.ttp-collapsed #ttp-body { display: none; }
+#ttp.ttp-dragging { box-shadow: 0 12px 40px rgba(0,0,0,0.75); }
+
+#ttp-titlebar {
+	display: flex;
+	align-items: center;
+	padding: 7px 10px;
+	border-bottom: 1px solid rgba(212, 136, 10, 0.18);
+	cursor: grab;
+	gap: 6px;
+}
+#ttp-titlebar:active { cursor: grabbing; }
+#ttp-title {
+	font-size: 0.62rem;
+	letter-spacing: 0.2em;
+	color: rgba(212, 136, 10, 0.7);
+	text-transform: uppercase;
+	flex-shrink: 0;
+}
+#ttp-summary {
+	font-size: 0.6rem;
+	color: rgba(245, 179, 50, 0.85);
+	margin-left: 8px;
+	font-variant-numeric: tabular-nums;
+	display: none;
+	flex: 1;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+#ttp.ttp-collapsed #ttp-summary { display: inline-block; }
+#ttp-actions {
+	display: flex;
+	gap: 4px;
+	margin-left: auto;
+}
+.ttp-tb-btn {
+	background: none;
+	border: 1px solid transparent;
+	color: rgba(212, 136, 10, 0.5);
+	font-size: 0.7rem;
+	font-family: inherit;
+	width: 22px;
+	height: 22px;
+	cursor: pointer;
+	border-radius: 2px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	transition: all 0.15s;
+}
+.ttp-tb-btn:hover {
+	border-color: rgba(212, 136, 10, 0.4);
+	color: #f5b332;
+}
+
+#ttp-body {
+	padding: 4px 0 0;
+	max-height: 60vh;
+	overflow-y: auto;
+}
+
+.ttp-group { margin-bottom: 4px; }
+.ttp-group-header {
+	font-size: 0.55rem;
+	letter-spacing: 0.2em;
+	text-transform: uppercase;
+	color: rgba(212, 136, 10, 0.5);
+	padding: 4px 10px 4px 12px;
+	border-left: 3px solid #d4880a;
+	margin: 4px 0 2px;
+}
+.ttp-row {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 6px 10px 6px 14px;
+	border-bottom: 1px solid rgba(212, 136, 10, 0.06);
+	position: relative;
+}
+.ttp-row:last-child { border-bottom: none; }
+.ttp-row-dot {
+	width: 8px; height: 8px;
+	border-radius: 50%;
+	flex-shrink: 0;
+	animation: ttp-pulse 1.8s ease-in-out infinite;
+}
+@keyframes ttp-pulse {
+	0%, 100% { opacity: 0.65; transform: scale(1); }
+	50%      { opacity: 1;    transform: scale(1.2); }
+}
+.ttp-row-desc {
+	flex: 1;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	cursor: text;
+	color: rgba(212, 136, 10, 0.92);
+	font-size: 0.66rem;
+	min-width: 0;
+}
+.ttp-row-desc:empty::before {
+	content: '(no description)';
+	color: rgba(212, 136, 10, 0.3);
+	font-style: italic;
+}
+.ttp-row-desc-input {
+	flex: 1;
+	min-width: 0;
+	background: rgba(212, 136, 10, 0.08);
+	border: 1px solid rgba(212, 136, 10, 0.4);
+	color: #f5b332;
+	font-family: inherit;
+	font-size: 0.66rem;
+	padding: 2px 5px;
+	border-radius: 2px;
+}
+.ttp-row-desc-input:focus { outline: none; border-color: #f5b332; }
+.ttp-row-elapsed {
+	font-variant-numeric: tabular-nums;
+	font-size: 0.62rem;
+	color: rgba(212, 136, 10, 0.85);
+	flex-shrink: 0;
+	min-width: 54px;
+	text-align: right;
+}
+.ttp-row-actions {
+	display: none;
+	gap: 4px;
+}
+.ttp-row:hover .ttp-row-actions { display: flex; }
+
+.ttp-row-stop, .ttp-row-delete {
+	background: none;
+	border: 1px solid rgba(212, 136, 10, 0.3);
+	color: rgba(212, 136, 10, 0.6);
+	font-family: inherit;
+	font-size: 0.5rem;
+	letter-spacing: 0.15em;
+	padding: 2px 6px;
+	cursor: pointer;
+	border-radius: 2px;
+	text-transform: uppercase;
+	transition: all 0.15s;
+}
+.ttp-row-stop:hover { border-color: rgba(212, 136, 10, 0.65); color: #f5b332; }
+.ttp-row-delete {
+	border-color: rgba(204, 51, 34, 0.35);
+	color: rgba(204, 51, 34, 0.6);
+	font-size: 0.7rem;
+	padding: 1px 6px;
+	letter-spacing: 0;
+	line-height: 1;
+}
+.ttp-row-delete:hover { border-color: #cc3322; color: #cc3322; }
+
+.ttp-empty {
+	padding: 16px 14px;
+	font-size: 0.6rem;
+	color: rgba(212, 136, 10, 0.35);
+	letter-spacing: 0.1em;
+	text-align: center;
+}
+
+#ttp-form {
+	padding: 8px 10px 10px;
+	border-top: 1px solid rgba(212, 136, 10, 0.12);
+	background: rgba(212, 136, 10, 0.03);
+}
+#ttp-form label {
+	display: block;
+	font-size: 0.5rem;
+	letter-spacing: 0.18em;
+	color: rgba(212, 136, 10, 0.5);
+	text-transform: uppercase;
+	margin: 6px 0 2px;
+}
+#ttp-form select, #ttp-form input[type="text"] {
+	width: 100%;
+	background: #0a0c08;
+	border: 1px solid rgba(212, 136, 10, 0.25);
+	color: #d4880a;
+	font-family: inherit;
+	font-size: 0.65rem;
+	padding: 5px 7px;
+	border-radius: 2px;
+	-webkit-appearance: none;
+	appearance: none;
+}
+#ttp-form select:focus, #ttp-form input[type="text"]:focus {
+	outline: none;
+	border-color: #f5b332;
+}
+#ttp-form-actions {
+	display: flex;
+	gap: 6px;
+	justify-content: flex-end;
+	margin-top: 8px;
+}
+#ttp-form-start, #ttp-form-cancel {
+	background: none;
+	border: 1px solid rgba(212, 136, 10, 0.4);
+	color: rgba(212, 136, 10, 0.8);
+	font-family: inherit;
+	font-size: 0.55rem;
+	letter-spacing: 0.18em;
+	padding: 4px 10px;
+	border-radius: 2px;
+	cursor: pointer;
+	text-transform: uppercase;
+	transition: all 0.15s;
+}
+#ttp-form-start:hover:not(:disabled) { border-color: #f5b332; color: #f5b332; }
+#ttp-form-cancel:hover { border-color: rgba(212, 136, 10, 0.6); }
+#ttp-form-start:disabled { opacity: 0.4; cursor: not-allowed; }
+
+#ttp-footer {
+	padding: 8px 10px;
+	border-top: 1px solid rgba(212, 136, 10, 0.1);
+}
+#ttp-new-btn {
+	width: 100%;
+	background: none;
+	border: 1px dashed rgba(212, 136, 10, 0.35);
+	color: rgba(212, 136, 10, 0.6);
+	font-family: inherit;
+	font-size: 0.58rem;
+	letter-spacing: 0.2em;
+	padding: 8px;
+	border-radius: 2px;
+	cursor: pointer;
+	text-transform: uppercase;
+	transition: all 0.15s;
+}
+#ttp-new-btn:hover { border-color: rgba(245, 179, 50, 0.7); color: #f5b332; }
+
+@media (prefers-reduced-motion: reduce) {
+	.ttp-row-dot { animation: none; opacity: 0.85; }
+}

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -1754,3 +1754,212 @@ body.command-deck {
   .cd-huyang-panel { height: 400px; }
   .cd-files-grid { grid-template-columns: repeat(2, 1fr); }
 }
+
+
+/* ============================================================ */
+/* WORK / PERSONAL TABS — Phase 1 time tracking                  */
+/* Shared across dashboard + projects-list pages.                */
+/* Per-area visual identity (Corporate/PennDOT/FDOT) lands in    */
+/* commit 9 — this commit ships baseline area-card chrome only.  */
+/* ============================================================ */
+
+.cd-tabs {
+	display: flex;
+	gap: 0;
+	border-bottom: 1px solid var(--cd-border, rgba(212, 136, 10, 0.18));
+	margin-bottom: 1rem;
+}
+.cd-tab {
+	background: none;
+	border: none;
+	border-bottom: 2px solid transparent;
+	color: var(--cd-text-dim, rgba(212, 136, 10, 0.5));
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.7rem;
+	letter-spacing: 0.22em;
+	padding: 10px 18px;
+	cursor: pointer;
+	text-transform: uppercase;
+	transition: color 0.15s, border-color 0.15s;
+	margin-bottom: -1px;
+}
+.cd-tab:hover { color: var(--cd-amber, #d4880a); }
+.cd-tab[aria-selected="true"] {
+	color: var(--cd-amber-hi, #f5b332);
+	border-bottom-color: var(--cd-amber-hi, #f5b332);
+}
+.cd-tab-pane[hidden] { display: none; }
+
+.cd-tab-search-row { margin-bottom: 1rem; }
+.cd-tab-search { width: 100%; max-width: 480px; }
+
+.cd-tab-empty {
+	padding: 2rem 1rem;
+	text-align: center;
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.7rem;
+	letter-spacing: 0.15em;
+	color: var(--cd-text-dim, rgba(212, 136, 10, 0.4));
+	text-transform: uppercase;
+}
+
+/* ---- Favorites strip (Work tab) ---- */
+
+.cd-favorites-strip { margin-bottom: 1.5rem; }
+.cd-favorites-label {
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+	margin-bottom: 0.5rem;
+}
+.cd-favorites-row {
+	display: flex;
+	gap: 0.6rem;
+	overflow-x: auto;
+	padding-bottom: 4px;
+	-webkit-overflow-scrolling: touch;
+}
+.cd-favorite-card {
+	flex: 0 0 auto;
+	min-width: 180px;
+	max-width: 240px;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	padding: 8px 10px 10px;
+	border: 1px solid var(--cd-border, rgba(212, 136, 10, 0.2));
+	border-left: 3px solid var(--card-area-color, #d4880a);
+	border-radius: 2px;
+	text-decoration: none;
+	transition: border-color 0.15s, transform 0.15s;
+	background: rgba(212, 136, 10, 0.02);
+}
+.cd-favorite-card:hover {
+	border-color: var(--card-area-color, #d4880a);
+	transform: translateY(-1px);
+}
+.cd-favorite-area {
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.5rem;
+	letter-spacing: 0.2em;
+	text-transform: uppercase;
+	color: var(--card-area-color, #d4880a);
+	opacity: 0.8;
+}
+.cd-favorite-title {
+	font-family: var(--cd-font-title, 'Fraunces', serif);
+	font-size: 0.95rem;
+	color: var(--cd-text, #d4880a);
+	line-height: 1.2;
+}
+.cd-favorite-meta {
+	display: flex;
+	gap: 0.4rem;
+	align-items: center;
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.55rem;
+	letter-spacing: 0.1em;
+	color: var(--cd-text-dim, rgba(212, 136, 10, 0.5));
+}
+
+/* ---- Area cards (Work tab) ---- */
+
+.cd-area-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+	gap: 1rem;
+}
+.cd-area-card {
+	display: flex;
+	flex-direction: row;
+	min-height: 130px;
+	border: 1px solid var(--cd-border, rgba(212, 136, 10, 0.2));
+	border-radius: 3px;
+	text-decoration: none;
+	overflow: hidden;
+	background: rgba(212, 136, 10, 0.02);
+	transition: border-color 0.15s, transform 0.15s, box-shadow 0.15s;
+	position: relative;
+}
+.cd-area-card:hover {
+	border-color: var(--card-area-color, #d4880a);
+	transform: translateY(-1px);
+	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+}
+.cd-area-stripe {
+	flex: 0 0 6px;
+	background: var(--card-area-color, #d4880a);
+	box-shadow: inset -1px 0 4px rgba(0, 0, 0, 0.4);
+}
+.cd-area-card-body {
+	flex: 1;
+	padding: 12px 14px;
+	display: flex;
+	flex-direction: column;
+	gap: 0.4rem;
+}
+.cd-area-card-title {
+	font-family: var(--cd-font-title, 'Fraunces', serif);
+	font-size: 1.4rem;
+	color: var(--card-area-color, var(--cd-text, #d4880a));
+	letter-spacing: 0.02em;
+	line-height: 1.1;
+}
+.cd-area-card-desc {
+	font-family: var(--cd-font-body, 'Crimson Pro', serif);
+	font-size: 0.85rem;
+	color: var(--cd-text-dim, rgba(212, 136, 10, 0.6));
+	line-height: 1.4;
+}
+.cd-area-card-meta {
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+	margin-top: auto;
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.58rem;
+	letter-spacing: 0.1em;
+	color: var(--cd-text-dim, rgba(212, 136, 10, 0.5));
+	flex-wrap: wrap;
+}
+.cd-area-card-link {
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.55rem;
+	letter-spacing: 0.22em;
+	color: var(--cd-amber-lo, rgba(212, 136, 10, 0.55));
+	text-transform: uppercase;
+	margin-top: 0.3rem;
+	transition: color 0.15s;
+}
+.cd-area-card:hover .cd-area-card-link {
+	color: var(--card-area-color, #f5b332);
+}
+
+/* ---- Indicators ---- */
+
+.cd-tracking-icon {
+	font-size: 0.7rem;
+	color: var(--cd-amber-lo, #9a6018);
+	cursor: help;
+}
+.cd-timer-dot {
+	display: inline-block;
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	background: var(--cd-amber, #d4880a);
+	animation: cd-timer-pulse 1.8s ease-in-out infinite;
+}
+@keyframes cd-timer-pulse {
+	0%, 100% { opacity: 0.65; transform: scale(1); }
+	50%      { opacity: 1;    transform: scale(1.2); }
+}
+@media (prefers-reduced-motion: reduce) {
+	.cd-timer-dot { animation: none; opacity: 0.85; }
+}
+
+@media (max-width: 600px) {
+	.cd-area-grid { grid-template-columns: 1fr; }
+	.cd-tab { padding: 10px 12px; font-size: 0.65rem; }
+}
+

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -1963,3 +1963,111 @@ body.command-deck {
 	.cd-tab { padding: 10px 12px; font-size: 0.65rem; }
 }
 
+
+/* ---- Sub-project listing (Work tab on /command-deck/projects/) ---- */
+
+.cd-area-section { margin-bottom: 1.75rem; }
+.cd-area-section-header {
+	display: flex;
+	align-items: center;
+	gap: 0.6rem;
+	margin-bottom: 0.6rem;
+	padding-bottom: 0.4rem;
+	border-bottom: 1px solid var(--cd-border, rgba(212, 136, 10, 0.15));
+}
+.cd-area-section-title {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	font-family: var(--cd-font-title, 'Fraunces', serif);
+	font-size: 1.15rem;
+	color: var(--card-area-color, var(--cd-text, #d4880a));
+	text-decoration: none;
+	letter-spacing: 0.02em;
+}
+.cd-area-section-title:hover { text-decoration: underline; text-underline-offset: 3px; }
+.cd-area-section-stripe {
+	display: inline-block;
+	width: 4px;
+	height: 18px;
+	background: var(--card-area-color, #d4880a);
+	border-radius: 1px;
+}
+.cd-area-section-count {
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.55rem;
+	letter-spacing: 0.18em;
+	text-transform: uppercase;
+	color: var(--cd-text-dim, rgba(212, 136, 10, 0.5));
+	margin-left: auto;
+}
+.cd-area-section-empty {
+	padding: 0.8rem 1rem;
+	font-family: var(--cd-font-body, 'Crimson Pro', serif);
+	font-size: 0.85rem;
+	color: var(--cd-text-dim, rgba(212, 136, 10, 0.5));
+	font-style: italic;
+}
+.cd-area-section-empty a {
+	color: var(--card-area-color, var(--cd-amber));
+	text-decoration: underline;
+	text-underline-offset: 2px;
+}
+
+.cd-subproject-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+	gap: 0.7rem;
+}
+.cd-subproject-card {
+	display: flex;
+	flex-direction: column;
+	gap: 0.4rem;
+	padding: 10px 12px 12px;
+	border: 1px solid var(--cd-border, rgba(212, 136, 10, 0.18));
+	border-left: 3px solid var(--card-area-color, #d4880a);
+	border-radius: 2px;
+	background: rgba(212, 136, 10, 0.02);
+	text-decoration: none;
+	transition: border-color 0.15s, transform 0.15s;
+}
+.cd-subproject-card:hover {
+	border-color: var(--card-area-color, #d4880a);
+	transform: translateY(-1px);
+}
+.cd-subproject-title {
+	display: flex;
+	align-items: baseline;
+	gap: 0.4rem;
+	font-family: var(--cd-font-title, 'Fraunces', serif);
+	font-size: 1rem;
+	color: var(--cd-text, #d4880a);
+	line-height: 1.2;
+}
+.cd-subproject-desc {
+	font-family: var(--cd-font-body, 'Crimson Pro', serif);
+	font-size: 0.82rem;
+	color: var(--cd-text-dim, rgba(212, 136, 10, 0.6));
+	line-height: 1.4;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}
+.cd-subproject-meta {
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+	margin-top: auto;
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.55rem;
+	letter-spacing: 0.1em;
+	color: var(--cd-text-dim, rgba(212, 136, 10, 0.5));
+	flex-wrap: wrap;
+}
+.cd-fav-icon {
+	font-size: 0.8rem;
+	color: var(--cd-amber-hi, #f5b332);
+	margin-left: auto;
+}
+

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -2071,3 +2071,384 @@ body.command-deck {
 	margin-left: auto;
 }
 
+
+/* ============================================================ */
+/* AREA PAGE + PER-AREA VISUAL IDENTITY (§0a.3)                  */
+/* CSS variables for area primaries + accents.                   */
+/* ============================================================ */
+
+:root {
+	--area-corporate:        #5b7a99;
+	--area-corporate-accent: #c8d4e0;
+	--area-penndot:          #1f3a5f;
+	--area-penndot-accent:   #f5b332;
+	--area-fdot:             #e07050;
+	--area-fdot-gradient:    linear-gradient(135deg, #e07050 0%, #f5b332 100%);
+}
+
+/* ---- Breadcrumb ---- */
+
+.cd-breadcrumb {
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.62rem;
+	letter-spacing: 0.15em;
+	color: var(--cd-text-dim, rgba(212, 136, 10, 0.5));
+	text-transform: uppercase;
+	margin-bottom: 0.6rem;
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+	flex-wrap: wrap;
+}
+.cd-breadcrumb a {
+	color: var(--cd-text-dim, rgba(212, 136, 10, 0.6));
+	text-decoration: none;
+}
+.cd-breadcrumb a:hover {
+	color: var(--card-area-color, var(--cd-amber, #d4880a));
+}
+.cd-breadcrumb-sep { opacity: 0.4; }
+.cd-breadcrumb-current {
+	color: var(--card-area-color, var(--cd-text, #d4880a));
+	font-weight: 600;
+}
+
+/* ---- Area page header ---- */
+
+.cd-area-page-header {
+	display: flex;
+	align-items: stretch;
+	gap: 0;
+	border: 1px solid var(--cd-border, rgba(212, 136, 10, 0.2));
+	border-radius: 3px;
+	overflow: hidden;
+	margin-bottom: 1.5rem;
+	background: rgba(212, 136, 10, 0.02);
+}
+.cd-area-page-stripe {
+	flex: 0 0 8px;
+	background: var(--card-area-color, #d4880a);
+}
+.cd-area-page-info {
+	flex: 1;
+	padding: 18px 20px;
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+.cd-area-page-title {
+	font-family: var(--cd-font-title, 'Fraunces', serif);
+	font-size: 2.1rem;
+	color: var(--card-area-color, var(--cd-text, #d4880a));
+	letter-spacing: 0.01em;
+	line-height: 1.05;
+	margin: 0;
+	display: flex;
+	align-items: baseline;
+	gap: 0.5rem;
+	flex-wrap: wrap;
+}
+.cd-area-prefix {
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.85rem;
+	letter-spacing: 0.2em;
+	color: var(--card-area-color, #5b7a99);
+	opacity: 0.7;
+}
+.cd-area-page-desc {
+	font-family: var(--cd-font-body, 'Crimson Pro', serif);
+	font-size: 0.95rem;
+	color: var(--cd-text-dim, rgba(212, 136, 10, 0.7));
+	line-height: 1.4;
+	margin: 0;
+}
+.cd-area-page-desc.cd-empty-desc { font-style: italic; opacity: 0.65; }
+.cd-area-page-meta {
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.6rem;
+	letter-spacing: 0.12em;
+	color: var(--cd-text-dim, rgba(212, 136, 10, 0.55));
+}
+.cd-area-page-actions {
+	display: flex;
+	align-items: flex-start;
+	padding: 18px 20px 0 0;
+	flex-shrink: 0;
+}
+.cd-area-empty {
+	font-family: var(--cd-font-body, 'Crimson Pro', serif);
+	font-style: italic;
+}
+
+/* ---- Time-tracking panel on sub-project detail page ---- */
+
+.cd-tt-panel { border-left: 3px solid var(--card-area-color, var(--cd-amber, #d4880a)); }
+.cd-tt-start-form {
+	display: flex;
+	gap: 0.5rem;
+	margin-bottom: 0.7rem;
+	align-items: center;
+	flex-wrap: wrap;
+}
+.cd-tt-start-form input { flex: 1; min-width: 200px; }
+.cd-tt-today-list { display: flex; flex-direction: column; gap: 0.3rem; }
+.cd-tt-today-total {
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.68rem;
+	letter-spacing: 0.15em;
+	text-transform: uppercase;
+	color: var(--cd-text-dim, rgba(212, 136, 10, 0.55));
+	margin-bottom: 0.4rem;
+}
+.cd-tt-today-total strong {
+	color: var(--cd-amber-hi, #f5b332);
+	font-weight: bold;
+	font-variant-numeric: tabular-nums;
+	letter-spacing: 0.05em;
+}
+.cd-tt-entry {
+	display: flex;
+	align-items: center;
+	gap: 0.6rem;
+	padding: 6px 0;
+	border-bottom: 1px solid rgba(212, 136, 10, 0.06);
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.7rem;
+	color: var(--cd-text, #d4880a);
+}
+.cd-tt-entry.is-running { color: var(--cd-amber-hi, #f5b332); }
+.cd-tt-entry-time {
+	font-size: 0.6rem;
+	letter-spacing: 0.05em;
+	color: var(--cd-text-dim, rgba(212, 136, 10, 0.55));
+	min-width: 110px;
+	font-variant-numeric: tabular-nums;
+}
+.cd-tt-entry-desc { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cd-tt-entry-elapsed {
+	font-variant-numeric: tabular-nums;
+	min-width: 60px;
+	text-align: right;
+	font-size: 0.7rem;
+}
+
+/* ---- Title-row icons (favorite + tracking on project detail) ---- */
+
+.cd-title-icon { font-size: 0.85rem; margin-left: 0.4rem; opacity: 0.85; }
+.cd-fav-toggle {
+	background: none;
+	border: none;
+	font-size: 1rem;
+	cursor: pointer;
+	color: var(--cd-text-dim, rgba(212, 136, 10, 0.4));
+	padding: 0 0 0 0.3rem;
+	transition: color 0.15s, transform 0.15s;
+	line-height: 1;
+}
+.cd-fav-toggle:hover { transform: scale(1.15); color: var(--cd-amber-hi, #f5b332); }
+.cd-fav-toggle.is-on { color: var(--cd-amber-hi, #f5b332); }
+
+.cd-checkbox-row {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.62rem;
+	letter-spacing: 0.1em;
+	color: var(--cd-text-dim, rgba(212, 136, 10, 0.6));
+	cursor: pointer;
+	margin-bottom: 0.5rem;
+}
+.cd-checkbox-row input[type="checkbox"] { accent-color: var(--cd-amber, #d4880a); }
+
+
+/* ============================================================ */
+/* PER-AREA: Corporate (CAI) — "The Mothership"                  */
+/* Slate-blue, cargo-hold vibes, // CAI // prefix on title.       */
+/* ============================================================ */
+
+body[data-area="corporate"] .cd-breadcrumb-current,
+body[data-area="corporate"] .cd-area-page-title { color: var(--area-corporate); }
+body[data-area="corporate"] .cd-area-page-stripe,
+body[data-area="corporate"] .cd-area-section-stripe { background: var(--area-corporate); }
+
+body[data-area="corporate"] .cd-subproject-card {
+	border-left-color: var(--area-corporate);
+	position: relative;
+}
+body[data-area="corporate"] .cd-subproject-card.cd-cargo-stamp::after {
+	content: "CARGO";
+	position: absolute;
+	top: 50%;
+	right: 12px;
+	transform: translateY(-50%) rotate(-12deg);
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 1.4rem;
+	letter-spacing: 0.18em;
+	color: var(--area-corporate);
+	opacity: 0;
+	pointer-events: none;
+	border: 2px solid var(--area-corporate);
+	padding: 2px 8px;
+	border-radius: 2px;
+	animation: cd-stamp-in 800ms ease-out forwards;
+}
+body[data-area="corporate"] .cd-subproject-card.cd-classified-stamp::after {
+	content: "CLASSIFIED";
+}
+@keyframes cd-stamp-in {
+	from { opacity: 0; transform: translateY(-50%) rotate(-12deg) scale(0.6); }
+	to   { opacity: 0.18; transform: translateY(-50%) rotate(-12deg) scale(1); }
+}
+
+body[data-area="corporate"] .cd-inventoried-flash {
+	position: absolute;
+	top: -28px; left: 50%;
+	transform: translateX(-50%);
+	background: var(--area-corporate);
+	color: #fff;
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.6rem;
+	letter-spacing: 0.18em;
+	padding: 4px 10px;
+	border-radius: 2px;
+	animation: cd-inventoried 600ms ease-out forwards;
+	pointer-events: none;
+	z-index: 5;
+}
+@keyframes cd-inventoried {
+	0%   { opacity: 0; transform: translateX(-50%) translateY(8px); }
+	30%  { opacity: 1; transform: translateX(-50%) translateY(0); }
+	100% { opacity: 0; transform: translateX(-50%) translateY(-6px); }
+}
+
+
+/* ============================================================ */
+/* PER-AREA: PennDOT — "The Keystone"                            */
+/* Keystone-blue + caution-yellow accent, blueprint background. */
+/* ============================================================ */
+
+body[data-area="penndot"] .cd-breadcrumb-current,
+body[data-area="penndot"] .cd-area-page-title { color: var(--area-penndot-accent); }
+body[data-area="penndot"] .cd-area-page-stripe,
+body[data-area="penndot"] .cd-area-section-stripe { background: var(--area-penndot); }
+body[data-area="penndot"] .cd-area-page-header {
+	border-color: var(--area-penndot-accent);
+	background:
+		linear-gradient(rgba(212, 136, 10, 0.02), rgba(212, 136, 10, 0.02)),
+		repeating-linear-gradient(0deg, transparent 0 40px, rgba(31, 58, 95, 0.08) 40px 41px),
+		repeating-linear-gradient(90deg, transparent 0 40px, rgba(31, 58, 95, 0.08) 40px 41px);
+}
+body[data-area="penndot"] .cd-keystone-glyph {
+	display: inline-block;
+	color: var(--area-penndot-accent);
+	font-size: 1.3rem;
+	transform: translateY(-2px);
+	margin-left: 0.3rem;
+}
+
+body[data-area="penndot"] .cd-subproject-card {
+	border-left-color: var(--area-penndot);
+	border-top: 2px solid var(--area-penndot-accent);
+}
+
+body[data-area="penndot"] .cd-mile-marker {
+	position: fixed;
+	top: 50%; left: 50%;
+	transform: translate(-50%, -50%);
+	background: var(--area-penndot);
+	color: var(--area-penndot-accent);
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 1.2rem;
+	letter-spacing: 0.25em;
+	padding: 12px 24px;
+	border: 2px solid var(--area-penndot-accent);
+	border-radius: 4px;
+	box-shadow: 0 6px 24px rgba(0,0,0,0.5);
+	z-index: 99999;
+	animation: cd-mile-marker 1500ms ease-out forwards;
+	pointer-events: none;
+}
+@keyframes cd-mile-marker {
+	0%   { opacity: 0; transform: translate(-50%, -50%) scale(0.6); }
+	20%  { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+	80%  { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+	100% { opacity: 0; transform: translate(-50%, -50%) scale(1.05); }
+}
+
+
+/* ============================================================ */
+/* PER-AREA: FDOT — "The Sunshine"                               */
+/* Coral + sunset gradient, ☀ glyph, palm tree drift egg.        */
+/* ============================================================ */
+
+body[data-area="fdot"] .cd-breadcrumb-current,
+body[data-area="fdot"] .cd-area-page-title { color: var(--area-fdot); }
+body[data-area="fdot"] .cd-area-page-stripe,
+body[data-area="fdot"] .cd-area-section-stripe {
+	background: var(--area-fdot-gradient);
+}
+body[data-area="fdot"] .cd-area-page-title-text {
+	font-style: italic;
+}
+body[data-area="fdot"] .cd-fdot-sun {
+	display: inline-block;
+	color: #f5b332;
+	margin-left: 0.3rem;
+	font-size: 1.4rem;
+	animation: cd-fdot-sun-glow 4s ease-in-out infinite;
+}
+@keyframes cd-fdot-sun-glow {
+	0%, 100% { text-shadow: 0 0 6px rgba(245, 179, 50, 0.5); }
+	50%      { text-shadow: 0 0 14px rgba(245, 179, 50, 0.85); }
+}
+
+body[data-area="fdot"] .cd-subproject-card {
+	border-left: 3px solid transparent;
+	border-image: var(--area-fdot-gradient);
+	border-image-slice: 1;
+}
+body[data-area="fdot"] .cd-fdot-hurricane-pill {
+	display: inline-block;
+	margin-left: 0.5rem;
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.55rem;
+	letter-spacing: 0.18em;
+	padding: 3px 8px;
+	border: 1px solid var(--area-fdot);
+	border-radius: 12px;
+	color: var(--area-fdot);
+	background: rgba(224, 112, 80, 0.08);
+	vertical-align: middle;
+}
+
+body[data-area="fdot"] .cd-fdot-palm {
+	position: fixed;
+	bottom: 60px;
+	left: -100px;
+	font-size: 64px;
+	pointer-events: none;
+	z-index: 1;
+	opacity: 0;
+	animation: cd-fdot-palm-drift 1200ms ease-out forwards;
+}
+@keyframes cd-fdot-palm-drift {
+	0%   { opacity: 0; left: -100px; }
+	20%  { opacity: 0.4; }
+	80%  { opacity: 0.4; left: calc(100% - 60px); }
+	100% { opacity: 0; left: calc(100% + 60px); }
+}
+
+
+@media (prefers-reduced-motion: reduce) {
+	body[data-area="corporate"] .cd-subproject-card.cd-cargo-stamp::after,
+	body[data-area="corporate"] .cd-inventoried-flash,
+	body[data-area="penndot"] .cd-mile-marker,
+	body[data-area="fdot"] .cd-fdot-sun,
+	body[data-area="fdot"] .cd-fdot-palm { animation: none; }
+	body[data-area="fdot"] .cd-fdot-palm { display: none; }
+}
+

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -133,7 +133,11 @@ body.command-deck {
   margin: 0 auto;
   padding: 0 1.5rem;
   width: 100%;
+  transition: padding-top 0.18s ease;
 }
+/* Reserve top space when the active timer strip is visible so the Command
+   Deck nav doesn't disappear under the strip + Today bar stack. */
+body.cd-strip-visible .cd-shell { padding-top: 32px; }
 
 /* ============================================================
    HEADER
@@ -1933,6 +1937,56 @@ body.command-deck {
 }
 .cd-area-card:hover .cd-area-card-link {
 	color: var(--card-area-color, #f5b332);
+}
+
+/* "+ NEW SUB-PROJECT" quick-create on dashboard area cards */
+.cd-area-card-wrap {
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+}
+.cd-area-card-wrap .cd-area-card { flex: 1; }
+.cd-area-card-add {
+	display: block;
+	text-align: center;
+	margin-top: 4px;
+	padding: 6px 10px;
+	border: 1px dashed var(--card-area-color, rgba(212, 136, 10, 0.4));
+	border-radius: 2px;
+	background: rgba(212, 136, 10, 0.02);
+	color: var(--card-area-color, var(--cd-amber-lo, rgba(212, 136, 10, 0.6)));
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.55rem;
+	letter-spacing: 0.2em;
+	text-transform: uppercase;
+	text-decoration: none;
+	opacity: 0.65;
+	transition: all 0.15s;
+}
+.cd-area-card-add:hover {
+	opacity: 1;
+	background: rgba(212, 136, 10, 0.06);
+	border-style: solid;
+}
+
+/* "+ NEW" mini-link on projects-list Work-tab area-section headers */
+.cd-area-section-add {
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.55rem;
+	letter-spacing: 0.18em;
+	text-transform: uppercase;
+	color: var(--card-area-color, var(--cd-amber-lo, rgba(212, 136, 10, 0.55)));
+	text-decoration: none;
+	border: 1px dashed currentColor;
+	padding: 3px 8px;
+	border-radius: 2px;
+	margin-left: 0.6rem;
+	opacity: 0.6;
+	transition: opacity 0.15s, background 0.15s;
+}
+.cd-area-section-add:hover {
+	opacity: 1;
+	background: rgba(212, 136, 10, 0.06);
 }
 
 /* ---- Indicators ---- */

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -2452,3 +2452,44 @@ body[data-area="fdot"] .cd-fdot-palm {
 	body[data-area="fdot"] .cd-fdot-palm { display: none; }
 }
 
+
+/* ============================================================ */
+/* HUYANG SEARCH-WORK TOGGLE (Work tab only) — §9.1              */
+/* ============================================================ */
+
+.cd-huyang-search-row {
+	padding: 6px 10px 0;
+	display: flex;
+	justify-content: flex-start;
+}
+body[data-cd-tab="personal"] .cd-huyang-search-row { display: none; }
+
+.cd-huyang-search-toggle {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	background: none;
+	border: 1px dashed rgba(212, 136, 10, 0.3);
+	color: rgba(212, 136, 10, 0.55);
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.55rem;
+	letter-spacing: 0.18em;
+	padding: 4px 9px;
+	border-radius: 2px;
+	cursor: pointer;
+	text-transform: uppercase;
+	transition: all 0.15s;
+}
+.cd-huyang-search-toggle:hover {
+	border-color: rgba(212, 136, 10, 0.55);
+	color: var(--cd-amber-hi, #f5b332);
+}
+.cd-huyang-search-toggle.is-active {
+	border-style: solid;
+	border-color: var(--cd-amber-hi, #f5b332);
+	background: rgba(245, 179, 50, 0.1);
+	color: var(--cd-amber-hi, #f5b332);
+	box-shadow: 0 0 8px rgba(245, 179, 50, 0.25);
+}
+.cd-huyang-search-icon { font-size: 0.7rem; line-height: 1; }
+

--- a/static/command_deck_tabs.js
+++ b/static/command_deck_tabs.js
@@ -1,0 +1,84 @@
+/* command_deck_tabs.js
+ * Work / Personal tab switcher + per-tab search filter.
+ * Shared by command_deck_dashboard.html and command_deck_projects.html.
+ *
+ * Markup contract:
+ *   <div class="cd-tabs"><button class="cd-tab" data-tab="work">…</button>…</div>
+ *   <div class="cd-tab-pane" data-tab="work">…</div>
+ *   <div class="cd-tab-pane" data-tab="personal" hidden>…</div>
+ *   <input class="cd-tab-search" data-tab="work" />          (optional, per pane)
+ *   <div class="cd-tab-empty" data-tab-empty="work" hidden>…</div> (optional, per pane)
+ *   Searchable cards within a pane carry data-search="lower-cased text".
+ *
+ * Persistence: localStorage['commandDeckTab']. Default: 'work'.
+ * Spec §4.2.
+ */
+(function () {
+	'use strict';
+
+	if (window.CommandDeckTabsLoaded) return;
+	window.CommandDeckTabsLoaded = true;
+
+	var STORAGE_KEY = 'commandDeckTab';
+	var DEFAULT_TAB = 'work';
+
+	var tabs = document.querySelectorAll('.cd-tab');
+	var panes = document.querySelectorAll('.cd-tab-pane');
+	if (!tabs.length || !panes.length) return;
+
+	function getActive() {
+		try {
+			var v = localStorage.getItem(STORAGE_KEY);
+			return v === 'work' || v === 'personal' ? v : DEFAULT_TAB;
+		} catch (e) { return DEFAULT_TAB; }
+	}
+	function setActive(name) {
+		try { localStorage.setItem(STORAGE_KEY, name); } catch (e) {}
+	}
+
+	function activate(name) {
+		tabs.forEach(function (t) {
+			var on = t.getAttribute('data-tab') === name;
+			t.setAttribute('aria-selected', on ? 'true' : 'false');
+		});
+		panes.forEach(function (p) {
+			p.hidden = p.getAttribute('data-tab') !== name;
+		});
+		// Reset search inputs in the newly-shown pane (per spec §8: "Clears on tab switch")
+		var input = document.querySelector('.cd-tab-search[data-tab="' + name + '"]');
+		if (input) {
+			input.value = '';
+			applyFilter(name, '');
+		}
+		setActive(name);
+	}
+
+	function applyFilter(tabName, query) {
+		var pane = document.querySelector('.cd-tab-pane[data-tab="' + tabName + '"]');
+		if (!pane) return;
+		var q = (query || '').trim().toLowerCase();
+		var cards = pane.querySelectorAll('[data-search]');
+		var matched = 0;
+		cards.forEach(function (card) {
+			var hay = card.getAttribute('data-search') || '';
+			var match = !q || hay.indexOf(q) !== -1;
+			card.style.display = match ? '' : 'none';
+			if (match) matched++;
+		});
+		var emptyEl = document.querySelector('.cd-tab-empty[data-tab-empty="' + tabName + '"]');
+		if (emptyEl) emptyEl.hidden = !(q && matched === 0);
+	}
+
+	tabs.forEach(function (t) {
+		t.addEventListener('click', function () {
+			activate(t.getAttribute('data-tab'));
+		});
+	});
+
+	document.querySelectorAll('.cd-tab-search').forEach(function (input) {
+		var name = input.getAttribute('data-tab');
+		input.addEventListener('input', function () { applyFilter(name, input.value); });
+	});
+
+	activate(getActive());
+})();

--- a/static/command_deck_tabs.js
+++ b/static/command_deck_tabs.js
@@ -44,6 +44,11 @@
 		panes.forEach(function (p) {
 			p.hidden = p.getAttribute('data-tab') !== name;
 		});
+		// Mirror the active tab onto <body> so CSS can scope per-tab chrome
+		// (e.g. hiding the Huyang search-work toggle on the Personal tab).
+		try { document.body.dataset.cdTab = name; } catch (e) {}
+		// Notify subscribers (the dashboard's inline JS listens to reset state).
+		try { document.dispatchEvent(new CustomEvent('cd-tab-changed', { detail: { tab: name } })); } catch (e) {}
 		// Reset search inputs in the newly-shown pane (per spec §8: "Clears on tab switch")
 		var input = document.querySelector('.cd-tab-search[data-tab="' + name + '"]');
 		if (input) {

--- a/static/time_tracker_core.js
+++ b/static/time_tracker_core.js
@@ -1,0 +1,158 @@
+/* time_tracker_core.js
+ *
+ * Shared poller + cache + action helpers for time tracking.
+ * Used by:
+ *   - templates/includes/active_timer_strip.html  (Today, Below Deck, Command Deck pages)
+ *   - templates/includes/time_tracker_panel.html  (Cockpit floating panel) — coming in commit 6
+ *
+ * One source of truth for /time/active to avoid double-polling. Subscribers
+ * register a callback that fires on every poll AND every 1-second tick (so
+ * elapsed counters can be re-rendered locally between polls without hitting
+ * the server).
+ *
+ * Saved-state guard (lessons-learned pattern from scratch pad / video player):
+ *   - `loaded` flag prevents notify() before initial fetch resolves
+ *   - Network failures don't blow away cached state
+ */
+(function (window) {
+  'use strict';
+
+  if (window.TimeTrackerCore) return; // idempotent on multi-include
+
+  var POLL_INTERVAL_MS = 30000;
+  var TICK_INTERVAL_MS = 1000;
+
+  var subscribers = [];
+  var current = [];
+  var loaded = false;
+  var pollTimer = null;
+  var tickTimer = null;
+  var inFlight = null;
+
+  function notify() {
+    subscribers.forEach(function (cb) {
+      try { cb(current); } catch (e) { console.error('TimeTrackerCore subscriber error:', e); }
+    });
+  }
+
+  function fetchActive() {
+    if (inFlight) return inFlight;
+    inFlight = fetch('/time/active', { credentials: 'same-origin' })
+      .then(function (r) { return r.ok ? r.json() : { active: [] }; })
+      .then(function (data) {
+        current = (data && data.active) || [];
+        loaded = true;
+        notify();
+      })
+      .catch(function () {
+        // network blip — keep last known state, don't blow it away
+      })
+      .then(function () { inFlight = null; });
+    return inFlight;
+  }
+
+  function tick() {
+    // Re-emit so subscribers can recompute elapsed locally
+    if (loaded) notify();
+  }
+
+  function ensureRunning() {
+    if (!pollTimer) pollTimer = setInterval(fetchActive, POLL_INTERVAL_MS);
+    if (!tickTimer) tickTimer = setInterval(tick, TICK_INTERVAL_MS);
+  }
+
+  function subscribe(cb) {
+    subscribers.push(cb);
+    if (loaded) {
+      try { cb(current); } catch (e) { console.error(e); }
+    }
+    fetchActive();
+    ensureRunning();
+    return function unsubscribe() {
+      subscribers = subscribers.filter(function (s) { return s !== cb; });
+    };
+  }
+
+  function refresh() { return fetchActive(); }
+
+  function elapsedSeconds(entry) {
+    if (!entry || !entry.started_at) return 0;
+    var t = new Date(entry.started_at).getTime();
+    if (isNaN(t)) return 0;
+    return Math.max(0, Math.floor((Date.now() - t) / 1000));
+  }
+
+  function pad(n) { return n < 10 ? '0' + n : '' + n; }
+
+  function formatElapsed(secs) {
+    if (!secs || secs < 0) secs = 0;
+    var h = Math.floor(secs / 3600);
+    var m = Math.floor((secs % 3600) / 60);
+    var s = secs % 60;
+    if (h > 0) return h + ':' + pad(m) + ':' + pad(s);
+    return m + ':' + pad(s);
+  }
+
+  function postJson(url, body) {
+    return fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify(body || {}),
+    }).then(function (r) {
+      return r.json().then(function (data) {
+        return { ok: r.ok, status: r.status, data: data };
+      });
+    });
+  }
+
+  function postEmpty(url) {
+    return fetch(url, { method: 'POST', credentials: 'same-origin' })
+      .then(function (r) {
+        return r.json().then(function (data) {
+          return { ok: r.ok, status: r.status, data: data };
+        });
+      });
+  }
+
+  function startTimer(projectId, description) {
+    return postJson('/time/start', { project_id: projectId, description: description || '' })
+      .then(function (result) { if (result.ok) refresh(); return result; });
+  }
+
+  function stopTimer(entryId) {
+    return postEmpty('/time/' + entryId + '/stop')
+      .then(function (result) { if (result.ok) refresh(); return result; });
+  }
+
+  function stopAllTimers() {
+    var ids = current.map(function (e) { return e.id; });
+    return Promise.all(ids.map(function (id) {
+      return postEmpty('/time/' + id + '/stop').catch(function () { /* swallow */ });
+    })).then(refresh);
+  }
+
+  function deleteTimer(entryId) {
+    return postEmpty('/time/' + entryId + '/delete')
+      .then(function (result) { if (result.ok) refresh(); return result; });
+  }
+
+  function updateTimer(entryId, fields) {
+    return postJson('/time/' + entryId + '/update', fields || {})
+      .then(function (result) { if (result.ok) refresh(); return result; });
+  }
+
+  window.TimeTrackerCore = {
+    subscribe: subscribe,
+    refresh: refresh,
+    elapsedSeconds: elapsedSeconds,
+    formatElapsed: formatElapsed,
+    startTimer: startTimer,
+    stopTimer: stopTimer,
+    stopAllTimers: stopAllTimers,
+    deleteTimer: deleteTimer,
+    updateTimer: updateTimer,
+    isLoaded: function () { return loaded; },
+    current: function () { return current.slice(); },
+  };
+})(window);

--- a/static/time_tracker_panel.js
+++ b/static/time_tracker_panel.js
@@ -1,0 +1,455 @@
+/* time_tracker_panel.js
+ *
+ * Cockpit floating timer panel — render, drag, picker, inline-create, Ctrl+K.
+ * Spec: .kt/spec-time-tracking-phase-1.md §5.
+ *
+ * Subscribes to window.TimeTrackerCore for active-entry updates.
+ * Exposes window.getTimerCmdItems() for the Ctrl+K palette in cockpit_modes.js.
+ */
+(function () {
+	'use strict';
+
+	if (window.TimeTrackerPanelLoaded) return;
+	window.TimeTrackerPanelLoaded = true;
+
+	var POS_KEY = 'timeTrackerPanelPos';
+	var SAFE_INSET_PX = 100;
+
+	var panel        = document.getElementById('ttp');
+	if (!panel) return;
+	var titlebar     = document.getElementById('ttp-titlebar');
+	var summarySpan  = document.getElementById('ttp-summary');
+	var groupsEl     = document.getElementById('ttp-groups');
+	var formEl       = document.getElementById('ttp-form');
+	var collapseBtn  = document.getElementById('ttp-collapse-btn');
+	var closeBtn     = document.getElementById('ttp-close-btn');
+	var newBtn       = document.getElementById('ttp-new-btn');
+	var formArea     = document.getElementById('ttp-form-area');
+	var formProject  = document.getElementById('ttp-form-project');
+	var formDesc     = document.getElementById('ttp-form-desc');
+	var formStart    = document.getElementById('ttp-form-start');
+	var formCancel   = document.getElementById('ttp-form-cancel');
+	var formNewWrap  = document.getElementById('ttp-form-new-title-wrap');
+	var formNewTitle = document.getElementById('ttp-form-new-title');
+
+	var state = {
+		forced: false,
+		collapsed: false,
+		formOpen: false,
+		formCreating: false,
+		cachedProjects: null,
+		activeEntries: [],
+		editingId: null,
+	};
+
+	function escHtml(s) {
+		var d = document.createElement('div');
+		d.appendChild(document.createTextNode(s == null ? '' : String(s)));
+		return d.innerHTML;
+	}
+	function fmt(secs) { return window.TimeTrackerCore.formatElapsed(secs); }
+
+	// ---- Position persistence + off-screen guard ----
+
+	function loadPos() {
+		try {
+			var raw = localStorage.getItem(POS_KEY);
+			if (!raw) return null;
+			var p = JSON.parse(raw);
+			if (typeof p.x !== 'number' || typeof p.y !== 'number') return null;
+			return p;
+		} catch (e) { return null; }
+	}
+	function savePos() {
+		var rect = panel.getBoundingClientRect();
+		var data = { x: rect.left, y: rect.top, collapsed: state.collapsed };
+		try { localStorage.setItem(POS_KEY, JSON.stringify(data)); } catch (e) {}
+	}
+	function applyPos(p) {
+		if (!p) return;
+		var w = panel.offsetWidth || 320;
+		var h = panel.offsetHeight || 200;
+		// Off-screen guard: at least SAFE_INSET_PX of panel must remain visible
+		if (p.x + w < SAFE_INSET_PX ||
+			p.x > window.innerWidth - SAFE_INSET_PX ||
+			p.y + h < SAFE_INSET_PX ||
+			p.y > window.innerHeight - SAFE_INSET_PX ||
+			p.x < 0 || p.y < 0) {
+			panel.style.left = '';
+			panel.style.top = '';
+			return;
+		}
+		panel.style.left = p.x + 'px';
+		panel.style.top  = p.y + 'px';
+		panel.style.right = 'auto';
+		panel.style.bottom = 'auto';
+	}
+
+	// ---- Visibility ----
+
+	function applyVisibility() {
+		var shouldShow = state.forced || state.activeEntries.length > 0;
+		panel.classList.toggle('ttp-open', shouldShow);
+		panel.classList.toggle('ttp-collapsed', state.collapsed);
+	}
+	function show(forced) {
+		if (forced) state.forced = true;
+		applyVisibility();
+	}
+	function hide() {
+		state.forced = false;
+		state.formOpen = false;
+		if (formEl) formEl.hidden = true;
+		applyVisibility();
+	}
+	function toggleCollapse() {
+		state.collapsed = !state.collapsed;
+		applyVisibility();
+		savePos();
+	}
+
+	// ---- Render active entries ----
+
+	function renderActive(entries) {
+		state.activeEntries = entries || [];
+		var TTC = window.TimeTrackerCore;
+		var totalSecs = state.activeEntries.reduce(function (a, e) { return a + TTC.elapsedSeconds(e); }, 0);
+
+		if (summarySpan) {
+			summarySpan.textContent = state.activeEntries.length === 0
+				? ''
+				: state.activeEntries.length + ' · ' + fmt(totalSecs);
+		}
+
+		// Group by area
+		var groups = {};
+		var order = [];
+		state.activeEntries.forEach(function (e) {
+			var key = e.area_id == null ? 'personal' : 'area-' + e.area_id;
+			if (!groups[key]) {
+				groups[key] = {
+					name: e.area_title || 'Personal',
+					color: e.area_color || '#d4880a',
+					entries: [],
+				};
+				order.push(key);
+			}
+			groups[key].entries.push(e);
+		});
+
+		if (state.activeEntries.length === 0) {
+			groupsEl.innerHTML = '<div class="ttp-empty">No active timers.</div>';
+		} else {
+			groupsEl.innerHTML = order.map(function (k) {
+				var g = groups[k];
+				return '<div class="ttp-group">' +
+					'<div class="ttp-group-header" style="border-left-color:' + g.color + '">' + escHtml(g.name) + '</div>' +
+					g.entries.map(function (e) {
+						var elapsed = TTC.elapsedSeconds(e);
+						var desc = e.description || e.project_title || '';
+						var isEditing = state.editingId === e.id;
+						return '<div class="ttp-row" data-id="' + e.id + '">' +
+							'<span class="ttp-row-dot" style="background:' + g.color + '"></span>' +
+							(isEditing
+								? '<input class="ttp-row-desc-input" data-id="' + e.id + '" value="' + escHtml(desc) + '">'
+								: '<span class="ttp-row-desc" data-id="' + e.id + '">' + escHtml(desc) + '</span>') +
+							'<span class="ttp-row-elapsed">' + fmt(elapsed) + '</span>' +
+							'<div class="ttp-row-actions">' +
+								'<button class="ttp-row-stop" data-id="' + e.id + '" type="button">STOP</button>' +
+								'<button class="ttp-row-delete" data-id="' + e.id + '" type="button" title="Delete">×</button>' +
+							'</div>' +
+						'</div>';
+					}).join('') +
+					'</div>';
+			}).join('');
+			bindRowActions();
+			if (state.editingId != null) {
+				var input = groupsEl.querySelector('.ttp-row-desc-input[data-id="' + state.editingId + '"]');
+				if (input) { input.focus(); input.select(); }
+			}
+		}
+		applyVisibility();
+	}
+
+	function bindRowActions() {
+		groupsEl.querySelectorAll('.ttp-row-stop').forEach(function (b) {
+			b.addEventListener('click', function () {
+				b.disabled = true;
+				window.TimeTrackerCore.stopTimer(b.getAttribute('data-id'));
+			});
+		});
+		groupsEl.querySelectorAll('.ttp-row-delete').forEach(function (b) {
+			b.addEventListener('click', function () {
+				var id = b.getAttribute('data-id');
+				if (!confirm('Delete this running timer? This cannot be undone.')) return;
+				b.disabled = true;
+				window.TimeTrackerCore.deleteTimer(id);
+			});
+		});
+		groupsEl.querySelectorAll('.ttp-row-desc').forEach(function (el) {
+			el.addEventListener('click', function () {
+				state.editingId = parseInt(el.getAttribute('data-id'), 10);
+				renderActive(state.activeEntries);
+			});
+		});
+		groupsEl.querySelectorAll('.ttp-row-desc-input').forEach(function (input) {
+			var id = input.getAttribute('data-id');
+			var original = input.value;
+			var done = false;
+			function commit(save) {
+				if (done) return;
+				done = true;
+				var v = input.value.trim();
+				state.editingId = null;
+				if (save && v !== original) {
+					window.TimeTrackerCore.updateTimer(id, { description: v });
+				} else {
+					renderActive(state.activeEntries);
+				}
+			}
+			input.addEventListener('blur', function () { commit(true); });
+			input.addEventListener('keydown', function (e) {
+				if (e.key === 'Enter') { e.preventDefault(); commit(true); }
+				else if (e.key === 'Escape') { commit(false); }
+			});
+		});
+	}
+
+	// ---- New-timer form ----
+
+	function fetchProjects() {
+		return fetch('/time/projects', { credentials: 'same-origin' })
+			.then(function (r) { return r.ok ? r.json() : { areas: [], personal: [] }; })
+			.then(function (data) { state.cachedProjects = data; return data; })
+			.catch(function () { return { areas: [], personal: [] }; });
+	}
+	function populateAreaPicker() {
+		formArea.innerHTML = '';
+		var data = state.cachedProjects || { areas: [], personal: [] };
+		data.areas.forEach(function (a) {
+			var opt = document.createElement('option');
+			opt.value = 'area:' + a.id;
+			opt.textContent = a.title;
+			opt.dataset.areaSlug = a.slug;
+			formArea.appendChild(opt);
+		});
+		if (data.personal && data.personal.length) {
+			var opt = document.createElement('option');
+			opt.value = 'personal';
+			opt.textContent = '(Personal projects)';
+			formArea.appendChild(opt);
+		}
+	}
+	function populateProjectPicker() {
+		formProject.innerHTML = '';
+		var sel = formArea.value;
+		var data = state.cachedProjects || { areas: [], personal: [] };
+		if (sel === 'personal') {
+			(data.personal || []).forEach(function (p) {
+				var opt = document.createElement('option');
+				opt.value = String(p.id);
+				opt.textContent = p.title;
+				formProject.appendChild(opt);
+			});
+		} else if (sel.indexOf('area:') === 0) {
+			var areaId = parseInt(sel.split(':')[1], 10);
+			var area = data.areas.find(function (a) { return a.id === areaId; });
+			if (area) {
+				(area.subprojects || []).forEach(function (p) {
+					var opt = document.createElement('option');
+					opt.value = String(p.id);
+					opt.textContent = p.title;
+					formProject.appendChild(opt);
+				});
+			}
+			var createOpt = document.createElement('option');
+			createOpt.value = '__create__';
+			createOpt.textContent = '+ New sub-project under ' + (area ? area.title : 'this area');
+			formProject.appendChild(createOpt);
+		}
+		handleProjectChange();
+	}
+	function handleProjectChange() {
+		if (formProject.value === '__create__') {
+			state.formCreating = true;
+			if (formNewWrap) formNewWrap.hidden = false;
+			if (formNewTitle) formNewTitle.focus();
+		} else {
+			state.formCreating = false;
+			if (formNewWrap) formNewWrap.hidden = true;
+		}
+	}
+	function openForm() {
+		state.formOpen = true;
+		state.forced = true;
+		if (formEl) formEl.hidden = false;
+		applyVisibility();
+		fetchProjects().then(function () {
+			populateAreaPicker();
+			populateProjectPicker();
+			if (formDesc) formDesc.focus();
+		});
+	}
+	function closeForm() {
+		state.formOpen = false;
+		state.formCreating = false;
+		if (formEl) formEl.hidden = true;
+		if (formNewWrap) formNewWrap.hidden = true;
+		applyVisibility();
+	}
+	function submitForm() {
+		// §5.6 — don't fire actions before initial load resolves
+		if (!window.TimeTrackerCore.isLoaded()) return;
+
+		var description = (formDesc.value || '').trim();
+		if (state.formCreating) {
+			var areaSlug = formArea.options[formArea.selectedIndex].dataset.areaSlug;
+			var newTitle = (formNewTitle.value || '').trim();
+			if (!newTitle) { formNewTitle.focus(); return; }
+			formStart.disabled = true;
+			fetch('/command-deck/areas/' + areaSlug + '/subprojects/new', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				credentials: 'same-origin',
+				body: JSON.stringify({ title: newTitle, tracking_enabled: true })
+			})
+				.then(function (r) { return r.json(); })
+				.then(function (resp) {
+					if (resp && resp.success) {
+						return window.TimeTrackerCore.startTimer(resp.subproject.id, description);
+					}
+				})
+				.then(function () {
+					formStart.disabled = false;
+					closeForm();
+					fetchProjects();
+				})
+				.catch(function () { formStart.disabled = false; });
+			return;
+		}
+		var pid = parseInt(formProject.value, 10);
+		if (!pid) return;
+		formStart.disabled = true;
+		window.TimeTrackerCore.startTimer(pid, description).then(function (result) {
+			formStart.disabled = false;
+			if (result.ok) {
+				formDesc.value = '';
+				if (formNewTitle) formNewTitle.value = '';
+				closeForm();
+			} else if (result.status === 409) {
+				alert('A timer is already running on that project.');
+			}
+		});
+	}
+
+	// ---- Drag ----
+
+	var dragging = false, dragDX = 0, dragDY = 0;
+	function onDragStart(e) {
+		if (e.target.closest('button, input, select')) return;
+		dragging = true;
+		var rect = panel.getBoundingClientRect();
+		var ev = e.touches ? e.touches[0] : e;
+		dragDX = ev.clientX - rect.left;
+		dragDY = ev.clientY - rect.top;
+		panel.classList.add('ttp-dragging');
+		document.addEventListener('mousemove', onDragMove);
+		document.addEventListener('touchmove', onDragMove, { passive: false });
+		document.addEventListener('mouseup', onDragEnd);
+		document.addEventListener('touchend', onDragEnd);
+		e.preventDefault();
+	}
+	function onDragMove(e) {
+		if (!dragging) return;
+		var ev = e.touches ? e.touches[0] : e;
+		panel.style.left = (ev.clientX - dragDX) + 'px';
+		panel.style.top  = (ev.clientY - dragDY) + 'px';
+		panel.style.right = 'auto';
+		panel.style.bottom = 'auto';
+		if (e.cancelable) e.preventDefault();
+	}
+	function onDragEnd() {
+		if (!dragging) return;
+		dragging = false;
+		panel.classList.remove('ttp-dragging');
+		document.removeEventListener('mousemove', onDragMove);
+		document.removeEventListener('touchmove', onDragMove);
+		document.removeEventListener('mouseup', onDragEnd);
+		document.removeEventListener('touchend', onDragEnd);
+		savePos();
+	}
+
+	// ---- Init ----
+
+	var savedPos = loadPos();
+	if (savedPos) {
+		state.collapsed = !!savedPos.collapsed;
+		requestAnimationFrame(function () { applyPos(savedPos); });
+	}
+
+	if (titlebar)    titlebar.addEventListener('mousedown', onDragStart);
+	if (titlebar)    titlebar.addEventListener('touchstart', onDragStart, { passive: false });
+	if (collapseBtn) collapseBtn.addEventListener('click', toggleCollapse);
+	if (closeBtn)    closeBtn.addEventListener('click', hide);
+	if (newBtn)      newBtn.addEventListener('click', openForm);
+	if (formCancel)  formCancel.addEventListener('click', closeForm);
+	if (formStart)   formStart.addEventListener('click', submitForm);
+	if (formArea)    formArea.addEventListener('change', populateProjectPicker);
+	if (formProject) formProject.addEventListener('change', handleProjectChange);
+
+	if (window.TimeTrackerCore) {
+		window.TimeTrackerCore.subscribe(renderActive);
+	}
+
+	// ---- Ctrl+K palette entries (consumed by cockpit_modes.js) ----
+
+	window.getTimerCmdItems = function () {
+		var items = [];
+		var entries = state.activeEntries;
+		items.push({
+			icon: '⏱',
+			label: 'Start timer',
+			hint: '',
+			action: function () { show(true); openForm(); }
+		});
+		if (entries.length === 1) {
+			items.push({
+				icon: '■',
+				label: 'Stop timer',
+				hint: entries[0].project_title || entries[0].description || '',
+				action: function () { window.TimeTrackerCore.stopTimer(entries[0].id); }
+			});
+		} else if (entries.length > 1) {
+			items.push({
+				icon: '■',
+				label: 'Stop timer (open panel)',
+				hint: entries.length + ' running',
+				action: function () { show(true); }
+			});
+		}
+		if (entries.length > 0) {
+			items.push({
+				icon: '✕',
+				label: 'Stop all timers',
+				hint: entries.length + ' running',
+				action: function () {
+					if (confirm('Stop all ' + entries.length + ' running timers?')) {
+						window.TimeTrackerCore.stopAllTimers();
+					}
+				}
+			});
+			items.push({
+				icon: '↻',
+				label: 'Switch timer',
+				hint: 'stop current, start new',
+				action: function () {
+					window.TimeTrackerCore.stopAllTimers().then(function () {
+						show(true);
+						openForm();
+					});
+				}
+			});
+		}
+		return items;
+	};
+})();

--- a/templates/below_deck.html
+++ b/templates/below_deck.html
@@ -17,7 +17,8 @@
         --text-dim:#7a5020;--border:#1e1608;--border-hi:#3a2c10;--muted:#5a3c18;--input-bg:#0a0c08;
     }
     *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
-    body{background:var(--bg);color:var(--text);font-family:'Share Tech Mono','Courier New',monospace;min-height:100vh;padding:env(safe-area-inset-top,20px) 0 60px;font-size:14px;overscroll-behavior-y:contain;}
+    body{background:var(--bg);color:var(--text);font-family:'Share Tech Mono','Courier New',monospace;min-height:100vh;padding:env(safe-area-inset-top,20px) 0 60px;font-size:14px;overscroll-behavior-y:contain;transition:padding-top 0.18s ease;}
+    body.cd-strip-visible{padding-top:calc(env(safe-area-inset-top,20px) + 32px);}
     .bd-container{width:100%;max-width:480px;margin:0 auto;padding:24px 20px 60px;}
     @media(min-width:768px){.bd-container{margin-top:40px;border:1px solid var(--border);}}
     .bd-header{display:flex;align-items:baseline;justify-content:space-between;margin-bottom:24px;padding-bottom:12px;border-bottom:1px solid var(--border);}
@@ -158,6 +159,7 @@
 </div>
 <script>
     const BD_PROJECTS = {{ projects | tojson }};
+    const BD_PICKER_GROUPS = {{ picker_groups | tojson }};
     const bdList=document.getElementById('bd-list'),bdWinsList=document.getElementById('bd-wins-list'),bdWinsSection=document.getElementById('bd-wins-section');
     let selectedTag=null,dragSrc=null,dragClone=null,touchDragging=false;
 
@@ -210,10 +212,18 @@
     function bdShowAssign(id){
         const li=document.querySelector(`.bd-item[data-id="${id}"]`);if(!li)return;
         if(li.querySelector('.bd-assign-select'))return;
-        if(!BD_PROJECTS||!BD_PROJECTS.length){alert('No projects yet. Create one in Command Deck first.');return;}
+        const groups=(typeof BD_PICKER_GROUPS!=='undefined'&&BD_PICKER_GROUPS&&BD_PICKER_GROUPS.length)
+            ? BD_PICKER_GROUPS
+            : (BD_PROJECTS&&BD_PROJECTS.length ? [{label:'',projects:BD_PROJECTS}] : []);
+        if(!groups.length){alert('No projects yet. Create one in Command Deck first.');return;}
         const select=document.createElement('select');select.className='bd-assign-select';
         const ph=document.createElement('option');ph.value='';ph.textContent='→ project...';ph.disabled=true;ph.selected=true;select.appendChild(ph);
-        BD_PROJECTS.forEach(p=>{const opt=document.createElement('option');opt.value=p.id;opt.textContent=p.title;select.appendChild(opt);});
+        groups.forEach(g=>{
+            const og=g.label?document.createElement('optgroup'):select;
+            if(g.label){og.label=g.label;}
+            g.projects.forEach(p=>{const opt=document.createElement('option');opt.value=p.id;opt.textContent=p.title;og.appendChild(opt);});
+            if(g.label)select.appendChild(og);
+        });
         const deleteBtn=li.querySelector('.bd-delete');li.insertBefore(select,deleteBtn);
         select.focus();
         select.addEventListener('change',function(){

--- a/templates/below_deck.html
+++ b/templates/below_deck.html
@@ -425,5 +425,6 @@
 </script>
 
 {% include 'includes/today_panel.html' %}
+{% include 'includes/active_timer_strip.html' %}
 </body>
 </html>

--- a/templates/command_deck_area.html
+++ b/templates/command_deck_area.html
@@ -1,0 +1,342 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <title>{{ area.title }} — Command Deck</title>
+  <link rel="stylesheet" href="/static/command_deck.css">
+</head>
+<body class="command-deck"
+      data-area="{{ area.slug }}"
+      data-lifetime-entries="{{ lifetime_entry_count }}"
+      style="--card-area-color: {{ area.area_color or '#d4880a' }};">
+<div class="cd-shell">
+
+  <!-- HEADER -->
+  <header class="cd-header">
+    <div class="cd-header-left">
+      <a href="/command-deck/" class="cd-wordmark">COMMAND DECK</a>
+      <span class="cd-ident">{{ area.title | upper }} · AREA</span>
+    </div>
+    <nav class="cd-header-nav">
+      <a href="/command-deck/" class="cd-nav-link">BRIDGE</a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/command-deck/projects/" class="cd-nav-link">PROJECTS</a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/below-deck" class="cd-nav-link">
+        BELOW DECK
+        <span class="cd-bd-badge" id="bdBadge"></span>
+      </a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/today/" class="cd-nav-link">TODAY</a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/publish" class="cd-nav-link">COCKPIT</a>
+    </nav>
+  </header>
+
+  <!-- MAIN GRID -->
+  <div class="cd-main">
+
+    <!-- LEFT — Area content -->
+    <div class="cd-content">
+
+      <!-- BREADCRUMB -->
+      <div class="cd-breadcrumb">
+        <a href="/command-deck/">Bridge</a>
+        <span class="cd-breadcrumb-sep">›</span>
+        <span class="cd-breadcrumb-segment">Work</span>
+        <span class="cd-breadcrumb-sep">›</span>
+        <span class="cd-breadcrumb-current">{{ area.title }}</span>
+      </div>
+
+      <!-- AREA HEADER -->
+      <div class="cd-area-page-header">
+        <div class="cd-area-page-stripe"></div>
+        <div class="cd-area-page-info">
+          <h1 class="cd-area-page-title">
+            {% if area.slug == 'corporate' %}<span class="cd-area-prefix">// CAI //</span>{% endif %}
+            <span class="cd-area-page-title-text">{{ area.title }}</span>
+            {% if area.slug == 'fdot' %}<span class="cd-fdot-sun" aria-hidden="true">☀</span>{% endif %}
+            {% if area.slug == 'penndot' %}<span class="cd-keystone-glyph" aria-hidden="true">⬡</span>{% endif %}
+          </h1>
+          {% if area.description %}
+            <p class="cd-area-page-desc" id="areaDesc">{{ area.description }}</p>
+          {% else %}
+            <p class="cd-area-page-desc cd-empty-desc" id="areaDesc">No description yet — use EDIT to add one.</p>
+          {% endif %}
+          <div class="cd-area-page-meta">
+            <span>{{ subprojects|length }} sub-project{{ 's' if subprojects|length != 1 }}</span>
+            {% if active_timer_count %}
+              <span>·</span>
+              <span class="cd-timer-dot"></span>
+              <span>{{ active_timer_count }} running</span>
+            {% endif %}
+          </div>
+        </div>
+        <div class="cd-area-page-actions">
+          <button class="cd-btn ghost sm" id="editAreaBtn">EDIT</button>
+        </div>
+      </div>
+
+      <!-- SUB-PROJECTS -->
+      <div class="cd-flex-between cd-mb-sm cd-mt">
+        <div class="cd-section-label">Sub-projects</div>
+        <button class="cd-btn primary sm" id="newSubprojectBtn">+ NEW SUB-PROJECT</button>
+      </div>
+
+      {% if subprojects %}
+        <div class="cd-subproject-grid cd-mb">
+          {% for sp in subprojects %}
+            <a href="/command-deck/projects/{{ sp.slug }}/"
+               class="cd-subproject-card"
+               data-area="{{ area.slug }}">
+              <div class="cd-subproject-title">
+                {{ sp.title }}
+                {% if sp.is_favorite %}<span class="cd-fav-icon">★</span>{% endif %}
+              </div>
+              {% if sp.description %}
+                <div class="cd-subproject-desc">{{ sp.description }}</div>
+              {% endif %}
+              <div class="cd-subproject-meta">
+                {% if sp.tracking_enabled %}<span class="cd-tracking-icon" title="Time tracking enabled">⏱</span>{% endif %}
+                {% if sp.active_timer_id %}<span class="cd-timer-dot"></span>{% endif %}
+                {% if sp.open_task_count %}<span>{{ sp.open_task_count }} task{{ 's' if sp.open_task_count != 1 }}</span>{% endif %}
+                {% if sp.block_count %}<span>{{ sp.block_count }} block{{ 's' if sp.block_count != 1 }}</span>{% endif %}
+              </div>
+            </a>
+          {% endfor %}
+        </div>
+      {% else %}
+        <div class="cd-panel cd-mb">
+          <div class="cd-panel-body">
+            <div class="cd-empty cd-area-empty">
+              {% if area.slug == 'corporate' %}
+                No active manifests. Refuel and depart.
+              {% elif area.slug == 'penndot' %}
+                DETOUR — no sub-projects yet.
+              {% elif area.slug == 'fdot' %}
+                Quiet day in the sunshine. No sub-projects yet.
+              {% else %}
+                No sub-projects yet under {{ area.title }}.
+              {% endif %}
+              <button class="cd-btn ghost sm" id="newSubprojectBtnEmpty" style="display:inline-flex;margin-left:0.5rem;">+ Add one</button>
+            </div>
+          </div>
+        </div>
+      {% endif %}
+
+    </div><!-- .cd-content -->
+
+    <!-- RIGHT SIDEBAR — Huyang scoped to area + Below Deck quick-add -->
+    <div class="cd-sidebar">
+
+      <!-- HUYANG — area context -->
+      <div class="cd-panel">
+        <div class="cd-panel-header">
+          <span class="cd-panel-title">
+            <span class="cd-huyang-name">Huyang</span>
+            &nbsp;·&nbsp; {{ area.title }}
+          </span>
+          <div class="cd-panel-actions">
+            <button class="cd-btn ghost sm" id="huyangClear">CLEAR</button>
+          </div>
+        </div>
+        <div class="cd-huyang-panel">
+          <div class="cd-huyang-history" id="huyangHistory">
+            {% if chat_history %}
+              {% for msg in chat_history %}
+                <div class="cd-msg {{ msg.role }}">
+                  <div class="cd-msg-bubble">{{ msg.content }}</div>
+                  <div class="cd-msg-meta">{{ 'you' if msg.role == 'user' else 'Huyang' }}</div>
+                </div>
+              {% endfor %}
+            {% else %}
+              <div class="cd-huyang-empty">
+                <p class="cd-huyang-empty-text">Huyang sees everything in {{ area.title }}.<br>Ask him about any sub-project here.</p>
+              </div>
+            {% endif %}
+          </div>
+          <div class="cd-huyang-input-row">
+            <textarea class="cd-huyang-textarea" id="huyangInput"
+              placeholder="ask about {{ area.title }}..." rows="1"></textarea>
+            <button class="cd-btn primary sm" id="huyangSend">TX</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- BELOW DECK QUICK PANEL -->
+      <div class="cd-panel">
+        <div class="cd-panel-header">
+          <span class="cd-panel-title">// Below Deck</span>
+          <a href="/below-deck" class="cd-btn ghost sm">OPEN FULL</a>
+        </div>
+        <div class="cd-panel-body" id="bdQuickPanel">
+          <div class="cd-input-row cd-mb-sm">
+            <input type="text" class="cd-input" id="bdNewTask" placeholder="quick task...">
+            <button class="cd-btn primary sm" id="bdAddBtn">ADD</button>
+          </div>
+          <div class="cd-empty cd-text-dim" style="font-size:0.8rem;">Tasks load on bridge.</div>
+        </div>
+      </div>
+
+    </div>
+
+  </div><!-- .cd-main -->
+
+  <!-- FOOTER -->
+  <footer class="cd-footer">
+    <div class="cd-footer-links">
+      <a href="/command-deck/" class="cd-footer-link">Bridge</a>
+      <a href="/command-deck/projects/" class="cd-footer-link">Projects</a>
+      <a href="/publish" class="cd-footer-link">Cockpit</a>
+    </div>
+    <span class="cd-footer-ident">YT-1300F · {{ area.title | upper }}</span>
+  </footer>
+
+</div><!-- .cd-shell -->
+
+<!-- NEW SUB-PROJECT MODAL -->
+<div class="cd-modal-overlay" id="newSubprojectModal">
+  <div class="cd-modal">
+    <div class="cd-modal-title">// New sub-project under {{ area.title }}</div>
+    <input type="text" class="cd-input cd-mb-sm" id="newSpTitle" placeholder="Sub-project title (e.g. Bridge 47 Inspection)" autocomplete="off">
+    <textarea class="cd-input cd-mb-sm" id="newSpDesc" placeholder="Optional one-line description" rows="2"></textarea>
+    <label class="cd-checkbox-row">
+      <input type="checkbox" id="newSpTracking" checked>
+      <span>Enable time tracking</span>
+    </label>
+    <div class="cd-modal-actions">
+      <button class="cd-btn ghost sm" id="newSpCancel">CANCEL</button>
+      <button class="cd-btn primary sm" id="newSpCreate">CREATE</button>
+    </div>
+  </div>
+</div>
+
+<!-- EDIT AREA MODAL -->
+<div class="cd-modal-overlay" id="editAreaModal">
+  <div class="cd-modal">
+    <div class="cd-modal-title">// Edit {{ area.title }}</div>
+    <input type="text" class="cd-input cd-mb-sm" id="editAreaTitle" value="{{ area.title }}">
+    <textarea class="cd-input cd-mb-sm" id="editAreaDescription" placeholder="Description" rows="3">{{ area.description or '' }}</textarea>
+    <div class="cd-modal-actions">
+      <button class="cd-btn ghost sm" id="editAreaCancel">CANCEL</button>
+      <button class="cd-btn primary sm" id="editAreaSave">SAVE</button>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  'use strict';
+
+  const AREA_SLUG = {{ area.slug | tojson }};
+  const AREA_ID = {{ area.id | tojson }};
+
+  // ---- New sub-project modal ----
+  const newModal = document.getElementById('newSubprojectModal');
+  const newOpen  = () => { newModal.classList.add('is-open'); document.getElementById('newSpTitle').focus(); };
+  const newClose = () => newModal.classList.remove('is-open');
+  document.getElementById('newSubprojectBtn')?.addEventListener('click', newOpen);
+  document.getElementById('newSubprojectBtnEmpty')?.addEventListener('click', newOpen);
+  document.getElementById('newSpCancel').addEventListener('click', newClose);
+  newModal.addEventListener('click', e => { if (e.target === newModal) newClose(); });
+  document.getElementById('newSpCreate').addEventListener('click', async () => {
+    const title = document.getElementById('newSpTitle').value.trim();
+    const description = document.getElementById('newSpDesc').value.trim();
+    const tracking = document.getElementById('newSpTracking').checked;
+    if (!title) { document.getElementById('newSpTitle').focus(); return; }
+    const r = await fetch(`/command-deck/areas/${AREA_SLUG}/subprojects/new`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      credentials: 'same-origin',
+      body: JSON.stringify({title, description, tracking_enabled: tracking})
+    });
+    const data = await r.json();
+    if (data && data.success) {
+      window.location.href = `/command-deck/projects/${data.subproject.slug}/`;
+    } else {
+      alert('Could not create sub-project.');
+    }
+  });
+
+  // ---- Edit area modal ----
+  const editModal = document.getElementById('editAreaModal');
+  document.getElementById('editAreaBtn').addEventListener('click', () => editModal.classList.add('is-open'));
+  document.getElementById('editAreaCancel').addEventListener('click', () => editModal.classList.remove('is-open'));
+  editModal.addEventListener('click', e => { if (e.target === editModal) editModal.classList.remove('is-open'); });
+  document.getElementById('editAreaSave').addEventListener('click', async () => {
+    const fd = new FormData();
+    fd.append('title', document.getElementById('editAreaTitle').value);
+    fd.append('description', document.getElementById('editAreaDescription').value);
+    fd.append('is_private', '0');
+    const r = await fetch(`/command-deck/projects/${AREA_SLUG}/update`, {method: 'POST', body: fd, credentials: 'same-origin'});
+    if (r.ok) window.location.reload();
+  });
+
+  // ---- Huyang chat (area-scoped) ----
+  const histEl = document.getElementById('huyangHistory');
+  const inputEl = document.getElementById('huyangInput');
+  const sendBtn = document.getElementById('huyangSend');
+  const clearBtn = document.getElementById('huyangClear');
+
+  function escHtml(s) {
+    const d = document.createElement('div'); d.appendChild(document.createTextNode(s == null ? '' : String(s))); return d.innerHTML;
+  }
+  function appendMsg(role, content) {
+    const empty = histEl.querySelector('.cd-huyang-empty');
+    if (empty) empty.remove();
+    const div = document.createElement('div');
+    div.className = 'cd-msg ' + role;
+    div.innerHTML = '<div class="cd-msg-bubble">' + escHtml(content) + '</div>' +
+                    '<div class="cd-msg-meta">' + (role === 'user' ? 'you' : 'Huyang') + '</div>';
+    histEl.appendChild(div);
+    histEl.scrollTop = histEl.scrollHeight;
+  }
+  async function send() {
+    const msg = inputEl.value.trim();
+    if (!msg) return;
+    appendMsg('user', msg);
+    inputEl.value = '';
+    sendBtn.disabled = true;
+    try {
+      const r = await fetch('/command-deck/chat', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        credentials: 'same-origin',
+        body: JSON.stringify({message: msg, project_id: AREA_ID})
+      });
+      const data = await r.json();
+      if (data && data.reply) appendMsg('assistant', data.reply);
+      else if (data && data.error) appendMsg('assistant', '[error: ' + data.error + ']');
+    } catch (e) {
+      appendMsg('assistant', '[Huyang offline]');
+    }
+    sendBtn.disabled = false;
+    inputEl.focus();
+  }
+  sendBtn.addEventListener('click', send);
+  inputEl.addEventListener('keydown', e => {
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(); }
+  });
+  clearBtn.addEventListener('click', async () => {
+    if (!confirm('Clear Huyang history for ' + {{ area.title | tojson }} + '?')) return;
+    await fetch('/command-deck/chat/clear', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      credentials: 'same-origin',
+      body: JSON.stringify({project_id: AREA_ID})
+    });
+    histEl.innerHTML = '<div class="cd-huyang-empty"><p class="cd-huyang-empty-text">Huyang cleared.</p></div>';
+  });
+
+  // Auto-scroll history on load
+  histEl.scrollTop = histEl.scrollHeight;
+})();
+</script>
+
+<script src="{{ url_for('static', filename='area_easter_eggs.js') }}"></script>
+
+{% include 'includes/today_panel.html' %}
+{% include 'includes/active_timer_strip.html' %}
+</body>
+</html>

--- a/templates/command_deck_area.html
+++ b/templates/command_deck_area.html
@@ -234,10 +234,15 @@
 
   // ---- New sub-project modal ----
   const newModal = document.getElementById('newSubprojectModal');
-  const newOpen  = () => { newModal.classList.add('is-open'); document.getElementById('newSpTitle').focus(); };
-  const newClose = () => newModal.classList.remove('is-open');
+  const newOpen  = () => { newModal.classList.add('open'); document.getElementById('newSpTitle').focus(); };
+  const newClose = () => newModal.classList.remove('open');
   document.getElementById('newSubprojectBtn')?.addEventListener('click', newOpen);
   document.getElementById('newSubprojectBtnEmpty')?.addEventListener('click', newOpen);
+  // Auto-open when arriving with ?new=1 (from "+ NEW" affordance on dashboard / projects list)
+  if (new URLSearchParams(window.location.search).has('new')) {
+    setTimeout(newOpen, 50);
+    history.replaceState(null, '', window.location.pathname);
+  }
   document.getElementById('newSpCancel').addEventListener('click', newClose);
   newModal.addEventListener('click', e => { if (e.target === newModal) newClose(); });
   document.getElementById('newSpCreate').addEventListener('click', async () => {
@@ -261,9 +266,9 @@
 
   // ---- Edit area modal ----
   const editModal = document.getElementById('editAreaModal');
-  document.getElementById('editAreaBtn').addEventListener('click', () => editModal.classList.add('is-open'));
-  document.getElementById('editAreaCancel').addEventListener('click', () => editModal.classList.remove('is-open'));
-  editModal.addEventListener('click', e => { if (e.target === editModal) editModal.classList.remove('is-open'); });
+  document.getElementById('editAreaBtn').addEventListener('click', () => editModal.classList.add('open'));
+  document.getElementById('editAreaCancel').addEventListener('click', () => editModal.classList.remove('open'));
+  editModal.addEventListener('click', e => { if (e.target === editModal) editModal.classList.remove('open'); });
   document.getElementById('editAreaSave').addEventListener('click', async () => {
     const fd = new FormData();
     fd.append('title', document.getElementById('editAreaTitle').value);

--- a/templates/command_deck_dashboard.html
+++ b/templates/command_deck_dashboard.html
@@ -106,47 +106,115 @@
         </div>
       </div>
 
-      <!-- PROJECTS -->
-      <div class="cd-mb-sm">
-        <div class="cd-section-label">Projects</div>
+      <!-- WORK / PERSONAL TABS -->
+      <div class="cd-tabs" role="tablist" aria-label="Project category">
+        <button class="cd-tab" role="tab" data-tab="work" aria-selected="true">WORK</button>
+        <button class="cd-tab" role="tab" data-tab="personal" aria-selected="false">PERSONAL</button>
       </div>
 
-      {% if projects %}
-        <div class="cd-project-grid cd-mb">
-          {% for project in projects %}
-            <a href="/command-deck/projects/{{ project.slug }}/"
-               class="cd-project-card {% if project.is_private == 1 or project.is_private == '1' %}is-private private-hidden{% endif %}"
-               data-private="{{ '1' if project.is_private else '0' }}">
-              <div class="cd-project-card-title">
-                  {{ project.title }}
-                  {% if project.is_private == 1 or project.is_private == '1' %}<span class="cd-private-badge">🔒 private</span>{% endif %}
-              </div>
-              {% if project.description %}
-                <div class="cd-project-card-desc">{{ project.description }}</div>
-              {% endif %}
-              <div class="cd-project-card-meta">
-                {% if project.open_task_count %}
-                  <span>{{ project.open_task_count }} task{{ 's' if project.open_task_count != 1 }}</span>
+      <!-- WORK TAB -->
+      <div class="cd-tab-pane" data-tab="work" role="tabpanel">
+        <div class="cd-tab-search-row">
+          <input type="text" class="cd-input cd-tab-search" data-tab="work" placeholder="Search areas + sub-projects..." autocomplete="off">
+        </div>
+
+        {% if favorited_subprojects and favorited_subprojects|length > 0 %}
+          <div class="cd-favorites-strip cd-mb">
+            <div class="cd-section-label cd-favorites-label">★ FAVORITES</div>
+            <div class="cd-favorites-row">
+              {% for sp in favorited_subprojects %}
+                <a href="/command-deck/projects/{{ sp.slug }}/"
+                   class="cd-favorite-card"
+                   data-search="{{ sp.title|lower }} {{ (sp.description or '')|lower }} {{ (sp.area_title or '')|lower }}"
+                   style="--card-area-color: {{ sp.area_color or '#d4880a' }};">
+                  <span class="cd-favorite-area">{{ sp.area_title }}</span>
+                  <span class="cd-favorite-title">{{ sp.title }}</span>
+                  <span class="cd-favorite-meta">
+                    {% if sp.tracking_enabled %}<span class="cd-tracking-icon" title="Time tracking enabled">⏱</span>{% endif %}
+                    {% if sp.active_timer_id %}<span class="cd-timer-dot" style="background: {{ sp.area_color or '#d4880a' }}"></span>{% endif %}
+                    {% if sp.open_task_count %}{{ sp.open_task_count }}t{% endif %}
+                  </span>
+                </a>
+              {% endfor %}
+            </div>
+          </div>
+        {% endif %}
+
+        <div class="cd-section-label cd-mb-sm">Areas of Responsibility</div>
+        <div class="cd-area-grid cd-mb">
+          {% for area in work_areas %}
+            <a href="/command-deck/areas/{{ area.slug }}/"
+               class="cd-area-card"
+               data-search="{{ area.title|lower }} {{ (area.description or '')|lower }}"
+               data-area="{{ area.slug }}"
+               style="--card-area-color: {{ area.area_color or '#d4880a' }};">
+              <span class="cd-area-stripe"></span>
+              <div class="cd-area-card-body">
+                <div class="cd-area-card-title">{{ area.title }}</div>
+                {% if area.description %}
+                  <div class="cd-area-card-desc">{{ area.description }}</div>
                 {% endif %}
-                {% if project.block_count %}
-                  <span>{{ project.block_count }} block{{ 's' if project.block_count != 1 }}</span>
-                {% endif %}
+                <div class="cd-area-card-meta">
+                  <span>{{ area.subproject_count }} sub-project{{ 's' if area.subproject_count != 1 }}</span>
+                  {% if area.open_task_count %}<span>·</span><span>{{ area.open_task_count }} open task{{ 's' if area.open_task_count != 1 }}</span>{% endif %}
+                  {% if area.active_timer_count %}<span>·</span><span class="cd-timer-dot" style="background: {{ area.area_color or '#d4880a' }}"></span><span>{{ area.active_timer_count }} running</span>{% endif %}
+                </div>
+                <div class="cd-area-card-link">VIEW AREA →</div>
               </div>
             </a>
           {% endfor %}
+        </div>
+        <div class="cd-tab-empty" data-tab-empty="work" hidden>No areas match.</div>
+      </div>
 
-          <!-- New project card -->
-          <button class="cd-project-card new-project" id="newProjectBtn">
-            + NEW PROJECT
-          </button>
+      <!-- PERSONAL TAB -->
+      <div class="cd-tab-pane" data-tab="personal" role="tabpanel" hidden>
+        <div class="cd-tab-search-row">
+          <input type="text" class="cd-input cd-tab-search" data-tab="personal" placeholder="Search personal projects..." autocomplete="off">
         </div>
-      {% else %}
-        <div class="cd-panel cd-mb">
-          <div class="cd-panel-body">
-            <div class="cd-empty">No projects yet. <button class="cd-btn ghost sm" id="newProjectBtn" style="display:inline-flex;">Start one</button></div>
+
+        {% if projects %}
+          <div class="cd-project-grid cd-mb">
+            {% for project in projects %}
+              <a href="/command-deck/projects/{{ project.slug }}/"
+                 class="cd-project-card {% if project.is_private == 1 or project.is_private == '1' %}is-private private-hidden{% endif %}"
+                 data-private="{{ '1' if project.is_private else '0' }}"
+                 data-search="{{ project.title|lower }} {{ (project.description or '')|lower }}">
+                <div class="cd-project-card-title">
+                    {{ project.title }}
+                    {% if project.is_private == 1 or project.is_private == '1' %}<span class="cd-private-badge">🔒 private</span>{% endif %}
+                </div>
+                {% if project.description %}
+                  <div class="cd-project-card-desc">{{ project.description }}</div>
+                {% endif %}
+                <div class="cd-project-card-meta">
+                  {% if project.open_task_count %}
+                    <span>{{ project.open_task_count }} task{{ 's' if project.open_task_count != 1 }}</span>
+                  {% endif %}
+                  {% if project.block_count %}
+                    <span>{{ project.block_count }} block{{ 's' if project.block_count != 1 }}</span>
+                  {% endif %}
+                  {% if project.active_timer_id %}
+                    <span class="cd-timer-dot" style="background: var(--cd-amber)"></span>
+                  {% endif %}
+                </div>
+              </a>
+            {% endfor %}
+
+            <!-- New project card -->
+            <button class="cd-project-card new-project" id="newProjectBtn">
+              + NEW PROJECT
+            </button>
           </div>
-        </div>
-      {% endif %}
+        {% else %}
+          <div class="cd-panel cd-mb">
+            <div class="cd-panel-body">
+              <div class="cd-empty">No personal projects yet. <button class="cd-btn ghost sm" id="newProjectBtn" style="display:inline-flex;">Start one</button></div>
+            </div>
+          </div>
+        {% endif %}
+        <div class="cd-tab-empty" data-tab-empty="personal" hidden>No projects match.</div>
+      </div>
 
     </div>
 
@@ -865,6 +933,9 @@ function cdShowAssign(id, context) {
 </script>
 
 
+<script src="{{ url_for('static', filename='command_deck_tabs.js') }}"></script>
+
 {% include 'includes/today_panel.html' %}
+{% include 'includes/active_timer_strip.html' %}
 </body>
 </html>

--- a/templates/command_deck_dashboard.html
+++ b/templates/command_deck_dashboard.html
@@ -143,25 +143,27 @@
         <div class="cd-section-label cd-mb-sm">Areas of Responsibility</div>
         <div class="cd-area-grid cd-mb">
           {% for area in work_areas %}
-            <a href="/command-deck/areas/{{ area.slug }}/"
-               class="cd-area-card"
-               data-search="{{ area.title|lower }} {{ (area.description or '')|lower }}"
-               data-area="{{ area.slug }}"
-               style="--card-area-color: {{ area.area_color or '#d4880a' }};">
-              <span class="cd-area-stripe"></span>
-              <div class="cd-area-card-body">
-                <div class="cd-area-card-title">{{ area.title }}</div>
-                {% if area.description %}
-                  <div class="cd-area-card-desc">{{ area.description }}</div>
-                {% endif %}
-                <div class="cd-area-card-meta">
-                  <span>{{ area.subproject_count }} sub-project{{ 's' if area.subproject_count != 1 }}</span>
-                  {% if area.open_task_count %}<span>·</span><span>{{ area.open_task_count }} open task{{ 's' if area.open_task_count != 1 }}</span>{% endif %}
-                  {% if area.active_timer_count %}<span>·</span><span class="cd-timer-dot" style="background: {{ area.area_color or '#d4880a' }}"></span><span>{{ area.active_timer_count }} running</span>{% endif %}
+            <div class="cd-area-card-wrap"
+                 data-search="{{ area.title|lower }} {{ (area.description or '')|lower }}"
+                 data-area="{{ area.slug }}"
+                 style="--card-area-color: {{ area.area_color or '#d4880a' }};">
+              <a href="/command-deck/areas/{{ area.slug }}/" class="cd-area-card">
+                <span class="cd-area-stripe"></span>
+                <div class="cd-area-card-body">
+                  <div class="cd-area-card-title">{{ area.title }}</div>
+                  {% if area.description %}
+                    <div class="cd-area-card-desc">{{ area.description }}</div>
+                  {% endif %}
+                  <div class="cd-area-card-meta">
+                    <span>{{ area.subproject_count }} sub-project{{ 's' if area.subproject_count != 1 }}</span>
+                    {% if area.open_task_count %}<span>·</span><span>{{ area.open_task_count }} open task{{ 's' if area.open_task_count != 1 }}</span>{% endif %}
+                    {% if area.active_timer_count %}<span>·</span><span class="cd-timer-dot" style="background: {{ area.area_color or '#d4880a' }}"></span><span>{{ area.active_timer_count }} running</span>{% endif %}
+                  </div>
+                  <div class="cd-area-card-link">VIEW AREA →</div>
                 </div>
-                <div class="cd-area-card-link">VIEW AREA →</div>
-              </div>
-            </a>
+              </a>
+              <a href="/command-deck/areas/{{ area.slug }}/?new=1" class="cd-area-card-add" title="New sub-project under {{ area.title }}">+ NEW SUB-PROJECT</a>
+            </div>
           {% endfor %}
         </div>
         <div class="cd-tab-empty" data-tab-empty="work" hidden>No areas match.</div>
@@ -299,13 +301,36 @@
 <div class="cd-modal-overlay" id="newProjectModal">
   <div class="cd-modal">
     <div class="cd-modal-title">// New Project</div>
+    <label style="display:block;font-family:var(--cd-font-ui);font-size:0.55rem;letter-spacing:0.18em;color:var(--cd-text-dim);text-transform:uppercase;margin-bottom:3px;">TYPE</label>
+    <select class="cd-input cd-mb-sm" id="newProjectType" style="margin-bottom:0.5rem;">
+      <option value="personal">Personal project</option>
+      {% for area in work_areas %}
+        <option value="work:{{ area.slug }}">Sub-project under {{ area.title }}</option>
+      {% endfor %}
+    </select>
     <input type="text" class="cd-input cd-mb-sm" id="newProjectTitle" placeholder="Project title..." style="margin-bottom:0.5rem;">
     <input type="text" class="cd-input" id="newProjectDesc" placeholder="Brief description (optional)...">
-    <div style="display:flex;align-items:center;gap:0.5rem;margin-top:0.5rem;">
-      <input type="checkbox" id="newProjectPrivate" style="width:14px;height:14px;accent-color:var(--cd-amber);">
-      <label for="newProjectPrivate" style="font-family:var(--cd-font-ui);font-size:0.62rem;letter-spacing:0.1em;color:var(--cd-text-dim);cursor:pointer;">
-        PRIVATE PROJECT
-      </label>
+    <div id="newProjectPersonalOpts" style="margin-top:0.5rem;">
+      <div style="display:flex;align-items:center;gap:0.5rem;">
+        <input type="checkbox" id="newProjectPrivate" style="width:14px;height:14px;accent-color:var(--cd-amber);">
+        <label for="newProjectPrivate" style="font-family:var(--cd-font-ui);font-size:0.62rem;letter-spacing:0.1em;color:var(--cd-text-dim);cursor:pointer;">
+          PRIVATE PROJECT
+        </label>
+      </div>
+      <div style="display:flex;align-items:center;gap:0.5rem;margin-top:0.4rem;">
+        <input type="checkbox" id="newProjectTrackingPersonal" style="width:14px;height:14px;accent-color:var(--cd-amber);">
+        <label for="newProjectTrackingPersonal" style="font-family:var(--cd-font-ui);font-size:0.62rem;letter-spacing:0.1em;color:var(--cd-text-dim);cursor:pointer;">
+          ⏱ TIME TRACKING
+        </label>
+      </div>
+    </div>
+    <div id="newProjectWorkOpts" style="margin-top:0.5rem;display:none;">
+      <div style="display:flex;align-items:center;gap:0.5rem;">
+        <input type="checkbox" id="newProjectTracking" checked style="width:14px;height:14px;accent-color:var(--cd-amber);">
+        <label for="newProjectTracking" style="font-family:var(--cd-font-ui);font-size:0.62rem;letter-spacing:0.1em;color:var(--cd-text-dim);cursor:pointer;">
+          ⏱ TIME TRACKING
+        </label>
+      </div>
     </div>
     <div class="cd-modal-actions">
       <button class="cd-btn ghost" id="newProjectCancelBtn">CANCEL</button>
@@ -338,6 +363,7 @@
 <script>
 
 const BD_PROJECTS = {{ projects | tojson }};
+const BD_PICKER_GROUPS = {{ picker_groups | tojson }};
 
 // ============================================================
 // BELOW DECK QUICK PANEL
@@ -540,19 +566,54 @@ function updateBadge() {
     if (e.target === this) this.classList.remove('open');
   });
 
-  document.getElementById('newProjectConfirmBtn').addEventListener('click', function() {
+  // Show/hide private vs tracking option blocks based on selected type
+  const typeSelect = document.getElementById('newProjectType');
+  const personalOpts = document.getElementById('newProjectPersonalOpts');
+  const workOpts = document.getElementById('newProjectWorkOpts');
+  function syncTypeOpts() {
+    const isWork = typeSelect.value.indexOf('work:') === 0;
+    personalOpts.style.display = isWork ? 'none' : '';
+    workOpts.style.display = isWork ? '' : 'none';
+  }
+  typeSelect.addEventListener('change', syncTypeOpts);
+  syncTypeOpts();
+
+  document.getElementById('newProjectConfirmBtn').addEventListener('click', async function() {
     const title = document.getElementById('newProjectTitle').value.trim();
     const desc  = document.getElementById('newProjectDesc').value.trim();
     if (!title) return;
 
+    const typeVal = typeSelect.value;
+    if (typeVal.indexOf('work:') === 0) {
+      // Work sub-project — POST JSON to area's subprojects endpoint
+      const areaSlug = typeVal.split(':')[1];
+      const tracking = document.getElementById('newProjectTracking').checked;
+      const r = await fetch(`/command-deck/areas/${areaSlug}/subprojects/new`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        credentials: 'same-origin',
+        body: JSON.stringify({title, description: desc, tracking_enabled: tracking})
+      });
+      const data = await r.json();
+      if (data && data.success) {
+        window.location.href = `/command-deck/projects/${data.subproject.slug}/`;
+      } else {
+        alert('Could not create sub-project.');
+      }
+      return;
+    }
+
+    // Personal project — existing form-submit flow
     const form = document.createElement('form');
     form.method = 'POST';
     form.action = '/command-deck/projects/new';
     const isPrivate = document.getElementById('newProjectPrivate').checked ? '1' : '0';
+    const trackPers = document.getElementById('newProjectTrackingPersonal').checked ? '1' : '0';
     form.innerHTML = `
       <input name="title" value="${escapeHtml(title)}">
       <input name="description" value="${escapeHtml(desc)}">
       <input name="is_private" value="${isPrivate}">
+      <input name="tracking_enabled" value="${trackPers}">
     `;
     document.body.appendChild(form);
     form.submit();
@@ -737,17 +798,27 @@ function cdShowAssign(id, context) {
   const li = document.querySelector(`[data-id="${id}"]`);
   if (!li) return;
   if (li.querySelector('.cd-assign-select')) return;
-  // Use projects from BD_PROJECTS if available, else fetch
-  const projects = (typeof BD_PROJECTS !== 'undefined' && BD_PROJECTS) ? BD_PROJECTS : [];
-  if (!projects.length) { alert('No projects yet.'); return; }
+  // Prefer grouped picker (Work areas + Personal); fall back to flat list.
+  const groups = (typeof BD_PICKER_GROUPS !== 'undefined' && BD_PICKER_GROUPS && BD_PICKER_GROUPS.length)
+	? BD_PICKER_GROUPS
+	: ((typeof BD_PROJECTS !== 'undefined' && BD_PROJECTS && BD_PROJECTS.length)
+		? [{label: '', projects: BD_PROJECTS}]
+		: []);
+  if (!groups.length) { alert('No projects yet.'); return; }
   const select = document.createElement('select');
   select.className = 'cd-assign-select';
   const ph = document.createElement('option');
   ph.value = ''; ph.textContent = '→ project...'; ph.disabled = true; ph.selected = true;
   select.appendChild(ph);
-  projects.forEach(p => {
-	const opt = document.createElement('option'); opt.value = p.id; opt.textContent = p.title;
-	select.appendChild(opt);
+  groups.forEach(g => {
+	const target = g.label ? document.createElement('optgroup') : select;
+	if (g.label) target.label = g.label;
+	g.projects.forEach(p => {
+	  const opt = document.createElement('option');
+	  opt.value = p.id; opt.textContent = p.title;
+	  target.appendChild(opt);
+	});
+	if (g.label) select.appendChild(target);
   });
   const deleteBtn = li.querySelector('.cd-task-delete, .cd-btn.danger');
   if (deleteBtn) li.insertBefore(select, deleteBtn);

--- a/templates/command_deck_dashboard.html
+++ b/templates/command_deck_dashboard.html
@@ -249,6 +249,13 @@
             {% endif %}
           </div>
 
+          <div class="cd-huyang-search-row">
+            <button class="cd-huyang-search-toggle" id="huyangSearchToggle" type="button"
+                    title="Toggle search-work mode" aria-pressed="false">
+              <span class="cd-huyang-search-icon">🔍</span>
+              <span class="cd-huyang-search-label">SEARCH WORK</span>
+            </button>
+          </div>
           <div class="cd-huyang-input-row">
             <textarea class="cd-huyang-textarea" id="huyangInput"
               placeholder="ask Huyang..." rows="1"></textarea>
@@ -595,6 +602,26 @@ function updateBadge() {
     return div;
   }
 
+  // Search-work mode toggle (Work tab only — toggle button hidden on Personal
+  // tab via CSS). Resets to off on page reload AND on tab switch (§9.1).
+  let searchWorkActive = false;
+  const searchToggle = document.getElementById('huyangSearchToggle');
+  function setSearchWork(on) {
+    searchWorkActive = !!on;
+    if (!searchToggle) return;
+    searchToggle.classList.toggle('is-active', searchWorkActive);
+    searchToggle.setAttribute('aria-pressed', searchWorkActive ? 'true' : 'false');
+    input.placeholder = searchWorkActive
+      ? 'Search across all work projects...'
+      : 'ask Huyang...';
+  }
+  if (searchToggle) {
+    searchToggle.addEventListener('click', function () { setSearchWork(!searchWorkActive); });
+  }
+  document.addEventListener('cd-tab-changed', function (e) {
+    if (e.detail && e.detail.tab === 'personal' && searchWorkActive) setSearchWork(false);
+  });
+
   function sendMessage() {
     const msg = input.value.trim();
     if (!msg) return;
@@ -605,10 +632,13 @@ function updateBadge() {
     const thinking = showThinking();
     sendBtn.disabled = true;
 
+    const payload = { message: msg, project_id: null };
+    if (searchWorkActive) payload.mode = 'search_work';
+
     fetch('/command-deck/chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ message: msg, project_id: null })
+      body: JSON.stringify(payload)
     })
     .then(r => r.json())
     .then(data => {

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -7,7 +7,8 @@
   <link rel="stylesheet" href="/static/command_deck.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/9.1.6/marked.min.js"></script>
 </head>
-<body class="command-deck">
+<body class="command-deck"
+      {% if parent_area %}data-area="{{ parent_area.slug }}" style="--card-area-color: {{ parent_area.area_color or '#d4880a' }};"{% endif %}>
 <div class="cd-shell">
 
   <!-- HEADER -->
@@ -38,10 +39,30 @@
     <!-- LEFT — Project content -->
     <div class="cd-content">
 
+      {% if parent_area %}
+      <!-- BREADCRUMB (sub-project) -->
+      <div class="cd-breadcrumb">
+        <a href="/command-deck/">Bridge</a>
+        <span class="cd-breadcrumb-sep">›</span>
+        <span class="cd-breadcrumb-segment">Work</span>
+        <span class="cd-breadcrumb-sep">›</span>
+        <a href="/command-deck/areas/{{ parent_area.slug }}/">{{ parent_area.title }}</a>
+        <span class="cd-breadcrumb-sep">›</span>
+        <span class="cd-breadcrumb-current">{{ project.title }}</span>
+      </div>
+      {% endif %}
+
       <!-- PROJECT TITLE + META -->
       <div class="cd-flex-between cd-mb-sm">
         <div>
-          <h1 class="cd-page-title" id="projectTitle">{{ project.title }}</h1>
+          <h1 class="cd-page-title" id="projectTitle">
+            {{ project.title }}
+            {% if project.tracking_enabled %}
+              <span class="cd-tracking-icon cd-title-icon" title="Time tracking enabled">⏱</span>
+            {% endif %}
+            <button class="cd-fav-toggle {% if project.is_favorite %}is-on{% endif %}" id="favoriteToggleBtn"
+                    type="button" title="Toggle favorite">{% if project.is_favorite %}★{% else %}☆{% endif %}</button>
+          </h1>
           {% if project.description %}
             <p class="cd-page-subtitle" id="projectDesc">{{ project.description }}</p>
           {% endif %}
@@ -51,6 +72,26 @@
           <button class="cd-btn sm danger" id="deleteProjectBtn">DELETE</button>
         </div>
       </div>
+
+      {% if project.tracking_enabled or project.project_type == 'work_subproject' %}
+      <!-- TIME TRACKING — start form + today's entries -->
+      <div class="cd-panel cd-mb cd-tt-panel">
+        <div class="cd-panel-header">
+          <span class="cd-panel-title">// Time</span>
+          <button class="cd-btn sm" id="startTimerBtn" type="button">+ START TIMER</button>
+        </div>
+        <div class="cd-panel-body">
+          <div id="startTimerForm" class="cd-tt-start-form" hidden>
+            <input type="text" class="cd-input" id="startTimerDesc" placeholder="What are you working on?" autocomplete="off">
+            <button class="cd-btn primary sm" id="startTimerSubmit" type="button">START</button>
+            <button class="cd-btn ghost sm" id="startTimerCancel" type="button">CANCEL</button>
+          </div>
+          <div id="todayTimeList" class="cd-tt-today-list">
+            <div class="cd-tt-loading cd-text-dim" style="font-size:0.7rem;">Loading today's entries...</div>
+          </div>
+        </div>
+      </div>
+      {% endif %}
 
       <!-- ADD BLOCK ROW -->
       <div class="cd-add-block-row">
@@ -269,6 +310,14 @@
             {% if project.is_private %}checked{% endif %}>
           <label for="editProjectPrivate" style="font-family:var(--cd-font-ui);font-size:0.62rem;letter-spacing:0.1em;color:var(--cd-text-dim);cursor:pointer;">
             PRIVATE PROJECT
+          </label>
+        </div>
+      <div style="display:flex;align-items:center;gap:0.5rem;margin-top:0.5rem;">
+          <input type="checkbox" id="editProjectTracking"
+            style="width:14px;height:14px;accent-color:var(--cd-amber);"
+            {% if project.tracking_enabled %}checked{% endif %}>
+          <label for="editProjectTracking" style="font-family:var(--cd-font-ui);font-size:0.62rem;letter-spacing:0.1em;color:var(--cd-text-dim);cursor:pointer;">
+            ⏱ TIME TRACKING
           </label>
         </div>
     <div class="cd-modal-actions">
@@ -910,10 +959,19 @@ document.getElementById('blocksContainer').addEventListener('click', function(e)
   document.getElementById('editModal').addEventListener('click',function(e){
     if(e.target===this) this.classList.remove('open');
   });
-  document.getElementById('editConfirmBtn').addEventListener('click',function(){
+  document.getElementById('editConfirmBtn').addEventListener('click', async function(){
     const title=document.getElementById('editTitle').value.trim();
     const desc=document.getElementById('editDesc').value.trim();
     if(!title) return;
+    // Tracking toggle is a separate route — fire it first if changed, await before navigating.
+    const wantTracking = document.getElementById('editProjectTracking').checked;
+    const currentTracking = {{ project.tracking_enabled | default(0, true) | tojson }};
+    if (wantTracking !== !!currentTracking) {
+      try {
+        await fetch(`/command-deck/projects/${PROJECT_SLUG}/tracking`,
+                    {method:'POST', credentials:'same-origin'});
+      } catch(e) { /* keep going — page reload will reflect server state */ }
+    }
     const form=document.createElement('form');
     form.method='POST';form.action=`/command-deck/projects/${PROJECT_SLUG}/update`;
     const isPrivate = document.getElementById('editProjectPrivate').checked ? '1' : '0';
@@ -1227,6 +1285,154 @@ function cdEditTask(id) {
 
 </script>
 
+
+<script>
+// ============================================================
+// FAVORITE TOGGLE + START-TIMER FORM + TODAY'S TIME LIST
+// ============================================================
+(function () {
+  'use strict';
+
+  const PROJECT_SLUG = {{ project.slug | tojson }};
+  const PROJECT_ID   = {{ project.id   | tojson }};
+  const PROJECT_TITLE = {{ project.title | tojson }};
+
+  // ---- Favorite toggle ----
+  const favBtn = document.getElementById('favoriteToggleBtn');
+  if (favBtn) {
+    favBtn.addEventListener('click', async function () {
+      favBtn.disabled = true;
+      try {
+        const r = await fetch(`/command-deck/projects/${PROJECT_SLUG}/favorite`, {method:'POST', credentials:'same-origin'});
+        const data = await r.json();
+        if (data && data.success) {
+          favBtn.textContent = data.is_favorite ? '★' : '☆';
+          favBtn.classList.toggle('is-on', !!data.is_favorite);
+        }
+      } finally { favBtn.disabled = false; }
+    });
+  }
+
+  // ---- Start-timer inline form ----
+  const startBtn   = document.getElementById('startTimerBtn');
+  const formEl     = document.getElementById('startTimerForm');
+  const descInput  = document.getElementById('startTimerDesc');
+  const submitBtn  = document.getElementById('startTimerSubmit');
+  const cancelBtn  = document.getElementById('startTimerCancel');
+  const todayList  = document.getElementById('todayTimeList');
+
+  function openStartForm() {
+    if (!formEl) return;
+    formEl.hidden = false;
+    if (descInput) { descInput.value = ''; descInput.focus(); }
+  }
+  function closeStartForm() {
+    if (formEl) formEl.hidden = true;
+  }
+  if (startBtn) startBtn.addEventListener('click', openStartForm);
+  if (cancelBtn) cancelBtn.addEventListener('click', closeStartForm);
+  if (descInput) descInput.addEventListener('keydown', e => {
+    if (e.key === 'Enter') { e.preventDefault(); submitBtn?.click(); }
+    if (e.key === 'Escape') closeStartForm();
+  });
+  if (submitBtn) submitBtn.addEventListener('click', async function () {
+    if (!window.TimeTrackerCore) return;
+    const description = (descInput.value || '').trim();
+    submitBtn.disabled = true;
+    const result = await window.TimeTrackerCore.startTimer(PROJECT_ID, description);
+    submitBtn.disabled = false;
+    if (result.ok) {
+      closeStartForm();
+      loadTodayTime();
+    } else if (result.status === 409) {
+      alert('A timer is already running on this project.');
+    } else {
+      alert('Could not start the timer.');
+    }
+  });
+
+  // ---- Today's time list ----
+  function fmt(secs) {
+    if (window.TimeTrackerCore) return window.TimeTrackerCore.formatElapsed(secs);
+    secs = Math.max(0, secs|0);
+    const h = (secs / 3600)|0, m = ((secs%3600)/60)|0, s = secs%60;
+    const pad = n => n < 10 ? '0'+n : ''+n;
+    return h > 0 ? h + ':' + pad(m) + ':' + pad(s) : m + ':' + pad(s);
+  }
+  function fmtTimeOfDay(iso) {
+    if (!iso) return '—';
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return '—';
+    return d.toLocaleTimeString([], {hour: 'numeric', minute: '2-digit'});
+  }
+  function escHtml(s) {
+    const d = document.createElement('div'); d.appendChild(document.createTextNode(s == null ? '' : String(s))); return d.innerHTML;
+  }
+
+  async function loadTodayTime() {
+    if (!todayList) return;
+    try {
+      const r = await fetch('/time/today/' + PROJECT_ID, {credentials: 'same-origin'});
+      if (!r.ok) { todayList.innerHTML = '<div class="cd-text-dim" style="font-size:0.7rem;">Could not load.</div>'; return; }
+      const data = await r.json();
+      const entries = data.entries || [];
+      if (entries.length === 0) {
+        todayList.innerHTML = '<div class="cd-text-dim" style="font-size:0.7rem;letter-spacing:0.1em;">No time logged today on this project yet.</div>';
+        return;
+      }
+      let total = 0;
+      const rows = entries.map(e => {
+        const isRunning = !e.ended_at;
+        const elapsed = e.duration_seconds != null ? e.duration_seconds : Math.floor((Date.now() - new Date(e.started_at).getTime()) / 1000);
+        total += Math.max(0, elapsed|0);
+        return '<div class="cd-tt-entry' + (isRunning ? ' is-running' : '') + '" data-id="' + e.id + '">' +
+          '<span class="cd-tt-entry-time">' + fmtTimeOfDay(e.started_at) + '–' + (e.ended_at ? fmtTimeOfDay(e.ended_at) : 'now') + '</span>' +
+          '<span class="cd-tt-entry-desc">' + (escHtml(e.description) || '<em class="cd-text-dim">no description</em>') + '</span>' +
+          '<span class="cd-tt-entry-elapsed">' + fmt(elapsed) + '</span>' +
+          (isRunning
+            ? '<button class="cd-btn ghost sm cd-tt-stop" data-id="' + e.id + '" type="button">STOP</button>'
+            : '<button class="cd-btn ghost sm cd-tt-delete" data-id="' + e.id + '" type="button" title="Delete">×</button>') +
+          '</div>';
+      }).join('');
+      todayList.innerHTML =
+        '<div class="cd-tt-today-total">Today total: <strong>' + fmt(total) + '</strong></div>' + rows;
+
+      todayList.querySelectorAll('.cd-tt-stop').forEach(b => b.addEventListener('click', async () => {
+        b.disabled = true;
+        await window.TimeTrackerCore.stopTimer(b.getAttribute('data-id'));
+        loadTodayTime();
+      }));
+      todayList.querySelectorAll('.cd-tt-delete').forEach(b => b.addEventListener('click', async () => {
+        if (!confirm('Delete this time entry?')) return;
+        b.disabled = true;
+        await window.TimeTrackerCore.deleteTimer(b.getAttribute('data-id'));
+        loadTodayTime();
+      }));
+    } catch (e) {
+      todayList.innerHTML = '<div class="cd-text-dim" style="font-size:0.7rem;">Could not load.</div>';
+    }
+  }
+
+  // Re-render on every tick + every TimeTrackerCore poll
+  if (todayList) {
+    loadTodayTime();
+    if (window.TimeTrackerCore) {
+      // Subscribe to drive periodic reloads when the active list changes
+      let lastActiveCount = -1;
+      window.TimeTrackerCore.subscribe(function (entries) {
+        const onThisProject = entries.filter(function (e) { return String(e.project_id) === String(PROJECT_ID); }).length;
+        if (onThisProject !== lastActiveCount) {
+          lastActiveCount = onThisProject;
+          loadTodayTime();
+        }
+      });
+    }
+  }
+})();
+</script>
+
+{% include 'includes/active_timer_strip.html' %}
+<script src="{{ url_for('static', filename='area_easter_eggs.js') }}"></script>
 
 {% include 'includes/today_panel.html' %}
 </body>

--- a/templates/command_deck_projects.html
+++ b/templates/command_deck_projects.html
@@ -61,6 +61,7 @@
                 {{ area.title }}
               </a>
               <span class="cd-area-section-count">{{ area_subs|length }} sub-project{{ 's' if area_subs|length != 1 }}</span>
+              <a href="/command-deck/areas/{{ area.slug }}/?new=1" class="cd-area-section-add" title="New sub-project under {{ area.title }}">+ NEW</a>
             </div>
             {% if area_subs %}
               <div class="cd-subproject-grid">
@@ -165,15 +166,38 @@
 <div class="cd-modal-overlay" id="newProjectModal">
   <div class="cd-modal">
     <div class="cd-modal-title">// New Project</div>
+    <label style="display:block;font-family:var(--cd-font-ui);font-size:0.55rem;letter-spacing:0.18em;color:var(--cd-text-dim);text-transform:uppercase;margin-bottom:3px;">TYPE</label>
+    <select class="cd-input cd-mb-sm" id="newProjectType" style="margin-bottom:0.5rem;">
+      <option value="personal">Personal project</option>
+      {% for area in work_areas %}
+        <option value="work:{{ area.slug }}">Sub-project under {{ area.title }}</option>
+      {% endfor %}
+    </select>
     <input type="text" class="cd-input cd-mb-sm" id="newProjectTitle"
       placeholder="Project title..." style="margin-bottom:0.5rem;">
     <input type="text" class="cd-input" id="newProjectDesc"
       placeholder="Brief description (optional)...">
-      <div style="display:flex;align-items:center;gap:0.5rem;margin-top:0.5rem;">
-      <input type="checkbox" id="newProjectPrivate" style="width:14px;height:14px;accent-color:var(--cd-amber);">
-      <label for="newProjectPrivate" style="font-family:var(--cd-font-ui);font-size:0.62rem;letter-spacing:0.1em;color:var(--cd-text-dim);cursor:pointer;">
-        PRIVATE PROJECT
-      </label>
+    <div id="newProjectPersonalOpts" style="margin-top:0.5rem;">
+      <div style="display:flex;align-items:center;gap:0.5rem;">
+        <input type="checkbox" id="newProjectPrivate" style="width:14px;height:14px;accent-color:var(--cd-amber);">
+        <label for="newProjectPrivate" style="font-family:var(--cd-font-ui);font-size:0.62rem;letter-spacing:0.1em;color:var(--cd-text-dim);cursor:pointer;">
+          PRIVATE PROJECT
+        </label>
+      </div>
+      <div style="display:flex;align-items:center;gap:0.5rem;margin-top:0.4rem;">
+        <input type="checkbox" id="newProjectTrackingPersonal" style="width:14px;height:14px;accent-color:var(--cd-amber);">
+        <label for="newProjectTrackingPersonal" style="font-family:var(--cd-font-ui);font-size:0.62rem;letter-spacing:0.1em;color:var(--cd-text-dim);cursor:pointer;">
+          ⏱ TIME TRACKING
+        </label>
+      </div>
+    </div>
+    <div id="newProjectWorkOpts" style="margin-top:0.5rem;display:none;">
+      <div style="display:flex;align-items:center;gap:0.5rem;">
+        <input type="checkbox" id="newProjectTracking" checked style="width:14px;height:14px;accent-color:var(--cd-amber);">
+        <label for="newProjectTracking" style="font-family:var(--cd-font-ui);font-size:0.62rem;letter-spacing:0.1em;color:var(--cd-text-dim);cursor:pointer;">
+          ⏱ TIME TRACKING
+        </label>
+      </div>
     </div>
     <div class="cd-modal-actions">
       <button class="cd-btn ghost" id="cancelBtn">CANCEL</button>
@@ -237,17 +261,49 @@ fetch('/below-deck/count').then(r=>r.json()).then(data=>{
   document.getElementById('newProjectModal').addEventListener('click',function(e){
     if(e.target===this) this.classList.remove('open');
   });
-  function submit(){
+  // Show/hide the per-type option block
+  const typeSelect = document.getElementById('newProjectType');
+  const personalOpts = document.getElementById('newProjectPersonalOpts');
+  const workOpts = document.getElementById('newProjectWorkOpts');
+  function syncTypeOpts(){
+    const isWork = typeSelect.value.indexOf('work:') === 0;
+    personalOpts.style.display = isWork ? 'none' : '';
+    workOpts.style.display = isWork ? '' : 'none';
+  }
+  typeSelect.addEventListener('change', syncTypeOpts);
+  syncTypeOpts();
+
+  async function submit(){
     const title = document.getElementById('newProjectTitle').value.trim();
     const desc  = document.getElementById('newProjectDesc').value.trim();
     if(!title) return;
+    const typeVal = typeSelect.value;
+    if(typeVal.indexOf('work:') === 0){
+      const areaSlug = typeVal.split(':')[1];
+      const tracking = document.getElementById('newProjectTracking').checked;
+      const r = await fetch(`/command-deck/areas/${areaSlug}/subprojects/new`, {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        credentials:'same-origin',
+        body: JSON.stringify({title, description: desc, tracking_enabled: tracking})
+      });
+      const data = await r.json();
+      if(data && data.success){
+        window.location.href = `/command-deck/projects/${data.subproject.slug}/`;
+      } else {
+        alert('Could not create sub-project.');
+      }
+      return;
+    }
     const form = document.createElement('form');
     form.method='POST'; form.action='/command-deck/projects/new';
     const isPrivate = document.getElementById('newProjectPrivate').checked ? '1' : '0';
+    const trackPers = document.getElementById('newProjectTrackingPersonal').checked ? '1' : '0';
     form.innerHTML = `
       <input name="title" value="${escapeHtml(title)}">
       <input name="description" value="${escapeHtml(desc)}">
       <input name="is_private" value="${isPrivate}">
+      <input name="tracking_enabled" value="${trackPers}">
     `;
     document.body.appendChild(form); form.submit();
   }

--- a/templates/command_deck_projects.html
+++ b/templates/command_deck_projects.html
@@ -40,40 +40,107 @@
         <button class="cd-btn primary" id="newProjectBtn">+ NEW PROJECT</button>
       </div>
 
-      {% if projects %}
-        <div class="cd-project-grid">
-          {% for project in projects %}
-            <a href="/command-deck/projects/{{ project.slug }}/"
-               class="cd-project-card {% if project.is_private %}is-private private-hidden{% endif %}"
-               data-private="{{ '1' if project.is_private else '0' }}">
-              <div class="cd-project-card-title">
-                  {{ project.title }}
-                  {% if project.is_private %}<span class="cd-private-badge">🔒 private</span>{% endif %}
-              </div>
-              {% if project.description %}
-                <div class="cd-project-card-desc">{{ project.description }}</div>
-              {% endif %}
-              <div class="cd-project-card-meta">
-                {% if project.open_task_count %}
-                  <span>{{ project.open_task_count }} task{{ 's' if project.open_task_count != 1 }}</span>
-                {% endif %}
-                {% if project.block_count %}
-                  <span>{{ project.block_count }} block{{ 's' if project.block_count != 1 }}</span>
-                {% endif %}
-                {% if project.file_count %}
-                  <span>{{ project.file_count }} file{{ 's' if project.file_count != 1 }}</span>
-                {% endif %}
-              </div>
-            </a>
-          {% endfor %}
+      <!-- WORK / PERSONAL TABS -->
+      <div class="cd-tabs" role="tablist" aria-label="Project category">
+        <button class="cd-tab" role="tab" data-tab="work" aria-selected="true">WORK</button>
+        <button class="cd-tab" role="tab" data-tab="personal" aria-selected="false">PERSONAL</button>
+      </div>
+
+      <!-- WORK TAB — sub-projects grouped by area -->
+      <div class="cd-tab-pane" data-tab="work" role="tabpanel">
+        <div class="cd-tab-search-row">
+          <input type="text" class="cd-input cd-tab-search" data-tab="work" placeholder="Search work sub-projects..." autocomplete="off">
         </div>
-      {% else %}
-        <div class="cd-panel">
-          <div class="cd-panel-body">
-            <div class="cd-empty">No projects yet. Start one above.</div>
+
+        {% for area in work_areas %}
+          {% set area_subs = subprojects | selectattr('area_id', 'equalto', area.id) | list %}
+          <div class="cd-area-section" data-area="{{ area.slug }}" style="--card-area-color: {{ area.area_color or '#d4880a' }};">
+            <div class="cd-area-section-header">
+              <a href="/command-deck/areas/{{ area.slug }}/" class="cd-area-section-title">
+                <span class="cd-area-section-stripe"></span>
+                {{ area.title }}
+              </a>
+              <span class="cd-area-section-count">{{ area_subs|length }} sub-project{{ 's' if area_subs|length != 1 }}</span>
+            </div>
+            {% if area_subs %}
+              <div class="cd-subproject-grid">
+                {% for sp in area_subs %}
+                  <a href="/command-deck/projects/{{ sp.slug }}/"
+                     class="cd-subproject-card"
+                     data-search="{{ sp.title|lower }} {{ (sp.description or '')|lower }} {{ area.title|lower }}"
+                     style="--card-area-color: {{ area.area_color or '#d4880a' }};">
+                    <div class="cd-subproject-title">
+                      {{ sp.title }}
+                      {% if sp.is_favorite %}<span class="cd-fav-icon">★</span>{% endif %}
+                    </div>
+                    {% if sp.description %}
+                      <div class="cd-subproject-desc">{{ sp.description }}</div>
+                    {% endif %}
+                    <div class="cd-subproject-meta">
+                      {% if sp.tracking_enabled %}<span class="cd-tracking-icon" title="Time tracking enabled">⏱</span>{% endif %}
+                      {% if sp.active_timer_id %}<span class="cd-timer-dot" style="background: {{ area.area_color or '#d4880a' }}"></span>{% endif %}
+                      {% if sp.open_task_count %}<span>{{ sp.open_task_count }} task{{ 's' if sp.open_task_count != 1 }}</span>{% endif %}
+                      {% if sp.block_count %}<span>{{ sp.block_count }} block{{ 's' if sp.block_count != 1 }}</span>{% endif %}
+                    </div>
+                  </a>
+                {% endfor %}
+              </div>
+            {% else %}
+              <div class="cd-area-section-empty">
+                No sub-projects yet. <a href="/command-deck/areas/{{ area.slug }}/">Open {{ area.title }} to add one →</a>
+              </div>
+            {% endif %}
           </div>
+        {% endfor %}
+        <div class="cd-tab-empty" data-tab-empty="work" hidden>No sub-projects match.</div>
+      </div>
+
+      <!-- PERSONAL TAB — existing personal-only project grid -->
+      <div class="cd-tab-pane" data-tab="personal" role="tabpanel" hidden>
+        <div class="cd-tab-search-row">
+          <input type="text" class="cd-input cd-tab-search" data-tab="personal" placeholder="Search personal projects..." autocomplete="off">
         </div>
-      {% endif %}
+
+        {% if projects %}
+          <div class="cd-project-grid">
+            {% for project in projects %}
+              <a href="/command-deck/projects/{{ project.slug }}/"
+                 class="cd-project-card {% if project.is_private %}is-private private-hidden{% endif %}"
+                 data-private="{{ '1' if project.is_private else '0' }}"
+                 data-search="{{ project.title|lower }} {{ (project.description or '')|lower }}">
+                <div class="cd-project-card-title">
+                    {{ project.title }}
+                    {% if project.is_private %}<span class="cd-private-badge">🔒 private</span>{% endif %}
+                </div>
+                {% if project.description %}
+                  <div class="cd-project-card-desc">{{ project.description }}</div>
+                {% endif %}
+                <div class="cd-project-card-meta">
+                  {% if project.open_task_count %}
+                    <span>{{ project.open_task_count }} task{{ 's' if project.open_task_count != 1 }}</span>
+                  {% endif %}
+                  {% if project.block_count %}
+                    <span>{{ project.block_count }} block{{ 's' if project.block_count != 1 }}</span>
+                  {% endif %}
+                  {% if project.file_count %}
+                    <span>{{ project.file_count }} file{{ 's' if project.file_count != 1 }}</span>
+                  {% endif %}
+                  {% if project.active_timer_id %}
+                    <span class="cd-timer-dot" style="background: var(--cd-amber)"></span>
+                  {% endif %}
+                </div>
+              </a>
+            {% endfor %}
+          </div>
+        {% else %}
+          <div class="cd-panel">
+            <div class="cd-panel-body">
+              <div class="cd-empty">No personal projects yet. Start one above.</div>
+            </div>
+          </div>
+        {% endif %}
+        <div class="cd-tab-empty" data-tab-empty="personal" hidden>No projects match.</div>
+      </div>
 
     </div>
   </div>
@@ -434,6 +501,9 @@ function escapeHtml(str){const d=document.createElement('div');d.appendChild(doc
 </script>
 
 
+<script src="{{ url_for('static', filename='command_deck_tabs.js') }}"></script>
+
 {% include 'includes/today_panel.html' %}
+{% include 'includes/active_timer_strip.html' %}
 </body>
 </html>

--- a/templates/includes/active_timer_strip.html
+++ b/templates/includes/active_timer_strip.html
@@ -213,11 +213,13 @@
     var TTC = window.TimeTrackerCore;
     if (!entries || entries.length === 0) {
       strip.classList.remove('tt-active', 'tt-expanded');
+      document.body.classList.remove('cd-strip-visible');
       expanded = false;
       rows.innerHTML = '';
       return;
     }
     strip.classList.add('tt-active');
+    document.body.classList.add('cd-strip-visible');
 
     var totalSecs = entries.reduce(function (acc, e) { return acc + TTC.elapsedSeconds(e); }, 0);
 

--- a/templates/includes/active_timer_strip.html
+++ b/templates/includes/active_timer_strip.html
@@ -1,0 +1,287 @@
+<!-- ============================================================ -->
+<!-- ACTIVE TIMER STRIP INCLUDE                                    -->
+<!-- Compact strip below the Today bar, showing all running timers -->
+<!-- with a chevron to expand for per-timer stop + stop-all.       -->
+<!-- Source of truth: window.TimeTrackerCore (time_tracker_core.js).-->
+<!-- Spec: .kt/spec-time-tracking-phase-1.md §6                     -->
+<!-- ============================================================ -->
+
+<style>
+#tt-strip {
+  position: fixed;
+  top: calc(28px + env(safe-area-inset-top, 0px));
+  left: 0;
+  right: 0;
+  z-index: 9998;
+  background: rgba(212, 136, 10, 0.07);
+  border-bottom: 1px solid rgba(212, 136, 10, 0.18);
+  font-family: 'Share Tech Mono', 'Courier New', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.12em;
+  color: rgba(212, 136, 10, 0.85);
+  display: none;
+  flex-direction: column;
+  user-select: none;
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+#tt-strip.tt-active { display: flex; }
+
+#tt-strip-summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 5px 14px;
+  cursor: pointer;
+  min-height: 28px;
+  transition: background 0.12s;
+}
+#tt-strip-summary:hover { background: rgba(212, 136, 10, 0.1); }
+
+#tt-strip-icon { font-size: 0.85rem; line-height: 1; }
+#tt-strip-text {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+#tt-strip-total {
+  font-variant-numeric: tabular-nums;
+  font-weight: bold;
+  color: #f5b332;
+  text-shadow: 0 0 6px rgba(245, 179, 50, 0.3);
+  flex-shrink: 0;
+}
+#tt-strip-chevron {
+  font-size: 0.5rem;
+  color: rgba(212, 136, 10, 0.5);
+  transition: transform 0.2s;
+  flex-shrink: 0;
+}
+#tt-strip.tt-expanded #tt-strip-chevron { transform: rotate(180deg); }
+
+#tt-strip-rows {
+  display: none;
+  border-top: 1px solid rgba(212, 136, 10, 0.1);
+  padding: 4px 0 6px;
+}
+#tt-strip.tt-expanded #tt-strip-rows { display: block; }
+
+.tt-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 14px 5px 20px;
+  font-size: 0.6rem;
+}
+.tt-row:hover { background: rgba(212, 136, 10, 0.06); }
+
+.tt-row-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  animation: tt-pulse 1.8s ease-in-out infinite;
+}
+@keyframes tt-pulse {
+  0%, 100% { opacity: 0.65; transform: scale(1); }
+  50%      { opacity: 1;    transform: scale(1.15); }
+}
+
+.tt-row-area {
+  font-size: 0.52rem;
+  color: rgba(212, 136, 10, 0.6);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+.tt-row-desc {
+  flex: 1;
+  color: rgba(212, 136, 10, 0.92);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.tt-row-elapsed {
+  font-variant-numeric: tabular-nums;
+  color: rgba(212, 136, 10, 0.85);
+  flex-shrink: 0;
+  min-width: 50px;
+  text-align: right;
+}
+.tt-row-stop {
+  background: none;
+  border: 1px solid rgba(212, 136, 10, 0.25);
+  color: rgba(212, 136, 10, 0.6);
+  padding: 2px 7px;
+  border-radius: 2px;
+  font-family: inherit;
+  font-size: 0.5rem;
+  letter-spacing: 0.18em;
+  cursor: pointer;
+  text-transform: uppercase;
+  flex-shrink: 0;
+  transition: all 0.15s;
+}
+.tt-row-stop:hover {
+  border-color: rgba(212, 136, 10, 0.6);
+  color: #f5b332;
+}
+
+#tt-stop-all-row {
+  display: flex;
+  justify-content: flex-end;
+  padding: 4px 14px 0;
+  margin-top: 2px;
+}
+#tt-stop-all-btn {
+  background: none;
+  border: 1px solid rgba(204, 51, 34, 0.4);
+  color: rgba(204, 51, 34, 0.7);
+  padding: 3px 10px;
+  border-radius: 2px;
+  font-family: inherit;
+  font-size: 0.52rem;
+  letter-spacing: 0.18em;
+  cursor: pointer;
+  text-transform: uppercase;
+  transition: all 0.15s;
+}
+#tt-stop-all-btn:hover {
+  border-color: #cc3322;
+  color: #cc3322;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tt-row-dot { animation: none; opacity: 0.85; }
+  #tt-strip-chevron { transition: none; }
+}
+
+@media (prefers-color-scheme: light) {
+  #tt-strip {
+    background: rgba(122, 62, 0, 0.05);
+    border-bottom-color: rgba(122, 62, 0, 0.18);
+    color: rgba(58, 30, 10, 0.8);
+  }
+  #tt-strip-summary:hover { background: rgba(122, 62, 0, 0.07); }
+  #tt-strip-total { color: #5a2e00; text-shadow: none; }
+  .tt-row:hover { background: rgba(122, 62, 0, 0.05); }
+  .tt-row-area { color: rgba(122, 62, 0, 0.55); }
+  .tt-row-desc { color: rgba(58, 30, 10, 0.92); }
+  .tt-row-elapsed { color: rgba(58, 30, 10, 0.8); }
+  .tt-row-stop { border-color: rgba(122, 62, 0, 0.25); color: rgba(122, 62, 0, 0.6); }
+  .tt-row-stop:hover { border-color: rgba(122, 62, 0, 0.55); color: #5a2e00; }
+  #tt-stop-all-btn { border-color: rgba(160, 50, 30, 0.4); color: rgba(160, 50, 30, 0.7); }
+  #tt-stop-all-btn:hover { border-color: #a0322a; color: #a0322a; }
+}
+</style>
+
+<div id="tt-strip" role="status" aria-label="Active timers" aria-live="polite">
+  <div id="tt-strip-summary" role="button" tabindex="0">
+    <span id="tt-strip-icon">⏱</span>
+    <span id="tt-strip-text"></span>
+    <span id="tt-strip-total"></span>
+    <span id="tt-strip-chevron">▾</span>
+  </div>
+  <div id="tt-strip-rows"></div>
+</div>
+
+<script src="{{ url_for('static', filename='time_tracker_core.js') }}"></script>
+<script>
+(function () {
+  'use strict';
+
+  var strip   = document.getElementById('tt-strip');
+  var summary = document.getElementById('tt-strip-summary');
+  var text    = document.getElementById('tt-strip-text');
+  var total   = document.getElementById('tt-strip-total');
+  var rows    = document.getElementById('tt-strip-rows');
+
+  var expanded = false;
+
+  function escHtml(s) {
+    var d = document.createElement('div');
+    d.appendChild(document.createTextNode(s == null ? '' : String(s)));
+    return d.innerHTML;
+  }
+
+  function uniq(arr) {
+    var seen = {};
+    return arr.filter(function (x) { if (seen[x]) return false; seen[x] = true; return true; });
+  }
+
+  function render(entries) {
+    var TTC = window.TimeTrackerCore;
+    if (!entries || entries.length === 0) {
+      strip.classList.remove('tt-active', 'tt-expanded');
+      expanded = false;
+      rows.innerHTML = '';
+      return;
+    }
+    strip.classList.add('tt-active');
+
+    var totalSecs = entries.reduce(function (acc, e) { return acc + TTC.elapsedSeconds(e); }, 0);
+
+    if (entries.length === 1) {
+      var e = entries[0];
+      var label = e.description || e.project_title || 'Timer';
+      var areaHtml = e.area_title
+        ? '<span class="tt-row-area">' + escHtml(e.area_title) + '</span>&nbsp;&nbsp;'
+        : '';
+      text.innerHTML = areaHtml + escHtml(label);
+    } else {
+      var areas = uniq(entries.map(function (e) { return e.area_title || 'Personal'; }));
+      text.textContent = entries.length + ' timers · ' + areas.join(', ');
+    }
+    total.textContent = TTC.formatElapsed(totalSecs);
+
+    var html = entries.map(function (e) {
+      var color = e.area_color || '#d4880a';
+      var areaName = e.area_title || 'Personal';
+      var desc = e.description || e.project_title || '';
+      return '<div class="tt-row" data-id="' + e.id + '">' +
+        '<span class="tt-row-dot" style="background:' + color + ';"></span>' +
+        '<span class="tt-row-area">' + escHtml(areaName) + '</span>' +
+        '<span class="tt-row-desc">' + escHtml(desc) + '</span>' +
+        '<span class="tt-row-elapsed">' + TTC.formatElapsed(TTC.elapsedSeconds(e)) + '</span>' +
+        '<button class="tt-row-stop" data-id="' + e.id + '" type="button">STOP</button>' +
+        '</div>';
+    }).join('') +
+      (entries.length > 1
+        ? '<div id="tt-stop-all-row"><button id="tt-stop-all-btn" type="button">STOP ALL</button></div>'
+        : '');
+    rows.innerHTML = html;
+
+    rows.querySelectorAll('.tt-row-stop').forEach(function (btn) {
+      btn.addEventListener('click', function (ev) {
+        ev.stopPropagation();
+        var id = btn.getAttribute('data-id');
+        btn.disabled = true;
+        TTC.stopTimer(id);
+      });
+    });
+    var stopAll = document.getElementById('tt-stop-all-btn');
+    if (stopAll) {
+      stopAll.addEventListener('click', function (ev) {
+        ev.stopPropagation();
+        if (!confirm('Stop all running timers?')) return;
+        stopAll.disabled = true;
+        TTC.stopAllTimers();
+      });
+    }
+  }
+
+  function toggleExpand() {
+    expanded = !expanded;
+    strip.classList.toggle('tt-expanded', expanded);
+  }
+
+  summary.addEventListener('click', toggleExpand);
+  summary.addEventListener('keydown', function (e) {
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleExpand(); }
+  });
+
+  if (window.TimeTrackerCore) {
+    window.TimeTrackerCore.subscribe(render);
+  }
+})();
+</script>

--- a/templates/includes/time_tracker_panel.html
+++ b/templates/includes/time_tracker_panel.html
@@ -1,0 +1,45 @@
+<!-- ============================================================ -->
+<!-- FLOATING TIME TRACKER PANEL — COCKPIT ONLY                    -->
+<!-- Renders only when ≥1 timer is active OR user invokes via      -->
+<!-- Ctrl+K. Drag, off-screen guard, localStorage position,        -->
+<!-- inline sub-project create. Source of truth: TimeTrackerCore.  -->
+<!-- Spec: .kt/spec-time-tracking-phase-1.md §5                     -->
+<!-- ============================================================ -->
+
+<link rel="stylesheet" href="{{ url_for('static', filename='cockpit_time_tracker.css') }}">
+
+<div id="ttp" role="region" aria-label="Time tracker panel">
+	<div id="ttp-titlebar">
+		<span id="ttp-title">⏱ TIME TRACKER</span>
+		<span id="ttp-summary"></span>
+		<div id="ttp-actions">
+			<button class="ttp-tb-btn" id="ttp-collapse-btn" type="button" title="Collapse" aria-label="Collapse">□</button>
+			<button class="ttp-tb-btn" id="ttp-close-btn" type="button" title="Close" aria-label="Close">✕</button>
+		</div>
+	</div>
+	<div id="ttp-body">
+		<div id="ttp-groups"></div>
+		<div id="ttp-form" hidden>
+			<label for="ttp-form-area">AREA</label>
+			<select id="ttp-form-area"></select>
+			<label for="ttp-form-project">PROJECT</label>
+			<select id="ttp-form-project"></select>
+			<div id="ttp-form-new-title-wrap" hidden>
+				<label for="ttp-form-new-title">NEW SUB-PROJECT TITLE</label>
+				<input id="ttp-form-new-title" type="text" placeholder="e.g. Bridge 47 Inspection" autocomplete="off">
+			</div>
+			<label for="ttp-form-desc">DESCRIPTION (OPTIONAL)</label>
+			<input id="ttp-form-desc" type="text" placeholder="What are you working on?" autocomplete="off">
+			<div id="ttp-form-actions">
+				<button id="ttp-form-cancel" type="button">CANCEL</button>
+				<button id="ttp-form-start" type="button">START</button>
+			</div>
+		</div>
+		<div id="ttp-footer">
+			<button id="ttp-new-btn" type="button">+ START NEW TIMER</button>
+		</div>
+	</div>
+</div>
+
+<script src="{{ url_for('static', filename='time_tracker_core.js') }}"></script>
+<script src="{{ url_for('static', filename='time_tracker_panel.js') }}"></script>

--- a/templates/publish_form.html
+++ b/templates/publish_form.html
@@ -405,6 +405,7 @@
 <!-- ============================================================ -->
 
 {% include 'includes/today_panel.html' %}
+{% include 'includes/time_tracker_panel.html' %}
 
 </body>
 </html>

--- a/templates/today.html
+++ b/templates/today.html
@@ -64,6 +64,7 @@
 </div>
 
 {% include 'includes/today_panel.html' %}
+{% include 'includes/active_timer_strip.html' %}
 
 <style>
 .today-group {


### PR DESCRIPTION
## Summary

Phase 1 of the time-tracking + Work/Personal restructure for Command Deck. See locked spec at `.kt/spec-time-tracking-phase-1.md` (gitignored — local KT doc).

10-commit PR. Each commit independently testable. **Lands via rebase-merge / fast-forward** to preserve all 10 messages.

## What ships

- **Schema**: 5 new project columns, `time_entries` + `settings` tables, `chat_messages.mode` — fully additive, idempotent migration
- **Multi-timer**: floating panel in Cockpit (Ctrl+K reachable), active strip on Today / Below Deck / all Command Deck pages, single shared poller (no double-poll)
- **Areas of Responsibility**: Corporate / PennDOT / FDOT, each with its own page, chrome, and tasteful easter eggs (1-in-20/30 frequencies, prefers-reduced-motion respected)
- **Sub-projects**: nested under areas, breadcrumb on detail page, ★ favorite + ⏱ tracking toggles, Time panel with start-form + today's-time list
- **Huyang search-work**: 🔍 toggle on Work-tab dashboard chat panel, keyword search across all work content, snippets injected with breadcrumbs, private projects excluded
- **Work/Personal tabs**: dashboard + projects-list, persists via localStorage

## Commit plan

- [x] **1/10** — Migration + schema
- [x] **2/10** — Backend: time tracking routes
- [x] **3/10** — Backend: project route additions
- [x] **4/10** — Backend: Huyang search-work
- [x] **5/10** — Shared timer-core JS + active timer strip
- [x] **6/10** — Floating timer panel
- [x] **7/10** — Command Deck dashboard restructure
- [x] **8/10** — Command Deck projects page restructure
- [x] **9/10** — Area page + project detail + per-area visual identity
- [x] **10/10** — Huyang search-work UI + KT doc updates

## Deployment notes (PA)

After merge:

\`\`\`bash
cd /home/aaronaiken/status_update
git pull
python migrate_add_time_tracking.py    # idempotent
# Reload web app from PA Web tab
\`\`\`

Migration was already verified locally (added 12 things on first run, "no changes" on second run).

## Test plan (manual)

- [ ] PA migration runs cleanly first time, "no changes" on rerun
- [ ] Three areas seeded with locked colors, settings row at id=1
- [ ] Floating panel mounts in Cockpit, drag survives reload, off-screen guard kicks in if dragged out
- [ ] Active strip mounts under Today bar on /today, /below-deck, /command-deck/*, hidden when no timers
- [ ] Concurrent timers across different sub-projects allowed; same-project second start returns 409 with prompt
- [ ] Today panel + active strip don't overlap on iOS Dynamic Island devices
- [ ] Sub-project detail page: breadcrumb to area, Time panel with start-form, today's-time list with stop/delete
- [ ] Tracking checkbox in Edit Project modal toggles ⏱ icon in title row
- [ ] Star toggle in title row persists (POST to /favorite); cross-area Favorites strip on dashboard reflects it
- [ ] Per-area chrome: Corporate slate-blue + // CAI //, PennDOT keystone-blue + blueprint grid, FDOT coral + sunset gradient + ☀
- [ ] Easter eggs: refresh Corporate area ~20× (CARGO/CLASSIFIED stamp), FDOT ~30× (palm drift); FDOT devtools console signature on every load; hurricane pill if visiting Jun 1 – Nov 30; PennDOT MILE MARKER N flash on every 10th lifetime time-entry
- [ ] Huyang search-work: toggle visible only on Work tab, resets on tab switch + reload, results cite project breadcrumbs, private projects excluded
- [ ] Ctrl+K palette: Start timer always; Stop / Stop all / Switch appear with appropriate state

🤖 Generated with [Claude Code](https://claude.com/claude-code)