### PR TITLE
Phase 2 Chunk A — ops confidence

### DIFF
--- a/app.py
+++ b/app.py
@@ -109,6 +109,11 @@ from blueprints.ani import ani_notify_publish  # used by publish_status
 
 from helpers.db import get_db, slugify, unique_slug, et_now
 
+# Jinja global for the CD footer pill — lazy: only invoked when the
+# includes/cd_footer_status.html partial actually renders.
+from helpers.backup_status import get_last_backup_status
+app.jinja_env.globals['last_backup_status'] = get_last_backup_status
+
 # ---- EXISTING ROUTES ----
 
 # ---- COCKPIT ROUTES ---- (moved to blueprints/cockpit.py)

--- a/app.py
+++ b/app.py
@@ -135,6 +135,7 @@ from blueprints.cockpit import cockpit_bp
 from blueprints.command_deck import command_deck_bp
 from blueprints.mozzie import mozzie_bp
 from blueprints.time_tracking import time_tracking_bp
+from blueprints.healthz import healthz_bp
 app.register_blueprint(tasks_bp)
 app.register_blueprint(today_bp)
 app.register_blueprint(below_deck_bp)
@@ -143,6 +144,7 @@ app.register_blueprint(cockpit_bp)
 app.register_blueprint(command_deck_bp)
 app.register_blueprint(mozzie_bp)
 app.register_blueprint(time_tracking_bp)
+app.register_blueprint(healthz_bp)
 
 
 if __name__ == "__main__": app.run(debug=True)

--- a/blueprints/healthz.py
+++ b/blueprints/healthz.py
@@ -1,0 +1,37 @@
+"""
+healthz — public DB-health endpoint for external uptime monitoring.
+
+Auth-free by design: monitoring services hit this without credentials and
+get a definitive 200/500 based on whether command_deck.db opens AND its
+schema is queryable. The query (SELECT COUNT(*) FROM projects) catches
+both file-level corruption (fails to open) and the all-zeros / empty-schema
+case we hit on 2026-05-02 (opens but nothing inside).
+
+Response is intentionally minimal — no internal state leak, no row counts,
+no file paths. The exception is logged server-side for triage; the client
+just sees ok or fail.
+"""
+import logging
+import sqlite3
+
+from flask import Blueprint, jsonify
+
+from helpers.db import get_db
+
+
+healthz_bp = Blueprint('healthz', __name__)
+logger = logging.getLogger(__name__)
+
+
+@healthz_bp.route('/healthz')
+def healthz():
+	try:
+		conn = get_db()
+		try:
+			conn.execute('SELECT COUNT(*) FROM projects').fetchone()
+		finally:
+			conn.close()
+	except (sqlite3.Error, OSError) as e:
+		logger.warning('healthz DB check failed: %s', e)
+		return jsonify(status='fail'), 500
+	return jsonify(status='ok'), 200

--- a/helpers/backup_status.py
+++ b/helpers/backup_status.py
@@ -1,0 +1,78 @@
+"""
+backup_status — parse ~/db-backups/backup.log to surface freshness in the UI.
+
+Both backup_all.py (cron sweep) and backup_db.py (manual snapshot, also
+called from perform_git_ops on every publish) append to the same log
+file. Each emits a predictable success marker on a clean run:
+
+  backup_all.py: '<ISO> sweep complete: N ok, 0 failed, P skipped'
+  backup_db.py:  '<ISO>   ✓ verified (integrity ok, ...)'
+
+We scan for the most recent of either pattern, compute age against
+datetime.now() (both are naive local time — same TZ produced both ends
+of the comparison so no conversion needed), and bucket into a status
+class the footer pill colours by.
+
+Failure modes (log missing, log unparseable, no successful entries
+found, parse error on timestamp) all return ('UNKNOWN', 'fail') —
+explicit red, never silent.
+"""
+import os
+import re
+from datetime import datetime
+
+
+BACKUP_DIR = os.environ.get(
+	'COCKPIT_BACKUP_DIR', os.path.expanduser('~/db-backups'))
+LOG_FILE = os.path.join(BACKUP_DIR, 'backup.log')
+
+_SUCCESS_RE = re.compile(
+	r'^(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}) '
+	r'(?:sweep complete: \d+ ok, 0 failed| *✓ verified)',
+	re.MULTILINE,
+)
+
+_OK_THRESHOLD_HOURS = 36
+_WARN_THRESHOLD_HOURS = 72
+
+
+def _format_age(delta):
+	s = max(0, int(delta.total_seconds()))
+	if s < 60:
+		return f'{s}s'
+	if s < 3600:
+		return f'{s // 60}m'
+	if s < 48 * 3600:
+		return f'{s // 3600}h'
+	return f'{s // 86400}d'
+
+
+def get_last_backup_status():
+	"""Return {age_str, status} for the footer pill.
+
+	status ∈ {'ok', 'warn', 'fail'}. Always returns a dict — the helper
+	never raises, so templates can call it without a try/except guard."""
+	try:
+		with open(LOG_FILE, 'r', encoding='utf-8') as f:
+			content = f.read()
+	except OSError:
+		return {'age_str': 'UNKNOWN', 'status': 'fail'}
+
+	matches = list(_SUCCESS_RE.finditer(content))
+	if not matches:
+		return {'age_str': 'UNKNOWN', 'status': 'fail'}
+
+	try:
+		last = datetime.fromisoformat(matches[-1].group('ts'))
+	except ValueError:
+		return {'age_str': 'UNKNOWN', 'status': 'fail'}
+
+	delta = datetime.now() - last
+	hours = delta.total_seconds() / 3600
+	if hours < _OK_THRESHOLD_HOURS:
+		status = 'ok'
+	elif hours < _WARN_THRESHOLD_HOURS:
+		status = 'warn'
+	else:
+		status = 'fail'
+	return {'age_str': _format_age(delta), 'status': status}

--- a/helpers/git.py
+++ b/helpers/git.py
@@ -1,5 +1,29 @@
 """Git helpers — status indicator + stash-safe pull/commit/push for status updates."""
+import os
 import subprocess
+
+
+REPO_ROOT = os.environ.get('COCKPIT_REPO_ROOT', '/home/aaronaiken/status_update')
+
+
+def _snapshot_db_best_effort():
+	"""Fire backup_db.py before the publish flow runs.
+
+	Defense-in-depth: every status update publish becomes a backup-trigger
+	event in addition to a content-publish event. Pairs with the daily
+	cron sweep (backup_all.py) and the manual CLI. Snapshots are cheap
+	(SQLite online backup API) and pruned to last 30, so over-snapshotting
+	is fine — under-snapshotting is what bit us 2026-05-02.
+
+	Best-effort: any failure logs and is swallowed. The publish must not
+	be blocked by a backup hiccup."""
+	try:
+		subprocess.run(
+			['python3', os.path.join(REPO_ROOT, 'backup_db.py')],
+			capture_output=True, timeout=30, check=True,
+		)
+	except Exception as e:
+		print(f'snapshot-on-publish failed (continuing anyway): {e}')
 
 
 def get_git_status():
@@ -18,6 +42,8 @@ def get_git_status():
 
 
 def perform_git_ops(filename):
+	_snapshot_db_best_effort()
+
 	stash = subprocess.run(
 		["git", "stash"], capture_output=True, encoding='utf-8'
 	)

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -24,6 +24,7 @@
   --cd-amber-lo: #6b4a10;
   --cd-green: #3a9a58;
   --cd-green-hi: #4dbb6a;
+  --cd-red: #cc4040;
   --cd-blue: #3a6a9a;
   --cd-border: #1e2830;
   --cd-border-amber: #2e1e08;
@@ -57,6 +58,7 @@
 	--cd-amber-lo: #c8bfad;
 	--cd-green: #2a6a3a;
 	--cd-green-hi: #3a8a4a;
+	--cd-red: #8a2020;
 	--cd-blue: #2a4a7a;
 	--cd-border: #d8cfc0;
 	--cd-border-amber: #c8bfad;
@@ -1376,6 +1378,39 @@ body.cd-strip-visible .cd-shell { padding-top: 32px; }
   letter-spacing: 0.1em;
   text-transform: uppercase;
   opacity: 0.5;
+}
+
+/* Last-backup pill — sits between the footer links and the ident
+   stamp. space-between in .cd-footer pushes it to the middle of the row. */
+.cd-footer-status {
+  font-family: var(--cd-font-ui);
+  font-size: 0.55rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--cd-text-dim);
+  opacity: 0.75;
+}
+
+.cd-footer-status::before {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--cd-text-dim);
+  flex-shrink: 0;
+}
+
+.cd-footer-status--ok::before   { background: var(--cd-green-hi); }
+.cd-footer-status--warn::before { background: var(--cd-amber-hi); }
+.cd-footer-status--fail::before { background: var(--cd-red); }
+
+.cd-footer-status--fail {
+  color: var(--cd-red);
+  opacity: 1;
 }
 
 /* ============================================================

--- a/templates/command_deck_area.html
+++ b/templates/command_deck_area.html
@@ -190,6 +190,7 @@
       <a href="/command-deck/projects/" class="cd-footer-link">Projects</a>
       <a href="/publish" class="cd-footer-link">Cockpit</a>
     </div>
+    {% include 'includes/cd_footer_status.html' %}
     <span class="cd-footer-ident">YT-1300F · {{ area.title | upper }}</span>
   </footer>
 

--- a/templates/command_deck_dashboard.html
+++ b/templates/command_deck_dashboard.html
@@ -280,6 +280,7 @@
       <button class="cd-nav-link" id="unlockPrivateBtn" style="background:none;border:none;cursor:pointer;" title="Private projects">🔒</button>
       {% endif %}
     </div>
+    {% include 'includes/cd_footer_status.html' %}
     <span class="cd-footer-ident">YT-1300F · COMMAND DECK · SECURE</span>
   </footer>
 

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -298,6 +298,7 @@
       <a href="/command-deck/projects/" class="cd-footer-link">Projects</a>
       <a href="/publish" class="cd-footer-link">Cockpit</a>
     </div>
+    {% include 'includes/cd_footer_status.html' %}
     <span class="cd-footer-ident">YT-1300F · COMMAND DECK · SECURE</span>
   </footer>
 

--- a/templates/command_deck_projects.html
+++ b/templates/command_deck_projects.html
@@ -157,6 +157,7 @@
       <button class="cd-nav-link" id="unlockPrivateBtn" style="background:none;border:none;cursor:pointer;" title="Private projects">🔒</button>
       {% endif %}
     </div>
+    {% include 'includes/cd_footer_status.html' %}
     <span class="cd-footer-ident">YT-1300F · COMMAND DECK · SECURE</span>
   </footer>
 

--- a/templates/includes/cd_footer_status.html
+++ b/templates/includes/cd_footer_status.html
@@ -1,0 +1,16 @@
+{# Last-backup pill — server-rendered into the CD footer.
+   The Jinja global is registered lazily so non-CD pages don't pay
+   the file-read cost. Color/glyph is driven entirely by status. #}
+{%- set bs = last_backup_status() -%}
+<span class="cd-footer-status cd-footer-status--{{ bs.status }}"
+      title="Last successful backup: {{ bs.age_str }} ago"
+      aria-label="Last backup {{ bs.age_str }} ago, status {{ bs.status }}">
+  {%- if bs.age_str == 'UNKNOWN' -%}
+    LAST BACKUP · UNKNOWN ✗
+  {%- else -%}
+    LAST BACKUP · {{ bs.age_str }} AGO
+    {%- if bs.status == 'ok' %} ✓
+    {%- elif bs.status == 'fail' %} ✗
+    {%- endif -%}
+  {%- endif -%}
+</span>


### PR DESCRIPTION
## Summary

First half of Phase 2 of the time-tracking roadmap. Three small ops follow-ups Aaron and I agreed to right after the 2026-05-02 backup work landed — they compound on the lessons we paid for in dollars-of-data-loss tuition. Phase 2 Chunk B (reports proper) is the next session's work.

Three commits, each independently shippable but sharing the theme "make backup state visible and active":

- **`feat(healthz)`** — public `GET /healthz` route that opens `command_deck.db` and runs `SELECT COUNT(*) FROM projects`. 200 + `{"status":"ok"}` on success, 500 + `{"status":"fail"}` otherwise. Auth-free so external monitoring can hit it. Schema-aware on purpose — `SELECT 1` would happily pass on a 2026-05-02-style all-zeros file. Wire any free uptime monitor (UptimeRobot, BetterStack) at this URL after merge to catch corruption in minutes.

- **`feat(cockpit)`** — last-backup pill in the Command Deck footer. `helpers/backup_status.py` parses `~/db-backups/backup.log`, finds the most recent successful entry from either `backup_all.py` (sweep complete with 0 failed) or `backup_db.py` (✓ verified), buckets into ok/warn/fail thresholds (<36h / 36–72h / >72h or unreadable). Server-rendered via a Jinja global registered on `app.jinja_env`, so it's lazy: only the four CD templates that include `templates/includes/cd_footer_status.html` pay the file-read cost. Drops between the existing footer-links bar and the YT-1300F ident stamp on dashboard, projects, project, and area pages.

- **`feat(publish)`** — snapshot-on-publish hook in `helpers/git.py:perform_git_ops()`. Fires `backup_db.py` as the very first step of the publish flow — before stash, pull, commit, push. Best-effort (failure logs and is swallowed; never aborts the publish). Snapshots are cheap and pruned to last 30, so over-snapshotting is fine; under-snapshotting is what bit us 2026-05-02. Pairs cleanly with the pill — every publish flips it to "0s AGO ✓" without any extra wiring.

## Test plan

- [x] `GET /healthz` returns 200 + `{"status":"ok"}` against a healthy DB
- [x] `GET /healthz` returns 500 + `{"status":"fail"}` when `COCKPIT_REPO_ROOT` points at a missing DB; exception logged server-side, never leaked in response
- [x] `helpers/backup_status.py` returns the right shape across all four states (recent ok, missing log, 50h-old warn, 80h-old fail)
- [x] Pill renders with `cd-footer-status--ok` class + ✓ glyph + correct age string on `/command-deck/`, `/command-deck/projects/`, `/command-deck/areas/corporate/`, `/command-deck/projects/<slug>/`
- [x] `_snapshot_db_best_effort()` produces a snapshot file + a `✓ verified` log line; bad REPO_ROOT logs the swallow message and raises no exception
- [x] Aaron eyeballed the rendered pill in a real browser locally (green ✓ state)
- [ ] Post-merge: configure free uptime monitor against prod `/healthz`
- [ ] Watch first publish-from-prod for clean snapshot-on-publish behavior (Aaron will yell if anything's off)

## KT doc sweep (gitignored, local-only)

- `.kt/BACKUP_AND_RECOVERY.md` — added §2 snapshot-on-publish, §8 last-backup pill, §9 /healthz; updated §6 ops checklist; bumped Last updated
- `.kt/KT-cockpit.md` — updated `perform_git_ops` snippet, helpers/git.py table entry, publishing flow step list; bumped Last updated
- `.kt/KT-command-deck.md` — added pill + healthz lines under Common Maintenance Tasks backup section; bumped Last updated
- `.kt/PROJECT_KNOWLEDGE.md` — bumped Last updated
- `.kt/phase-2-kickoff.md` — added 2026-05-05 status note marking Chunk A shipped

## Merge strategy

Rebase-merge / fast-forward only. Three commits stand on their own and the Han Solo voice runs through the bodies — squash would erase the narrative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)