### PR TITLE
Time tracking — Phase 1.5 (start-timer from tasks + checklist items)

### DIFF
--- a/blueprints/time_tracking.py
+++ b/blueprints/time_tracking.py
@@ -67,8 +67,27 @@ def _et_today_bounds_utc():
 # ---- Serializers ----
 
 
+def _row_get(row, key, default=None):
+	"""sqlite3.Row doesn't support .get() — this fills the gap for optional join cols."""
+	try:
+		return row[key]
+	except (IndexError, KeyError):
+		return default
+
+
+def _fetch_entry_with_context(conn, entry_id):
+	"""Re-fetch a time_entries row with task + checklist_item context joined."""
+	return conn.execute('''
+		SELECT te.*, t.title AS task_title, ci.text AS checklist_item_text
+		FROM time_entries te
+		LEFT JOIN tasks t ON te.task_id = t.id
+		LEFT JOIN checklist_items ci ON te.checklist_item_id = ci.id
+		WHERE te.id = ?
+	''', (entry_id,)).fetchone()
+
+
 def _serialize_active_entry(row):
-	"""Active-entry shape per spec §3.1."""
+	"""Active-entry shape — Phase 1 §3.1 + Phase 1.5 task/item context."""
 	started = _parse_iso_utc(row['started_at'])
 	elapsed = int((datetime.now(pytz.UTC) - started).total_seconds()) if started else 0
 	return {
@@ -81,6 +100,10 @@ def _serialize_active_entry(row):
 		'description': row['description'],
 		'started_at': row['started_at'],
 		'elapsed_seconds': max(0, elapsed),
+		'task_id': _row_get(row, 'task_id'),
+		'task_title': _row_get(row, 'task_title'),
+		'checklist_item_id': _row_get(row, 'checklist_item_id'),
+		'checklist_item_text': _row_get(row, 'checklist_item_text'),
 	}
 
 
@@ -90,6 +113,9 @@ def _serialize_entry(row):
 		'id': row['id'],
 		'project_id': row['project_id'],
 		'task_id': row['task_id'],
+		'checklist_item_id': _row_get(row, 'checklist_item_id'),
+		'task_title': _row_get(row, 'task_title'),
+		'checklist_item_text': _row_get(row, 'checklist_item_text'),
 		'description': row['description'],
 		'started_at': row['started_at'],
 		'ended_at': row['ended_at'],
@@ -109,14 +135,19 @@ def time_active():
 	conn = get_db()
 	rows = conn.execute('''
 		SELECT te.id, te.project_id, te.description, te.started_at,
+		       te.task_id, te.checklist_item_id,
 		       p.title             AS project_title,
 		       p.parent_project_id,
 		       parent.id           AS area_id,
 		       parent.title        AS area_title,
-		       parent.area_color   AS area_color
+		       parent.area_color   AS area_color,
+		       t.title             AS task_title,
+		       ci.text             AS checklist_item_text
 		FROM time_entries te
 		JOIN projects p ON te.project_id = p.id
 		LEFT JOIN projects parent ON p.parent_project_id = parent.id
+		LEFT JOIN tasks t ON te.task_id = t.id
+		LEFT JOIN checklist_items ci ON te.checklist_item_id = ci.id
 		WHERE te.ended_at IS NULL
 		ORDER BY te.started_at ASC
 	''').fetchall()
@@ -131,8 +162,15 @@ def time_start():
 	data = request.get_json(silent=True) or request.form
 	project_id = data.get('project_id')
 	description = (data.get('description') or '').strip()
+	task_id = data.get('task_id')
+	checklist_item_id = data.get('checklist_item_id')
+
 	if not project_id:
 		return jsonify({'error': 'project_id required'}), 400
+
+	# Phase 1.5 — mutual exclusion of task vs checklist item
+	if task_id and checklist_item_id:
+		return jsonify({'error': 'task_or_item_not_both'}), 400
 
 	conn = get_db()
 	project = conn.execute(
@@ -147,6 +185,39 @@ def time_start():
 			'error': 'project_not_trackable',
 			'project_type': project['project_type'],
 		}), 400
+
+	# Phase 1.5 — task_id must point to a task on this project
+	if task_id:
+		task = conn.execute(
+			'SELECT id, project_id FROM tasks WHERE id = ?', (task_id,)
+		).fetchone()
+		if not task:
+			conn.close()
+			return jsonify({'error': 'task_not_found'}), 404
+		if task['project_id'] != int(project_id):
+			conn.close()
+			return jsonify({
+				'error': 'task_project_mismatch',
+				'task_project_id': task['project_id'],
+			}), 400
+
+	# Phase 1.5 — checklist_item_id must reach this project via blocks
+	if checklist_item_id:
+		item = conn.execute('''
+			SELECT ci.id, b.project_id
+			FROM checklist_items ci
+			JOIN blocks b ON ci.block_id = b.id
+			WHERE ci.id = ?
+		''', (checklist_item_id,)).fetchone()
+		if not item:
+			conn.close()
+			return jsonify({'error': 'checklist_item_not_found'}), 404
+		if item['project_id'] != int(project_id):
+			conn.close()
+			return jsonify({
+				'error': 'item_project_mismatch',
+				'item_project_id': item['project_id'],
+			}), 400
 
 	# §0a.2 #3 — 409 on concurrent same-project timer
 	existing = conn.execute(
@@ -163,12 +234,18 @@ def time_start():
 	now = _utc_now_iso()
 	cur = conn.execute('''
 		INSERT INTO time_entries
-			(project_id, description, started_at, created, updated)
-		VALUES (?, ?, ?, ?, ?)
-	''', (project_id, description, now, now, now))
+			(project_id, task_id, checklist_item_id, description,
+			 started_at, created, updated)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+	''', (
+		project_id,
+		int(task_id) if task_id else None,
+		int(checklist_item_id) if checklist_item_id else None,
+		description, now, now, now,
+	))
 	new_id = cur.lastrowid
 	conn.commit()
-	row = conn.execute('SELECT * FROM time_entries WHERE id = ?', (new_id,)).fetchone()
+	row = _fetch_entry_with_context(conn, new_id)
 	conn.close()
 	return jsonify({'success': True, 'entry': _serialize_entry(row)})
 
@@ -199,7 +276,7 @@ def time_stop(entry_id):
 		WHERE id = ?
 	''', (now_iso, max(0, duration), now_iso, entry_id))
 	conn.commit()
-	row = conn.execute('SELECT * FROM time_entries WHERE id = ?', (entry_id,)).fetchone()
+	row = _fetch_entry_with_context(conn, entry_id)
 	conn.close()
 	return jsonify({'success': True, 'entry': _serialize_entry(row)})
 
@@ -267,7 +344,7 @@ def time_update(entry_id):
 		WHERE id = ?
 	''', (new_description, new_started, new_ended, new_duration, now_iso, entry_id))
 	conn.commit()
-	row = conn.execute('SELECT * FROM time_entries WHERE id = ?', (entry_id,)).fetchone()
+	row = _fetch_entry_with_context(conn, entry_id)
 	conn.close()
 	return jsonify({'success': True, 'entry': _serialize_entry(row)})
 
@@ -341,11 +418,14 @@ def time_today(project_id):
 	start_utc, end_utc = _et_today_bounds_utc()
 	conn = get_db()
 	rows = conn.execute('''
-		SELECT * FROM time_entries
-		WHERE project_id = ?
-		  AND started_at >= ?
-		  AND started_at <  ?
-		ORDER BY started_at ASC
+		SELECT te.*, t.title AS task_title, ci.text AS checklist_item_text
+		FROM time_entries te
+		LEFT JOIN tasks t ON te.task_id = t.id
+		LEFT JOIN checklist_items ci ON te.checklist_item_id = ci.id
+		WHERE te.project_id = ?
+		  AND te.started_at >= ?
+		  AND te.started_at <  ?
+		ORDER BY te.started_at ASC
 	''', (project_id, start_utc, end_utc)).fetchall()
 	conn.close()
 	return jsonify({

--- a/migrate_add_checklist_item_id.py
+++ b/migrate_add_checklist_item_id.py
@@ -1,0 +1,81 @@
+"""
+migrate_add_checklist_item_id.py
+Phase 1.5 of the time-tracking spec — see .kt/spec-time-tracking-phase-1-5.md.
+
+What it does (idempotent — safe to run multiple times):
+  - Adds checklist_item_id INTEGER NULL column to time_entries.
+
+Schema rule (enforced in application logic, not in DB):
+  At most one of (task_id, checklist_item_id) is set on a given entry.
+
+Prints a summary of what was added vs. what was already in place.
+Running it again prints "no changes."
+
+Run from PythonAnywhere bash:
+    cd /home/aaronaiken/status_update
+    python migrate_add_checklist_item_id.py
+"""
+
+import sqlite3
+import os
+
+DB_FILE = os.path.join(
+	os.environ.get('COCKPIT_REPO_ROOT', '/home/aaronaiken/status_update'),
+	'assets/data/command_deck.db'
+)
+
+
+def column_exists(cur, table, col):
+	cols = [row[1] for row in cur.execute(f"PRAGMA table_info({table})").fetchall()]
+	return col in cols
+
+
+def run():
+	if not os.path.exists(DB_FILE):
+		print(f"× DB not found at {DB_FILE}")
+		print("  Run migrate_to_sqlite.py first.")
+		return
+
+	conn = sqlite3.connect(DB_FILE)
+	cur = conn.cursor()
+
+	# Guard: time_entries must exist (Phase 1 prerequisite)
+	te_exists = cur.execute(
+		"SELECT name FROM sqlite_master WHERE type='table' AND name='time_entries'"
+	).fetchone() is not None
+	if not te_exists:
+		print("× time_entries table not found. Run migrate_add_time_tracking.py first.")
+		conn.close()
+		return
+
+	added = []
+	skipped = []
+
+	if column_exists(cur, 'time_entries', 'checklist_item_id'):
+		skipped.append('time_entries.checklist_item_id')
+	else:
+		cur.execute("ALTER TABLE time_entries ADD COLUMN checklist_item_id INTEGER")
+		added.append('time_entries.checklist_item_id')
+
+	conn.commit()
+	conn.close()
+
+	print()
+	print(f"Migration: migrate_add_checklist_item_id.py")
+	print(f"DB:        {DB_FILE}")
+	print()
+	if added:
+		print(f"✓ Added ({len(added)}):")
+		for item in added:
+			print(f"    + {item}")
+	if skipped:
+		print(f"— Already in place ({len(skipped)}):")
+		for item in skipped:
+			print(f"    · {item}")
+	if not added:
+		print("No changes — schema already up to date.")
+	print()
+
+
+if __name__ == '__main__':
+	run()

--- a/static/cockpit_time_tracker.css
+++ b/static/cockpit_time_tracker.css
@@ -116,8 +116,14 @@
 	0%, 100% { opacity: 0.65; transform: scale(1); }
 	50%      { opacity: 1;    transform: scale(1.2); }
 }
-.ttp-row-desc {
+.ttp-row-text {
 	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 1px;
+}
+.ttp-row-desc {
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -125,6 +131,15 @@
 	color: rgba(212, 136, 10, 0.92);
 	font-size: 0.66rem;
 	min-width: 0;
+}
+.ttp-row-ctx {
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.55rem;
+	letter-spacing: 0.08em;
+	color: rgba(212, 136, 10, 0.5);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 .ttp-row-desc:empty::before {
 	content: '(no description)';

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -2282,6 +2282,20 @@ body.cd-strip-visible .cd-shell { padding-top: 32px; }
 	font-variant-numeric: tabular-nums;
 }
 .cd-tt-entry-desc { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cd-tt-entry-context {
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.55rem;
+	letter-spacing: 0.06em;
+	color: var(--card-area-color, var(--cd-amber-lo, rgba(212, 136, 10, 0.55)));
+	background: rgba(212, 136, 10, 0.05);
+	padding: 1px 5px;
+	border-radius: 2px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 200px;
+	flex-shrink: 0;
+}
 .cd-tt-entry-elapsed {
 	font-variant-numeric: tabular-nums;
 	min-width: 60px;

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -2320,6 +2320,118 @@ body.cd-strip-visible .cd-shell { padding-top: 32px; }
 
 
 /* ============================================================ */
+/* PHASE 1.5 — ⏱ buttons on task rows + checklist items          */
+/* ============================================================ */
+
+/* Base button — small, dim, monospaced */
+.cd-tt-row-btn {
+	background: none;
+	border: 1px solid transparent;
+	color: var(--cd-amber-lo, rgba(212, 136, 10, 0.55));
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.7rem;
+	letter-spacing: 0.05em;
+	padding: 1px 6px;
+	border-radius: 2px;
+	cursor: pointer;
+	flex-shrink: 0;
+	font-variant-numeric: tabular-nums;
+	transition: all 0.15s;
+	min-width: 22px;
+	line-height: 1.1;
+}
+.cd-tt-row-btn:hover {
+	border-color: var(--card-area-color, var(--cd-amber, #d4880a));
+	color: var(--cd-amber-hi, #f5b332);
+}
+
+/* Running state — area color, persistent border, live elapsed */
+.cd-tt-row-btn[data-running="1"] {
+	border-color: var(--card-area-color, var(--cd-amber, #d4880a));
+	color: var(--cd-amber-hi, #f5b332);
+	background: rgba(245, 179, 50, 0.08);
+}
+
+/* Pulsing dot on the row when its timer is running */
+.cd-task-item.cd-tt-running::before,
+.cd-checklist-item.cd-tt-running::before {
+	content: '';
+	display: inline-block;
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: var(--card-area-color, var(--cd-amber, #d4880a));
+	margin-right: 0.4rem;
+	flex-shrink: 0;
+	animation: cd-tt-row-pulse 1.8s ease-in-out infinite;
+}
+@keyframes cd-tt-row-pulse {
+	0%, 100% { opacity: 0.65; transform: scale(1); }
+	50%      { opacity: 1;    transform: scale(1.2); }
+}
+
+/* Checklist item ⏱ — hidden until row hover (desktop), low-opacity always (mobile) */
+.cd-tt-item-btn {
+	opacity: 0;
+	transition: opacity 0.15s;
+}
+.cd-checklist-item:hover .cd-tt-item-btn,
+.cd-checklist-item.cd-tt-running .cd-tt-item-btn,
+.cd-checklist-item .cd-tt-item-btn:focus {
+	opacity: 1;
+}
+@media (hover: none) {
+	/* Touch devices have no hover — show at reduced opacity */
+	.cd-tt-item-btn { opacity: 0.55; }
+	.cd-checklist-item.cd-tt-running .cd-tt-item-btn { opacity: 1; }
+}
+
+/* "today: H:MM" tag on task rows */
+.cd-tt-today-tag {
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.55rem;
+	letter-spacing: 0.1em;
+	color: var(--card-area-color, var(--cd-amber-lo, rgba(212, 136, 10, 0.6)));
+	background: rgba(212, 136, 10, 0.06);
+	padding: 1px 6px;
+	border-radius: 2px;
+	flex-shrink: 0;
+	font-variant-numeric: tabular-nums;
+}
+
+/* Toast — bottom-center, brief */
+.cd-tt-toast {
+	position: fixed;
+	bottom: 32px;
+	left: 50%;
+	transform: translateX(-50%) translateY(20px);
+	background: rgba(10, 10, 8, 0.95);
+	color: var(--cd-amber-hi, #f5b332);
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.7rem;
+	letter-spacing: 0.12em;
+	padding: 8px 16px;
+	border: 1px solid var(--cd-border-amber, rgba(212, 136, 10, 0.3));
+	border-radius: 3px;
+	box-shadow: 0 6px 24px rgba(0, 0, 0, 0.55);
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 0.18s, transform 0.18s;
+	z-index: 11000;
+}
+.cd-tt-toast.show {
+	opacity: 1;
+	transform: translateX(-50%) translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.cd-task-item.cd-tt-running::before,
+	.cd-checklist-item.cd-tt-running::before { animation: none; opacity: 0.85; }
+	.cd-tt-toast { transition: opacity 0.05s; }
+}
+
+
+/* ============================================================ */
 /* PER-AREA: Corporate (CAI) — "The Mothership"                  */
 /* Slate-blue, cargo-hold vibes, // CAI // prefix on title.       */
 /* ============================================================ */

--- a/static/time_tracker_panel.js
+++ b/static/time_tracker_panel.js
@@ -148,11 +148,15 @@
 						var elapsed = TTC.elapsedSeconds(e);
 						var desc = e.description || e.project_title || '';
 						var isEditing = state.editingId === e.id;
+						var ctxLine = '';
+						if (e.task_title) ctxLine = '<span class="ttp-row-ctx">task · ' + escHtml(e.task_title) + '</span>';
+						else if (e.checklist_item_text) ctxLine = '<span class="ttp-row-ctx">item · ' + escHtml(e.checklist_item_text) + '</span>';
+						var descNode = isEditing
+							? '<input class="ttp-row-desc-input" data-id="' + e.id + '" value="' + escHtml(desc) + '">'
+							: '<span class="ttp-row-desc" data-id="' + e.id + '">' + escHtml(desc) + '</span>';
 						return '<div class="ttp-row" data-id="' + e.id + '">' +
 							'<span class="ttp-row-dot" style="background:' + g.color + '"></span>' +
-							(isEditing
-								? '<input class="ttp-row-desc-input" data-id="' + e.id + '" value="' + escHtml(desc) + '">'
-								: '<span class="ttp-row-desc" data-id="' + e.id + '">' + escHtml(desc) + '</span>') +
+							'<div class="ttp-row-text">' + descNode + ctxLine + '</div>' +
 							'<span class="ttp-row-elapsed">' + fmt(elapsed) + '</span>' +
 							'<div class="ttp-row-actions">' +
 								'<button class="ttp-row-stop" data-id="' + e.id + '" type="button">STOP</button>' +

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -1392,8 +1392,15 @@ function cdEditTask(id) {
         const isRunning = !e.ended_at;
         const elapsed = e.duration_seconds != null ? e.duration_seconds : Math.floor((Date.now() - new Date(e.started_at).getTime()) / 1000);
         total += Math.max(0, elapsed|0);
+        let contextBadge = '';
+        if (e.task_title) {
+          contextBadge = '<span class="cd-tt-entry-context task">[task: ' + escHtml(e.task_title) + ']</span>';
+        } else if (e.checklist_item_text) {
+          contextBadge = '<span class="cd-tt-entry-context item">[item: ' + escHtml(e.checklist_item_text) + ']</span>';
+        }
         return '<div class="cd-tt-entry' + (isRunning ? ' is-running' : '') + '" data-id="' + e.id + '">' +
           '<span class="cd-tt-entry-time">' + fmtTimeOfDay(e.started_at) + '–' + (e.ended_at ? fmtTimeOfDay(e.ended_at) : 'now') + '</span>' +
+          contextBadge +
           '<span class="cd-tt-entry-desc">' + (escHtml(e.description) || '<em class="cd-text-dim">no description</em>') + '</span>' +
           '<span class="cd-tt-entry-elapsed">' + fmt(elapsed) + '</span>' +
           (isRunning
@@ -1587,6 +1594,39 @@ function cdEditTask(id) {
     clearTimeout(toastEl._t);
     toastEl._t = setTimeout(function () { toastEl.classList.remove('show'); }, 2200);
   }
+
+  // ---- Auto-stop on task/item completion (Phase 1.5 §4.5) ----
+  // Fires alongside the existing complete/toggle handlers — both POSTs run
+  // independently, the user sees "task done + timer stopped" near-simultaneously.
+  document.addEventListener('change', function (e) {
+    if (!window.TimeTrackerCore) return;
+    if (!e.target.checked) return; // un-check does not auto-restart anything
+    if (e.target.classList.contains('project-task-check')) {
+      const taskId = e.target.dataset.id;
+      const active = window.TimeTrackerCore.current().find(function (en) {
+        return String(en.task_id) === String(taskId);
+      });
+      if (active) {
+        window.TimeTrackerCore.stopTimer(active.id).then(function (r) {
+          if (r.ok && r.data && r.data.entry) {
+            showToast('Stopped after ' + fmt(r.data.entry.duration_seconds || 0) + '.');
+          }
+        });
+      }
+    } else if (e.target.dataset.itemId) {
+      const itemId = e.target.dataset.itemId;
+      const active = window.TimeTrackerCore.current().find(function (en) {
+        return String(en.checklist_item_id) === String(itemId);
+      });
+      if (active) {
+        window.TimeTrackerCore.stopTimer(active.id).then(function (r) {
+          if (r.ok && r.data && r.data.entry) {
+            showToast('Stopped after ' + fmt(r.data.entry.duration_seconds || 0) + '.');
+          }
+        });
+      }
+    }
+  });
 
   // ---- Wire to TimeTrackerCore ----
   if (window.TimeTrackerCore) {

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -131,12 +131,15 @@
               {% elif block.type == 'checklist' %}
                 <ul class="cd-checklist" data-block-id="{{ block.id }}">
                   {% for item in block['items'] %}
-                    <li class="cd-checklist-item {% if item.checked %}checked{% endif %}" data-item-id="{{ item.id }}">
+                    <li class="cd-checklist-item {% if item.checked %}checked{% endif %}" data-item-id="{{ item.id }}" data-item-text="{{ item.text }}">
                       <input type="checkbox"
                         {% if item.checked %}checked{% endif %}
                         data-item-id="{{ item.id }}"
                         data-slug="{{ project.slug }}">
                       <label>{{ item.text }}</label>
+                      {% if project.tracking_enabled %}
+                        <button class="cd-tt-row-btn cd-tt-item-btn" data-tt-item-id="{{ item.id }}" data-tt-text="{{ item.text }}" title="Start timer on this item" type="button">⏱</button>
+                      {% endif %}
                       <button class="cd-btn ghost sm checklist-item-delete" data-id="{{ item.id }}" data-slug="{{ project.slug }}">✕</button>
                     </li>
                   {% endfor %}
@@ -171,9 +174,13 @@
           {% if project_tasks %}
             <ul class="cd-task-list" id="projectTaskList">
               {% for task in project_tasks %}
-                <li class="cd-task-item" data-id="{{ task.id }}">
+                <li class="cd-task-item" data-id="{{ task.id }}" data-task-title="{{ task.title }}">
                   <input type="checkbox" class="cd-task-check project-task-check" data-id="{{ task.id }}" data-slug="{{ project.slug }}">
                   <span class="cd-task-title">{{ task.title }}</span>
+                  {% if project.tracking_enabled %}
+                    <span class="cd-tt-today-tag" data-task-today-tag="{{ task.id }}" hidden></span>
+                    <button class="cd-tt-row-btn cd-tt-task-btn" data-tt-task-id="{{ task.id }}" data-tt-text="{{ task.title }}" title="Start timer on this task" type="button">⏱</button>
+                  {% endif %}
                   <button class="cd-task-edit" data-id="{{ task.id }}" title="Edit">✎</button>
                   <button class="cd-btn ghost sm project-task-delete" data-id="{{ task.id }}" data-slug="{{ project.slug }}">✕</button>
                 </li>
@@ -1427,6 +1434,172 @@ function cdEditTask(id) {
         }
       });
     }
+  }
+})();
+
+// ============================================================
+// PHASE 1.5 — ⏱ buttons on task rows + checklist items
+// ============================================================
+(function () {
+  'use strict';
+
+  const PROJECT_ID = {{ project.id | tojson }};
+  const PROJECT_TITLE = {{ project.title | tojson }};
+
+  function fmt(s) {
+    if (window.TimeTrackerCore) return window.TimeTrackerCore.formatElapsed(s);
+    s = Math.max(0, s|0);
+    const h=(s/3600)|0, m=((s%3600)/60)|0, sec=s%60, pad=n=>n<10?'0'+n:''+n;
+    return h>0 ? h+':'+pad(m)+':'+pad(sec) : m+':'+pad(sec);
+  }
+
+  // ---- Click handlers (delegated, so dynamically-added rows work too) ----
+  document.addEventListener('click', function (e) {
+    const btn = e.target.closest('.cd-tt-row-btn');
+    if (!btn) return;
+    e.preventDefault();
+    e.stopPropagation();
+    if (btn.dataset.running === '1') {
+      // Stop this row's running timer
+      const entryId = btn.dataset.entryId;
+      if (!entryId) return;
+      btn.disabled = true;
+      window.TimeTrackerCore.stopTimer(entryId).then(function (r) {
+        btn.disabled = false;
+        if (r.ok && r.data && r.data.entry) {
+          const secs = r.data.entry.duration_seconds || 0;
+          showToast('Stopped after ' + fmt(secs) + '.');
+        }
+      });
+      return;
+    }
+    // Start a timer
+    const taskId = btn.dataset.ttTaskId || null;
+    const itemId = btn.dataset.ttItemId || null;
+    const text   = btn.dataset.ttText || '';
+    startWithConflictGuard({task_id: taskId, checklist_item_id: itemId, description: text});
+  });
+
+  function startWithConflictGuard(payload) {
+    const TTC = window.TimeTrackerCore;
+    if (!TTC || !TTC.isLoaded()) return;  // saved-state guard
+    const existing = TTC.current().find(function (e) { return String(e.project_id) === String(PROJECT_ID); });
+    if (existing) {
+      const prev = (existing.description || existing.project_title || 'current timer') +
+                   ' · ' + fmt(TTC.elapsedSeconds(existing));
+      const next = payload.description || 'this timer';
+      if (!confirm("You're tracking " + PROJECT_TITLE + " right now (" + prev + "). " +
+                   "Stop that and start tracking '" + next + "' instead?")) return;
+      TTC.stopTimer(existing.id).then(function () {
+        startTimerExt(payload).then(function (r) { if (r.ok) showToast('Switched to ' + next + '.'); });
+      });
+    } else {
+      startTimerExt(payload);
+    }
+  }
+
+  // Phase 1.5 extension: pass task_id / checklist_item_id through to /time/start.
+  // (TimeTrackerCore.startTimer only sends project_id + description today.)
+  function startTimerExt(payload) {
+    const body = {project_id: PROJECT_ID, description: payload.description || ''};
+    if (payload.task_id) body.task_id = payload.task_id;
+    if (payload.checklist_item_id) body.checklist_item_id = payload.checklist_item_id;
+    return fetch('/time/start', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      credentials: 'same-origin',
+      body: JSON.stringify(body)
+    }).then(function (r) {
+      return r.json().then(function (data) {
+        const result = {ok: r.ok, status: r.status, data: data};
+        if (r.ok && window.TimeTrackerCore) window.TimeTrackerCore.refresh();
+        else if (r.status === 409) showToast('Already tracking this project.');
+        else if (r.status === 400) showToast(data.error || 'Could not start timer.');
+        return result;
+      });
+    });
+  }
+
+  // ---- Render running state on task/item rows ----
+  function syncRowStates(entries) {
+    const myEntries = (entries || []).filter(function (e) { return String(e.project_id) === String(PROJECT_ID); });
+    // Reset all rows
+    document.querySelectorAll('.cd-tt-row-btn').forEach(function (btn) {
+      btn.dataset.running = '0';
+      btn.dataset.entryId = '';
+      btn.textContent = '⏱';
+      btn.title = 'Start timer';
+      const row = btn.closest('.cd-task-item, .cd-checklist-item');
+      if (row) row.classList.remove('cd-tt-running');
+    });
+    // Mark active ones
+    myEntries.forEach(function (e) {
+      let btn = null;
+      if (e.task_id) btn = document.querySelector('.cd-tt-task-btn[data-tt-task-id="' + e.task_id + '"]');
+      else if (e.checklist_item_id) btn = document.querySelector('.cd-tt-item-btn[data-tt-item-id="' + e.checklist_item_id + '"]');
+      if (!btn) return;
+      btn.dataset.running = '1';
+      btn.dataset.entryId = e.id;
+      btn.textContent = '■ ' + fmt(window.TimeTrackerCore.elapsedSeconds(e));
+      btn.title = 'Stop timer';
+      const row = btn.closest('.cd-task-item, .cd-checklist-item');
+      if (row) row.classList.add('cd-tt-running');
+    });
+  }
+
+  // ---- Today-tag totals on task rows ----
+  function syncTodayTags() {
+    fetch('/time/today/' + PROJECT_ID, {credentials: 'same-origin'})
+      .then(function (r) { return r.ok ? r.json() : {entries: []}; })
+      .then(function (data) {
+        const totals = {};
+        (data.entries || []).forEach(function (e) {
+          if (!e.task_id) return;
+          const dur = e.duration_seconds != null
+            ? e.duration_seconds
+            : Math.floor((Date.now() - new Date(e.started_at).getTime()) / 1000);
+          totals[e.task_id] = (totals[e.task_id] || 0) + Math.max(0, dur);
+        });
+        document.querySelectorAll('[data-task-today-tag]').forEach(function (tag) {
+          const tid = tag.getAttribute('data-task-today-tag');
+          const total = totals[tid];
+          if (total && total > 0) {
+            tag.textContent = 'today: ' + fmt(total);
+            tag.hidden = false;
+          } else {
+            tag.hidden = true;
+          }
+        });
+      })
+      .catch(function () {});
+  }
+
+  // ---- Toast (one-shot, brief) ----
+  let toastEl = null;
+  function showToast(msg) {
+    if (!toastEl) {
+      toastEl = document.createElement('div');
+      toastEl.className = 'cd-tt-toast';
+      document.body.appendChild(toastEl);
+    }
+    toastEl.textContent = msg;
+    toastEl.classList.add('show');
+    clearTimeout(toastEl._t);
+    toastEl._t = setTimeout(function () { toastEl.classList.remove('show'); }, 2200);
+  }
+
+  // ---- Wire to TimeTrackerCore ----
+  if (window.TimeTrackerCore) {
+    window.TimeTrackerCore.subscribe(function (entries) {
+      syncRowStates(entries);
+    });
+    // Refresh today-tags on load + when active count for this project changes
+    let lastSig = '';
+    syncTodayTags();
+    window.TimeTrackerCore.subscribe(function (entries) {
+      const sig = entries.filter(function (e) { return String(e.project_id) === String(PROJECT_ID); }).length;
+      if (sig !== lastSig) { lastSig = sig; syncTodayTags(); }
+    });
   }
 })();
 </script>

--- a/templates/includes/active_timer_strip.html
+++ b/templates/includes/active_timer_strip.html
@@ -94,6 +94,16 @@
   text-transform: uppercase;
   flex-shrink: 0;
 }
+.tt-row-ctx {
+  font-size: 0.55rem;
+  letter-spacing: 0.08em;
+  color: rgba(212, 136, 10, 0.55);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 1;
+  min-width: 0;
+}
 .tt-row-desc {
   flex: 1;
   color: rgba(212, 136, 10, 0.92);
@@ -240,9 +250,13 @@
       var color = e.area_color || '#d4880a';
       var areaName = e.area_title || 'Personal';
       var desc = e.description || e.project_title || '';
+      var ctx = '';
+      if (e.task_title) ctx = '<span class="tt-row-ctx">[task: ' + escHtml(e.task_title) + ']</span>';
+      else if (e.checklist_item_text) ctx = '<span class="tt-row-ctx">[item: ' + escHtml(e.checklist_item_text) + ']</span>';
       return '<div class="tt-row" data-id="' + e.id + '">' +
         '<span class="tt-row-dot" style="background:' + color + ';"></span>' +
         '<span class="tt-row-area">' + escHtml(areaName) + '</span>' +
+        ctx +
         '<span class="tt-row-desc">' + escHtml(desc) + '</span>' +
         '<span class="tt-row-elapsed">' + TTC.formatElapsed(TTC.elapsedSeconds(e)) + '</span>' +
         '<button class="tt-row-stop" data-id="' + e.id + '" type="button">STOP</button>' +


### PR DESCRIPTION
## Summary

Phase 1.5 of the time-tracking roadmap. See locked spec at `.kt/spec-time-tracking-phase-1-5.md` (gitignored — local KT doc).

5-commit PR. Lands via **rebase-merge / fast-forward**.

## What ships

- `⏱` button on every task row + every checklist item under a tracking-enabled project
- Click → starts a timer scoped to that task/item, description auto-populated
- Active strip + floating panel + today's-time list show task/item context
- Completing a task or checking an item with a running timer auto-stops with toast
- Same-project conflict shows confirm dialog with both descriptions (no silent switches)

## Commit plan

- [x] **1/5** — Migration: add `checklist_item_id` col
- [x] **2/5** — Backend: `/time/start` validation + context joins
- [x] **3/5** — Project-detail UI: ⏱ buttons + states
- [x] **4/5** — Auto-stop on complete + context surfaces
- [x] **5/5** — KT doc updates

## Deployment notes (PA)

After merge:

\`\`\`bash
cd /home/aaronaiken/status_update
git pull
python migrate_add_checklist_item_id.py   # idempotent
# Reload from PA Web tab
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)