### PR TITLE
Phase 2 — reports + lifetime totals + inline re-assign + panel today total

### DIFF
--- a/app.py
+++ b/app.py
@@ -141,6 +141,7 @@ from blueprints.command_deck import command_deck_bp
 from blueprints.mozzie import mozzie_bp
 from blueprints.time_tracking import time_tracking_bp
 from blueprints.healthz import healthz_bp
+from blueprints.reports import reports_bp
 app.register_blueprint(tasks_bp)
 app.register_blueprint(today_bp)
 app.register_blueprint(below_deck_bp)
@@ -150,6 +151,7 @@ app.register_blueprint(command_deck_bp)
 app.register_blueprint(mozzie_bp)
 app.register_blueprint(time_tracking_bp)
 app.register_blueprint(healthz_bp)
+app.register_blueprint(reports_bp)
 
 
 if __name__ == "__main__": app.run(debug=True)

--- a/blueprints/command_deck.py
+++ b/blueprints/command_deck.py
@@ -242,6 +242,42 @@ def cd_project(slug):
 		SELECT * FROM blocks WHERE project_id = ? ORDER BY "order" ASC, id ASC
 	''', (project['id'],)).fetchall()
 
+	# Phase 2 §4.2 — lifetime totals per task and per checklist item.
+	# Computed server-side; rendered inline alongside the JS-driven today tag.
+	# Today refreshes dynamically on every timer event; lifetime refreshes on
+	# next page load (it accumulates slowly, so this is fine).
+	task_lifetime = {
+		row['task_id']: row['secs']
+		for row in conn.execute('''
+			SELECT te.task_id, COALESCE(SUM(te.duration_seconds), 0) AS secs
+			FROM time_entries te
+			JOIN tasks t ON te.task_id = t.id
+			WHERE t.project_id = ? AND te.duration_seconds IS NOT NULL
+			GROUP BY te.task_id
+		''', (project['id'],)).fetchall()
+	}
+	item_lifetime = {
+		row['checklist_item_id']: row['secs']
+		for row in conn.execute('''
+			SELECT te.checklist_item_id, COALESCE(SUM(te.duration_seconds), 0) AS secs
+			FROM time_entries te
+			JOIN checklist_items ci ON te.checklist_item_id = ci.id
+			JOIN blocks b ON ci.block_id = b.id
+			WHERE b.project_id = ? AND te.duration_seconds IS NOT NULL
+			GROUP BY te.checklist_item_id
+		''', (project['id'],)).fetchall()
+	}
+
+	def _fmt_hmm(s):
+		s = max(0, int(s or 0))
+		if s == 0:
+			return ''
+		h = s // 3600
+		m = (s % 3600) // 60
+		if h == 0 and m == 0:
+			return '<1m'
+		return f'{h}:{m:02d}'
+
 	blocks = []
 	for b in blocks_raw:
 		block = dict(b)
@@ -250,14 +286,26 @@ def cd_project(slug):
 				'SELECT * FROM checklist_items WHERE block_id = ? ORDER BY id ASC',
 				(block['id'],)
 			).fetchall()
-			block['items'] = [dict(i) for i in items]
+			items_with_lifetime = []
+			for i in items:
+				item = dict(i)
+				item['lifetime_seconds'] = item_lifetime.get(item['id'], 0)
+				item['lifetime_text'] = _fmt_hmm(item['lifetime_seconds'])
+				items_with_lifetime.append(item)
+			block['items'] = items_with_lifetime
 		blocks.append(block)
 
-	project_tasks = conn.execute('''
+	project_tasks_raw = conn.execute('''
 		SELECT * FROM tasks
 		WHERE project_id = ? AND status = 'open'
 		ORDER BY "order" ASC, id ASC
 	''', (project['id'],)).fetchall()
+	project_tasks = []
+	for t in project_tasks_raw:
+		task = dict(t)
+		task['lifetime_seconds'] = task_lifetime.get(task['id'], 0)
+		task['lifetime_text'] = _fmt_hmm(task['lifetime_seconds'])
+		project_tasks.append(task)
 
 	files = conn.execute(
 		'SELECT * FROM files WHERE project_id = ? ORDER BY uploaded DESC',
@@ -279,7 +327,7 @@ def cd_project(slug):
 		project=project,
 		parent_area=parent_area,
 		blocks=blocks,
-		project_tasks=[dict(t) for t in project_tasks],
+		project_tasks=project_tasks,
 		files=[dict(f) for f in files],
 		chat_history=[dict(m) for m in chat_history]
 	)

--- a/blueprints/reports.py
+++ b/blueprints/reports.py
@@ -1,0 +1,309 @@
+"""
+Reports blueprint — Phase 2 of the time-tracking spec.
+
+GET /command-deck/reports/data
+  Aggregations for the reports page (template lands in commit 4).
+  Returns entries within an ET-anchored date window plus four
+  precomputed totals shapes — by_area, by_project, by_day, by_timesheet
+  — so the client can switch between toggle views without re-fetching.
+
+Storage convention matches helpers/db.py + blueprints/time_tracking.py:
+  - time_entries.started_at / ended_at are ISO 8601 UTC strings
+  - day-window math is anchored to America/New_York
+  - running entries (ended_at IS NULL) get an effective end of "now"
+    and elapsed-so-far is counted toward totals; they're flagged
+    `running: true` in the entries list so the UI can pulse them.
+
+Privacy:
+  Default excludes is_private projects (locked semantics, matches
+  Huyang search-work). Client opts in via ?include_private=1 once
+  the user has unlocked via /command-deck/verify-pin. The unlock
+  state is purely client-side (localStorage in the dashboard) — this
+  endpoint trusts the client to pass the flag responsibly. The auth
+  gate is the Cockpit session cookie; the lock is for over-the-
+  shoulder peeks, not for security.
+"""
+from datetime import datetime, timedelta, date
+
+import pytz
+from flask import Blueprint, jsonify, request
+
+from helpers.auth import is_authenticated
+from helpers.db import get_db
+
+
+reports_bp = Blueprint('reports', __name__)
+
+
+_UTC_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
+_EASTERN = pytz.timezone('US/Eastern')
+
+
+# ---- Period resolution ----
+
+
+def _et_today():
+	return datetime.now(_EASTERN).date()
+
+
+def _resolve_period(period, start_arg, end_arg):
+	"""
+	Returns (start_date, end_date) — both Python dates, ET-anchored.
+	end is exclusive (one day past the last included day).
+
+	period precedence: explicit start/end if both present, otherwise
+	the period preset, otherwise the current week (Sun–Sat).
+	"""
+	if start_arg and end_arg:
+		try:
+			return (
+				date.fromisoformat(start_arg),
+				date.fromisoformat(end_arg),
+			)
+		except ValueError:
+			pass  # fall through to preset
+
+	today = _et_today()
+
+	if period == 'today':
+		return (today, today + timedelta(days=1))
+
+	if period == 'this-month':
+		first = today.replace(day=1)
+		next_month = (first.replace(day=28) + timedelta(days=4)).replace(day=1)
+		return (first, next_month)
+
+	# Default: this week, Sun–Sat. Python's weekday() makes Monday=0 / Sunday=6;
+	# we want Sunday as start, so we shift by (weekday + 1) % 7 days back.
+	days_since_sunday = (today.weekday() + 1) % 7
+	sunday = today - timedelta(days=days_since_sunday)
+	return (sunday, sunday + timedelta(days=7))
+
+
+def _et_date_to_utc_iso(d):
+	"""Take an ET date (00:00 ET on that calendar day) → UTC ISO storage string."""
+	dt_et = _EASTERN.localize(datetime.combine(d, datetime.min.time()))
+	return dt_et.astimezone(pytz.UTC).strftime(_UTC_FORMAT)
+
+
+def _utc_now_iso():
+	return datetime.now(pytz.UTC).strftime(_UTC_FORMAT)
+
+
+def _started_at_to_et_day(started_at_iso):
+	"""ISO UTC → 'YYYY-MM-DD' in ET (for day buckets)."""
+	dt = datetime.strptime(started_at_iso, _UTC_FORMAT)
+	dt = pytz.UTC.localize(dt)
+	return dt.astimezone(_EASTERN).date().isoformat()
+
+
+# ---- Aggregation builders ----
+
+
+def _build_totals(entries, start_date, end_date):
+	"""Walk the entries list once, build all four totals shapes."""
+	by_area, by_project, by_day, by_timesheet = {}, {}, {}, {}
+
+	# Pre-seed by_day + by_timesheet day keys so missing days render as 0
+	day_keys = []
+	d = start_date
+	while d < end_date:
+		key = d.isoformat()
+		day_keys.append(key)
+		by_day[key] = 0
+		d += timedelta(days=1)
+
+	total_seconds = 0
+	for e in entries:
+		secs = e['duration_seconds'] or 0
+		total_seconds += secs
+
+		area_id = e.get('area_id') or 0  # 0 = personal (no area)
+		area_key = str(area_id)
+		if area_key not in by_area:
+			by_area[area_key] = {
+				'title': e.get('area_title') or 'Personal',
+				'color': e.get('area_color') or '',
+				'seconds': 0,
+			}
+		by_area[area_key]['seconds'] += secs
+
+		proj_key = str(e['project_id'])
+		if proj_key not in by_project:
+			by_project[proj_key] = {
+				'title': e.get('project_title') or '',
+				'area_color': e.get('area_color') or '',
+				'area_title': e.get('area_title') or 'Personal',
+				'seconds': 0,
+			}
+		by_project[proj_key]['seconds'] += secs
+
+		day_key = _started_at_to_et_day(e['started_at'])
+		if day_key in by_day:
+			by_day[day_key] += secs
+
+		if proj_key not in by_timesheet:
+			by_timesheet[proj_key] = {
+				'title': e.get('project_title') or '',
+				'area_color': e.get('area_color') or '',
+				'area_title': e.get('area_title') or 'Personal',
+				'days': {k: 0 for k in day_keys},
+				'total': 0,
+			}
+		if day_key in by_timesheet[proj_key]['days']:
+			by_timesheet[proj_key]['days'][day_key] += secs
+		by_timesheet[proj_key]['total'] += secs
+
+	return {
+		'by_area': by_area,
+		'by_project': by_project,
+		'by_day': by_day,
+		'by_timesheet': by_timesheet,
+		'total_seconds': total_seconds,
+	}
+
+
+# ---- Route ----
+
+
+@reports_bp.route('/command-deck/reports/data', methods=['GET'])
+def reports_data():
+	if not is_authenticated():
+		return jsonify({'error': 'unauthorized'}), 403
+
+	period = request.args.get('period')
+	start_arg = request.args.get('start')
+	end_arg = request.args.get('end')
+	group = request.args.get('group', 'area')
+	if group not in ('area', 'project', 'day', 'timesheet'):
+		group = 'area'
+
+	area_filter = request.args.get('area')
+	project_filter = request.args.get('project')
+	include_private = request.args.get('include_private') == '1'
+
+	start_date, end_date = _resolve_period(period, start_arg, end_arg)
+	start_utc = _et_date_to_utc_iso(start_date)
+	end_utc = _et_date_to_utc_iso(end_date)
+	now_utc = _utc_now_iso()
+
+	# Window is keyed by started_at, consistent with the Phase 1 midnight rule:
+	# an entry that crosses midnight (or spans days) is attributed to the day
+	# of its started_at. Same principle extended to weeks/months — keeps the
+	# day buckets and the totals self-consistent. A running timer that started
+	# yesterday would not appear in today's report; a timer started today that
+	# crosses into tomorrow would appear in today's report with full elapsed.
+	clauses = ['te.started_at >= ?', 'te.started_at < ?']
+	args = [start_utc, end_utc]
+
+	if not include_private:
+		clauses.append('p.is_private = 0')
+		clauses.append('(parent.is_private IS NULL OR parent.is_private = 0)')
+
+	if area_filter:
+		try:
+			area_id = int(area_filter)
+			clauses.append('(parent.id = ? OR p.id = ?)')
+			args.extend([area_id, area_id])
+		except (ValueError, TypeError):
+			pass
+
+	if project_filter:
+		try:
+			project_id = int(project_filter)
+			clauses.append('p.id = ?')
+			args.append(project_id)
+		except (ValueError, TypeError):
+			pass
+
+	where_sql = ' AND '.join(clauses)
+
+	conn = get_db()
+	rows = conn.execute(f'''
+		SELECT te.id, te.project_id, te.task_id, te.checklist_item_id,
+		       te.description, te.started_at, te.ended_at,
+		       te.duration_seconds,
+		       p.title           AS project_title,
+		       p.is_private      AS project_is_private,
+		       parent.id         AS area_id,
+		       parent.title      AS area_title,
+		       parent.area_color AS area_color,
+		       t.title           AS task_title,
+		       ci.text           AS checklist_item_text
+		FROM time_entries te
+		JOIN projects p           ON te.project_id = p.id
+		LEFT JOIN projects parent ON p.parent_project_id = parent.id
+		LEFT JOIN tasks t         ON te.task_id = t.id
+		LEFT JOIN checklist_items ci ON te.checklist_item_id = ci.id
+		WHERE {where_sql}
+		ORDER BY te.started_at ASC
+	''', args).fetchall()
+
+	# Count private entries we excluded so the UI can render the
+	# "// N private projects hidden — unlock to include" note.
+	hidden_private_count = 0
+	if not include_private:
+		hidden_count_row = conn.execute(f'''
+			SELECT COUNT(DISTINCT p.id) AS n
+			FROM time_entries te
+			JOIN projects p           ON te.project_id = p.id
+			LEFT JOIN projects parent ON p.parent_project_id = parent.id
+			WHERE te.started_at >= ? AND te.started_at < ?
+			  AND (p.is_private = 1 OR parent.is_private = 1)
+		''', [start_utc, end_utc]).fetchone()
+		hidden_private_count = hidden_count_row['n'] if hidden_count_row else 0
+
+	conn.close()
+
+	entries = []
+	for r in rows:
+		# For running entries, substitute now() so duration math reflects
+		# elapsed-so-far. Annotate with running:true so the UI can pulse.
+		ended = r['ended_at']
+		duration = r['duration_seconds']
+		running = ended is None
+		if running:
+			started_dt = datetime.strptime(r['started_at'], _UTC_FORMAT)
+			started_dt = pytz.UTC.localize(started_dt)
+			elapsed = int((datetime.now(pytz.UTC) - started_dt).total_seconds())
+			duration = max(0, elapsed)
+			ended = now_utc
+
+		entries.append({
+			'id': r['id'],
+			'project_id': r['project_id'],
+			'project_title': r['project_title'],
+			'area_id': r['area_id'],
+			'area_title': r['area_title'],
+			'area_color': r['area_color'],
+			'task_id': r['task_id'],
+			'task_title': r['task_title'],
+			'checklist_item_id': r['checklist_item_id'],
+			'checklist_item_text': r['checklist_item_text'],
+			'description': r['description'],
+			'started_at': r['started_at'],
+			'ended_at': ended,
+			'duration_seconds': duration,
+			'running': running,
+		})
+
+	totals = _build_totals(entries, start_date, end_date)
+
+	return jsonify({
+		'meta': {
+			'start': start_date.isoformat(),
+			'end': end_date.isoformat(),
+			'group': group,
+			'totals_seconds': totals['total_seconds'],
+			'entry_count': len(entries),
+			'hidden_private_count': hidden_private_count,
+			'include_private': include_private,
+		},
+		'entries': entries,
+		'totals': {
+			'by_area': totals['by_area'],
+			'by_project': totals['by_project'],
+			'by_day': totals['by_day'],
+			'by_timesheet': totals['by_timesheet'],
+		},
+	})

--- a/blueprints/reports.py
+++ b/blueprints/reports.py
@@ -26,10 +26,15 @@ Privacy:
 from datetime import datetime, timedelta, date
 
 import pytz
-from flask import Blueprint, jsonify, request
+import os
 
-from helpers.auth import is_authenticated
+from flask import Blueprint, jsonify, render_template, request
+
+from helpers.auth import cd_auth_required, is_authenticated
 from helpers.db import get_db
+
+
+PRIVATE_PROJECTS_PIN = os.environ.get('PRIVATE_PROJECTS_PIN', '')
 
 
 reports_bp = Blueprint('reports', __name__)
@@ -163,7 +168,19 @@ def _build_totals(entries, start_date, end_date):
 	}
 
 
-# ---- Route ----
+# ---- Routes ----
+
+
+@reports_bp.route('/command-deck/reports/', methods=['GET'])
+@reports_bp.route('/command-deck/reports', methods=['GET'])
+@cd_auth_required
+def reports_page():
+	"""Renders the reports page shell. The data comes from /reports/data
+	via JS so the toggle + period nav can swap views without full reloads."""
+	return render_template(
+		'command_deck_reports.html',
+		private_projects_enabled=bool(PRIVATE_PROJECTS_PIN),
+	)
 
 
 @reports_bp.route('/command-deck/reports/data', methods=['GET'])

--- a/blueprints/time_tracking.py
+++ b/blueprints/time_tracking.py
@@ -284,8 +284,14 @@ def time_stop(entry_id):
 @time_tracking_bp.route('/time/<int:entry_id>/update', methods=['POST'])
 def time_update(entry_id):
 	"""
-	Update description, started_at, and/or ended_at on an entry (running or stopped).
+	Update description, started_at, ended_at, task_id, and/or
+	checklist_item_id on an entry (running or stopped).
+
 	Per §0a.2 #2 — recomputes duration_seconds when ended_at is set.
+	Per Phase 2 spec §3.2 — re-assigning task_id or checklist_item_id
+	is allowed but validated against the entry's existing project_id.
+	Cross-project re-assignment is forbidden (delete + recreate
+	instead). The entry's project_id is never changed by this route.
 	"""
 	if not is_authenticated():
 		return jsonify({'error': 'unauthorized'}), 403
@@ -299,6 +305,8 @@ def time_update(entry_id):
 	new_description = row['description']
 	new_started = row['started_at']
 	new_ended = row['ended_at']
+	new_task_id = row['task_id']
+	new_item_id = row['checklist_item_id']
 
 	if 'description' in data:
 		new_description = (data.get('description') or '').strip()
@@ -325,6 +333,65 @@ def time_update(entry_id):
 				conn.close()
 				return jsonify({'error': 'invalid_ended_at'}), 400
 
+	if 'task_id' in data:
+		val = data.get('task_id')
+		if val in (None, '', 'null'):
+			new_task_id = None
+		else:
+			try:
+				new_task_id = int(val)
+			except (ValueError, TypeError):
+				conn.close()
+				return jsonify({'error': 'invalid_task_id'}), 400
+
+	if 'checklist_item_id' in data:
+		val = data.get('checklist_item_id')
+		if val in (None, '', 'null'):
+			new_item_id = None
+		else:
+			try:
+				new_item_id = int(val)
+			except (ValueError, TypeError):
+				conn.close()
+				return jsonify({'error': 'invalid_checklist_item_id'}), 400
+
+	if new_task_id is not None and new_item_id is not None:
+		conn.close()
+		return jsonify({'error': 'task_or_item_not_both'}), 400
+
+	entry_project_id = row['project_id']
+
+	if 'task_id' in data and new_task_id is not None:
+		task = conn.execute(
+			'SELECT id, project_id FROM tasks WHERE id = ?', (new_task_id,)
+		).fetchone()
+		if not task:
+			conn.close()
+			return jsonify({'error': 'task_not_found'}), 404
+		if task['project_id'] != entry_project_id:
+			conn.close()
+			return jsonify({
+				'error': 'task_project_mismatch',
+				'task_project_id': task['project_id'],
+			}), 400
+
+	if 'checklist_item_id' in data and new_item_id is not None:
+		item = conn.execute('''
+			SELECT ci.id, b.project_id
+			FROM checklist_items ci
+			JOIN blocks b ON ci.block_id = b.id
+			WHERE ci.id = ?
+		''', (new_item_id,)).fetchone()
+		if not item:
+			conn.close()
+			return jsonify({'error': 'checklist_item_not_found'}), 404
+		if item['project_id'] != entry_project_id:
+			conn.close()
+			return jsonify({
+				'error': 'item_project_mismatch',
+				'item_project_id': item['project_id'],
+			}), 400
+
 	if new_ended:
 		try:
 			s = _parse_iso_utc(new_started)
@@ -340,9 +407,13 @@ def time_update(entry_id):
 	conn.execute('''
 		UPDATE time_entries
 		SET description = ?, started_at = ?, ended_at = ?,
-		    duration_seconds = ?, updated = ?
+		    duration_seconds = ?, task_id = ?, checklist_item_id = ?,
+		    updated = ?
 		WHERE id = ?
-	''', (new_description, new_started, new_ended, new_duration, now_iso, entry_id))
+	''', (
+		new_description, new_started, new_ended, new_duration,
+		new_task_id, new_item_id, now_iso, entry_id,
+	))
 	conn.commit()
 	row = _fetch_entry_with_context(conn, entry_id)
 	conn.close()

--- a/blueprints/time_tracking.py
+++ b/blueprints/time_tracking.py
@@ -420,6 +420,51 @@ def time_update(entry_id):
 	return jsonify({'success': True, 'entry': _serialize_entry(row)})
 
 
+@time_tracking_bp.route('/time/today/total', methods=['GET'])
+def time_today_total():
+	"""Phase 2 §3.4 — today's tracked time across all projects (ET day).
+
+	Returns both:
+	  stopped_today_seconds — sum of duration_seconds for entries with
+	    ended_at set today. The client adds local elapsed-so-far for
+	    any running entries (from /time/active) to get a live total
+	    that ticks up every second without polling this route every
+	    second.
+	  today_total_seconds — convenience snapshot at fetch time. Equal
+	    to stopped + sum of running elapsed AT fetch time. Useful for
+	    consumers that don't subscribe to /time/active.
+
+	Drives the today total in the Cockpit floating-panel titlebar."""
+	if not is_authenticated():
+		return jsonify({'error': 'unauthorized'}), 403
+	start_utc, end_utc = _et_today_bounds_utc()
+	conn = get_db()
+	rows = conn.execute('''
+		SELECT started_at, ended_at, duration_seconds
+		FROM time_entries
+		WHERE started_at >= ? AND started_at < ?
+	''', (start_utc, end_utc)).fetchall()
+	conn.close()
+
+	stopped = 0
+	running_elapsed = 0
+	now = datetime.now(pytz.UTC)
+	for r in rows:
+		if r['ended_at'] and r['duration_seconds'] is not None:
+			stopped += max(0, int(r['duration_seconds']))
+		elif not r['ended_at']:
+			started = _parse_iso_utc(r['started_at'])
+			if started:
+				running_elapsed += max(0, int((now - started).total_seconds()))
+
+	today_et = datetime.now(pytz.timezone('US/Eastern')).date().isoformat()
+	return jsonify({
+		'stopped_today_seconds': stopped,
+		'today_total_seconds': stopped + running_elapsed,
+		'today_date': today_et,
+	})
+
+
 @time_tracking_bp.route('/time/<int:entry_id>/delete', methods=['POST'])
 def time_delete(entry_id):
 	if not is_authenticated():

--- a/migrate_add_phase2_indexes.py
+++ b/migrate_add_phase2_indexes.py
@@ -1,0 +1,110 @@
+"""
+migrate_add_phase2_indexes.py
+Phase 2 of the time-tracking spec — see .kt/spec-time-tracking-phase-2.md.
+
+What it does (idempotent — safe to run multiple times):
+
+  - idx_time_entries_project_started — composite (project_id, started_at).
+    Reports queries filter by project + date range and sort by started_at;
+    this covers all three predicates.
+
+  - idx_time_entries_task — partial index on task_id WHERE NOT NULL.
+    Backs the per-task lifetime SUM(duration_seconds) on the project page.
+
+  - idx_time_entries_checklist_item — partial index on checklist_item_id
+    WHERE NOT NULL. Same purpose, item scope.
+
+The two partial indexes are deliberately partial: most time entries don't
+have a task or item assignment (project-scoped only), so a full index
+would waste space and slow writes for no read benefit.
+
+Prints a summary. Running it again prints "no changes."
+
+Run from PythonAnywhere bash:
+    cd /home/aaronaiken/status_update
+    python migrate_add_phase2_indexes.py
+"""
+
+import os
+import sqlite3
+
+DB_FILE = os.path.join(
+	os.environ.get('COCKPIT_REPO_ROOT', '/home/aaronaiken/status_update'),
+	'assets/data/command_deck.db'
+)
+
+
+INDEXES = [
+	(
+		'idx_time_entries_project_started',
+		'CREATE INDEX IF NOT EXISTS idx_time_entries_project_started '
+		'ON time_entries(project_id, started_at)',
+	),
+	(
+		'idx_time_entries_task',
+		'CREATE INDEX IF NOT EXISTS idx_time_entries_task '
+		'ON time_entries(task_id) WHERE task_id IS NOT NULL',
+	),
+	(
+		'idx_time_entries_checklist_item',
+		'CREATE INDEX IF NOT EXISTS idx_time_entries_checklist_item '
+		'ON time_entries(checklist_item_id) WHERE checklist_item_id IS NOT NULL',
+	),
+]
+
+
+def existing_indexes(cur, table):
+	rows = cur.execute(f"PRAGMA index_list({table})").fetchall()
+	return {row[1] for row in rows}
+
+
+def run():
+	if not os.path.exists(DB_FILE):
+		print(f"× DB not found at {DB_FILE}")
+		print("  Run migrate_to_sqlite.py first.")
+		return
+
+	conn = sqlite3.connect(DB_FILE)
+	cur = conn.cursor()
+
+	te_exists = cur.execute(
+		"SELECT name FROM sqlite_master WHERE type='table' AND name='time_entries'"
+	).fetchone() is not None
+	if not te_exists:
+		print("× time_entries table not found. Run migrate_add_time_tracking.py first.")
+		conn.close()
+		return
+
+	have = existing_indexes(cur, 'time_entries')
+	added = []
+	skipped = []
+
+	for name, sql in INDEXES:
+		if name in have:
+			skipped.append(name)
+		else:
+			cur.execute(sql)
+			added.append(name)
+
+	conn.commit()
+	conn.close()
+
+	print()
+	print("Migration: migrate_add_phase2_indexes.py")
+	print(f"DB:        {DB_FILE}")
+	print()
+	if added:
+		print(f"✓ Added ({len(added)}):")
+		for item in added:
+			print(f"    + {item}")
+	if skipped:
+		print(f"— Already in place ({len(skipped)}):")
+		for item in skipped:
+			print(f"    · {item}")
+	if not added:
+		print("No changes — schema already up to date.")
+	print()
+
+
+if __name__ == '__main__':
+	run()

--- a/static/cockpit_time_tracker.css
+++ b/static/cockpit_time_tracker.css
@@ -55,10 +55,33 @@
 	text-overflow: ellipsis;
 }
 #ttp.ttp-collapsed #ttp-summary { display: inline-block; }
+
+/* Phase 2 §4.4 — today total link in the titlebar. Sits between the
+   active-summary text and the collapse/close buttons. Hidden when the
+   panel is collapsed to a pill (the summary takes the row instead). */
+#ttp-today-total {
+	font-family: 'Share Tech Mono', monospace;
+	font-size: 0.58rem;
+	letter-spacing: 0.1em;
+	color: rgba(212, 136, 10, 0.55);
+	text-decoration: none;
+	margin-left: auto;
+	padding: 1px 4px;
+	border-radius: 2px;
+	transition: color 0.15s, background 0.15s;
+	white-space: nowrap;
+	font-variant-numeric: tabular-nums;
+}
+#ttp-today-total:hover {
+	color: rgba(245, 179, 50, 1);
+	background: rgba(212, 136, 10, 0.10);
+}
+#ttp.ttp-collapsed #ttp-today-total { display: none; }
+
 #ttp-actions {
 	display: flex;
 	gap: 4px;
-	margin-left: auto;
+	margin-left: 8px;
 }
 .ttp-tb-btn {
 	background: none;

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -2448,6 +2448,38 @@ body.cd-strip-visible .cd-shell { padding-top: 32px; }
 	font-variant-numeric: tabular-nums;
 }
 
+/* "lifetime: H:MM" tag — Phase 2. Server-rendered, dimmer than the today
+   tag so the eye reads them in order. Always present alongside today on
+   tasks; hover-only on checklist items (mirrors the cd-tt-item-btn rule
+   so dense checklists stay scannable). */
+.cd-tt-lifetime-tag {
+	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
+	font-size: 0.55rem;
+	letter-spacing: 0.1em;
+	color: var(--cd-text-dim, #7a6a52);
+	background: rgba(122, 106, 82, 0.08);
+	padding: 1px 6px;
+	border-radius: 2px;
+	flex-shrink: 0;
+	font-variant-numeric: tabular-nums;
+}
+
+/* Checklist-item time tags — hidden until row hover (desktop), low-opacity
+   always (mobile). Same pattern as cd-tt-item-btn. */
+.cd-checklist-item .cd-tt-tag-item {
+	opacity: 0;
+	transition: opacity 0.15s;
+}
+.cd-checklist-item:hover .cd-tt-tag-item,
+.cd-checklist-item.cd-tt-running .cd-tt-tag-item,
+.cd-checklist-item .cd-tt-tag-item:focus {
+	opacity: 1;
+}
+@media (hover: none) {
+	.cd-checklist-item .cd-tt-tag-item { opacity: 0.55; }
+	.cd-checklist-item.cd-tt-running .cd-tt-tag-item { opacity: 1; }
+}
+
 /* Toast — bottom-center, brief */
 .cd-tt-toast {
 	position: fixed;

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -2331,6 +2331,94 @@ body.cd-strip-visible .cd-shell { padding-top: 32px; }
 	max-width: 200px;
 	flex-shrink: 0;
 }
+button.cd-tt-entry-context.cd-tt-assign-trigger {
+	border: 1px solid transparent;
+	cursor: pointer;
+	font: inherit;
+	transition: background 0.15s, border-color 0.15s;
+}
+button.cd-tt-entry-context.cd-tt-assign-trigger:hover,
+button.cd-tt-entry-context.cd-tt-assign-trigger:focus-visible {
+	background: rgba(212, 136, 10, 0.13);
+	border-color: var(--cd-amber-lo);
+	outline: none;
+}
+button.cd-tt-entry-context.unassigned {
+	color: var(--cd-text-dim);
+	background: rgba(122, 106, 82, 0.08);
+}
+
+/* Phase 2 inline re-assign dropdown */
+.cd-tt-assign-dropdown {
+	position: absolute;
+	z-index: 11000;
+	min-width: 14em;
+	max-width: 22em;
+	max-height: 60vh;
+	overflow-y: auto;
+	background: var(--cd-bg-raised);
+	border: 1px solid var(--cd-border-amber);
+	border-radius: var(--cd-radius);
+	box-shadow: 0 8px 24px var(--cd-shadow);
+	padding: 0.4rem 0;
+	font-family: var(--cd-font-body);
+}
+.cd-tt-assign-header {
+	font-family: var(--cd-font-ui);
+	font-size: 0.55rem;
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
+	color: var(--cd-amber-hi);
+	padding: 0.3rem 0.75rem 0.5rem;
+	border-bottom: 1px solid var(--cd-border);
+	margin-bottom: 0.25rem;
+}
+.cd-tt-assign-label {
+	font-family: var(--cd-font-ui);
+	font-size: 0.5rem;
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
+	color: var(--cd-text-dim);
+	padding: 0.45rem 0.75rem 0.2rem;
+}
+.cd-tt-assign-option {
+	display: block;
+	width: 100%;
+	background: none;
+	border: none;
+	text-align: left;
+	font-family: var(--cd-font-body);
+	font-size: 0.78rem;
+	color: var(--cd-text);
+	padding: 0.35rem 0.85rem;
+	cursor: pointer;
+	transition: background 0.1s;
+}
+.cd-tt-assign-option:hover,
+.cd-tt-assign-option:focus-visible {
+	background: rgba(245, 179, 50, 0.10);
+	color: var(--cd-amber-hi);
+	outline: none;
+}
+.cd-tt-assign-option.clear {
+	color: var(--cd-text-dim);
+	font-family: var(--cd-font-ui);
+	font-size: 0.62rem;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+}
+.cd-tt-assign-divider {
+	height: 1px;
+	background: var(--cd-border);
+	margin: 0.35rem 0;
+}
+.cd-tt-assign-empty {
+	padding: 0.6rem 0.85rem;
+	font-family: var(--cd-font-ui);
+	font-size: 0.62rem;
+	color: var(--cd-text-dim);
+	letter-spacing: 0.06em;
+}
 .cd-tt-entry-elapsed {
 	font-variant-numeric: tabular-nums;
 	min-width: 60px;

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -3038,6 +3038,104 @@ body[data-cd-tab="personal"] .cd-huyang-search-row { display: none; }
   .cd-reports-row-bar-fill { transition: none; }
 }
 
+/* Timesheet view — project × day matrix.
+   Allows horizontal scroll for long ranges; sticky first column +
+   sticky header so labels stay anchored as the user scans across
+   the week. */
+.cd-timesheet-scroll {
+  overflow-x: auto;
+  border: 1px solid var(--cd-border);
+  border-radius: var(--cd-radius);
+}
+
+.cd-timesheet-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-family: var(--cd-font-body);
+  font-size: 0.8rem;
+  min-width: 32em;
+}
+
+.cd-timesheet-table th,
+.cd-timesheet-table td {
+  padding: 0.55rem 0.7rem;
+  border-bottom: 1px solid var(--cd-border);
+  text-align: left;
+  white-space: nowrap;
+}
+
+.cd-timesheet-table thead th {
+  font-family: var(--cd-font-ui);
+  font-size: 0.55rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--cd-text-dim);
+  background: var(--cd-bg-surface);
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  border-bottom: 1px solid var(--cd-border-amber);
+}
+
+.cd-timesheet-row-head {
+  font-family: var(--cd-font-body);
+  color: var(--cd-text);
+  text-align: left;
+  font-weight: normal;
+  position: sticky;
+  left: 0;
+  background: var(--cd-bg-surface);
+  z-index: 1;
+  border-right: 1px solid var(--cd-border);
+}
+
+.cd-timesheet-row-head .cd-reports-row-sub {
+  display: block;
+  margin-top: 0.15rem;
+}
+
+.cd-timesheet-table tbody td {
+  color: var(--cd-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.cd-timesheet-row-total {
+  color: var(--cd-amber-hi);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.cd-timesheet-table thead th.cd-timesheet-total-head {
+  color: var(--cd-amber-hi);
+}
+
+.cd-timesheet-table tfoot th,
+.cd-timesheet-table tfoot td {
+  border-top: 1px solid var(--cd-border-amber);
+  border-bottom: none;
+  font-family: var(--cd-font-ui);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--cd-amber-hi);
+  background: var(--cd-bg-surface);
+}
+
+.cd-timesheet-table tfoot .cd-timesheet-row-head {
+  color: var(--cd-text-dim);
+}
+
+.cd-reports-inline-link {
+  background: none;
+  border: none;
+  color: var(--cd-amber-hi);
+  font: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+}
+
 @media (max-width: 720px) {
   .cd-reports-row {
     grid-template-columns: 4px 1fr 2.5em 4em;

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -2708,3 +2708,355 @@ body[data-cd-tab="personal"] .cd-huyang-search-row { display: none; }
 }
 .cd-huyang-search-icon { font-size: 0.7rem; line-height: 1; }
 
+/* ============================================================
+   REPORTS PAGE — Phase 2 of time tracking
+   ============================================================ */
+
+.cd-reports-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem 1.25rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--cd-border);
+  margin-bottom: 1rem;
+  font-family: var(--cd-font-ui);
+}
+
+.cd-reports-period {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.cd-reports-nav-btn {
+  background: none;
+  border: 1px solid var(--cd-border);
+  color: var(--cd-amber-hi);
+  font-family: var(--cd-font-ui);
+  font-size: 0.8rem;
+  padding: 0.25rem 0.55rem;
+  border-radius: var(--cd-radius);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+.cd-reports-nav-btn:hover {
+  background: var(--cd-glow);
+  border-color: var(--cd-amber-lo);
+}
+
+.cd-reports-period-label {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  color: var(--cd-text-bright);
+  text-transform: uppercase;
+  min-width: 12em;
+  justify-content: center;
+}
+
+.cd-reports-jump {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+  font: inherit;
+}
+
+.cd-reports-presets,
+.cd-reports-groups {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.cd-reports-groups-label {
+  font-size: 0.6rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--cd-text-dim);
+  margin-right: 0.4rem;
+}
+
+.cd-reports-preset,
+.cd-reports-group {
+  background: none;
+  border: 1px solid var(--cd-border);
+  color: var(--cd-text-dim);
+  font-family: var(--cd-font-ui);
+  font-size: 0.62rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.3rem 0.6rem;
+  border-radius: var(--cd-radius);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.cd-reports-preset:hover,
+.cd-reports-group:hover {
+  color: var(--cd-amber-hi);
+  border-color: var(--cd-amber-lo);
+}
+.cd-reports-preset.active,
+.cd-reports-group.active {
+  background: rgba(245, 179, 50, 0.10);
+  border-color: var(--cd-amber-lo);
+  color: var(--cd-amber-hi);
+}
+
+.cd-reports-custom {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--cd-font-ui);
+  font-size: 0.65rem;
+  color: var(--cd-text-dim);
+}
+.cd-reports-custom-input {
+  background: var(--cd-bg-surface);
+  border: 1px solid var(--cd-border);
+  color: var(--cd-text);
+  font: inherit;
+  padding: 0.2rem 0.4rem;
+  border-radius: var(--cd-radius);
+}
+.cd-reports-custom-sep { letter-spacing: 0.1em; }
+.cd-reports-custom-apply {
+  background: none;
+  border: 1px solid var(--cd-amber-lo);
+  color: var(--cd-amber-hi);
+  font: inherit;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.25rem 0.55rem;
+  border-radius: var(--cd-radius);
+  cursor: pointer;
+}
+.cd-reports-custom-apply:hover {
+  background: var(--cd-glow);
+}
+
+.cd-reports-privacy-note {
+  font-family: var(--cd-font-ui);
+  font-size: 0.65rem;
+  color: var(--cd-text-dim);
+  letter-spacing: 0.05em;
+  padding: 0.5rem 0;
+  margin-bottom: 0.5rem;
+}
+
+.cd-reports-empty,
+.cd-reports-empty-cell {
+  font-family: var(--cd-font-ui);
+  font-size: 0.7rem;
+  color: var(--cd-text-dim);
+  letter-spacing: 0.06em;
+  text-align: center;
+  padding: 2rem 1rem;
+}
+
+.cd-reports-loading {
+  font-family: var(--cd-font-ui);
+  font-size: 0.65rem;
+  color: var(--cd-text-dim);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 1.5rem 0;
+  text-align: center;
+}
+
+.cd-reports-error {
+  font-family: var(--cd-font-ui);
+  font-size: 0.7rem;
+  color: var(--cd-red, #cc4040);
+  padding: 1.5rem 0;
+  text-align: center;
+}
+
+/* Rollup rows */
+.cd-reports-rollup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 1.5rem;
+}
+
+.cd-reports-row {
+  display: grid;
+  grid-template-columns: 4px minmax(8em, 1.4fr) 3fr 3em 4em;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.45rem 0.6rem;
+  background: var(--cd-bg-surface);
+  border: 1px solid var(--cd-border);
+  border-radius: var(--cd-radius);
+}
+
+.cd-reports-row-stripe {
+  align-self: stretch;
+  border-radius: 1.5px;
+  min-height: 1.4em;
+}
+
+.cd-reports-row-title {
+  font-family: var(--cd-font-body);
+  font-size: 0.85rem;
+  color: var(--cd-text);
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+  word-break: break-word;
+}
+
+.cd-reports-row-sub {
+  font-family: var(--cd-font-ui);
+  font-size: 0.55rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--cd-text-dim);
+}
+
+.cd-reports-row-bar {
+  background: var(--cd-bg-raised);
+  border-radius: 1.5px;
+  height: 0.7rem;
+  overflow: hidden;
+  position: relative;
+}
+
+.cd-reports-row-bar-fill {
+  height: 100%;
+  background: var(--cd-amber);
+  transition: width 0.25s ease-out;
+}
+
+.cd-reports-row-pct,
+.cd-reports-row-duration {
+  font-family: var(--cd-font-ui);
+  font-size: 0.7rem;
+  color: var(--cd-text-dim);
+  text-align: right;
+}
+
+.cd-reports-row-duration {
+  color: var(--cd-text-bright);
+  font-variant-numeric: tabular-nums;
+}
+
+.cd-num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-family: var(--cd-font-ui);
+}
+
+/* Chronological entries table */
+.cd-reports-entries-title {
+  font-family: var(--cd-font-display);
+  font-size: 1.1rem;
+  color: var(--cd-amber-hi);
+  letter-spacing: 0.05em;
+  margin: 1.5rem 0 0.5rem;
+}
+
+.cd-reports-entries-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--cd-font-body);
+  font-size: 0.8rem;
+}
+
+.cd-reports-entries-table th {
+  font-family: var(--cd-font-ui);
+  font-size: 0.55rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--cd-text-dim);
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--cd-border);
+}
+
+.cd-reports-entries-table td {
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--cd-border);
+  vertical-align: top;
+  color: var(--cd-text);
+}
+
+.cd-reports-entries-table tr.cd-reports-entry.is-running td {
+  background: rgba(245, 179, 50, 0.06);
+}
+
+.cd-reports-entries-table tfoot td {
+  border-bottom: none;
+  border-top: 1px solid var(--cd-border-amber);
+  padding-top: 0.7rem;
+  font-family: var(--cd-font-ui);
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--cd-amber-hi);
+}
+
+.cd-reports-total-label {
+  text-align: right;
+  color: var(--cd-text-dim);
+}
+
+.cd-reports-area-stripe {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  margin-right: 0.4rem;
+  vertical-align: 0.05em;
+}
+
+.cd-reports-running-dot {
+  display: inline-block;
+  width: 0.45rem;
+  height: 0.45rem;
+  margin-left: 0.3rem;
+  border-radius: 50%;
+  background: var(--cd-amber-hi);
+  animation: cd-reports-pulse 1.6s ease-in-out infinite;
+  vertical-align: 0.1em;
+}
+
+@keyframes cd-reports-pulse {
+  0%, 100% { opacity: 0.4; }
+  50%      { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cd-reports-running-dot { animation: none; opacity: 0.7; }
+  .cd-reports-row-bar-fill { transition: none; }
+}
+
+@media (max-width: 720px) {
+  .cd-reports-row {
+    grid-template-columns: 4px 1fr 2.5em 4em;
+    grid-template-areas:
+      "stripe title pct duration"
+      "stripe bar bar bar";
+    row-gap: 0.3rem;
+  }
+  .cd-reports-row-stripe { grid-area: stripe; }
+  .cd-reports-row-title { grid-area: title; }
+  .cd-reports-row-bar { grid-area: bar; }
+  .cd-reports-row-pct { grid-area: pct; }
+  .cd-reports-row-duration { grid-area: duration; }
+
+  .cd-reports-entries-table th:nth-child(2),
+  .cd-reports-entries-table td:nth-child(2),
+  .cd-reports-entries-table th:nth-child(5),
+  .cd-reports-entries-table td:nth-child(5) {
+    display: none;
+  }
+}
+

--- a/static/command_deck_reports.js
+++ b/static/command_deck_reports.js
@@ -1,0 +1,397 @@
+// command_deck_reports.js — Phase 2 of time tracking.
+// Drives the /command-deck/reports/ page: period nav, group toggle, entries
+// rendering. Talks to /command-deck/reports/data — the endpoint returns all
+// four totals shapes (by_area / by_project / by_day / by_timesheet) so
+// switching the toggle is client-side only, no re-fetch.
+
+(function () {
+	'use strict';
+
+	const PRESETS = ['today', 'this-week', 'this-month', 'custom'];
+	const GROUPS_PHASE_4 = ['area', 'project', 'day', 'timesheet']; // timesheet lands in commit 5
+	const VALID_GROUPS = ['area', 'project', 'day'];
+
+	const state = {
+		preset: localStorage.getItem('reportsPeriod') || 'this-week',
+		group: localStorage.getItem('reportsGroup') || 'area',
+		start: null,   // 'YYYY-MM-DD' (custom mode only — server resolves for presets)
+		end: null,     // 'YYYY-MM-DD' (custom mode only)
+		data: null,    // last fetched payload
+	};
+
+	// ---- Date helpers ----
+
+	function pad(n) { return String(n).padStart(2, '0'); }
+
+	function fmtDate(d) {
+		return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+	}
+
+	function parseISODate(s) {
+		const [y, m, d] = s.split('-').map(Number);
+		return new Date(y, m - 1, d);
+	}
+
+	function startOfWeekSunday(d) {
+		const day = d.getDay(); // Sun=0
+		const result = new Date(d);
+		result.setDate(d.getDate() - day);
+		return result;
+	}
+
+	function addDays(d, n) {
+		const r = new Date(d);
+		r.setDate(d.getDate() + n);
+		return r;
+	}
+
+	function startOfMonth(d) {
+		return new Date(d.getFullYear(), d.getMonth(), 1);
+	}
+
+	function startOfNextMonth(d) {
+		return new Date(d.getFullYear(), d.getMonth() + 1, 1);
+	}
+
+	function fmtSeconds(secs) {
+		secs = Math.max(0, Math.round(secs || 0));
+		const h = Math.floor(secs / 3600);
+		const m = Math.floor((secs % 3600) / 60);
+		if (h === 0 && m === 0) return secs > 0 ? '<1m' : '0:00';
+		return `${h}:${pad(m)}`;
+	}
+
+	function fmtTime(iso) {
+		// ISO UTC → HH:MM in viewer's local TZ. Browser handles ET conversion
+		// since Aaron is in ET locally; on PA the server is whatever PA's TZ is.
+		const dt = new Date(iso);
+		return `${pad(dt.getHours())}:${pad(dt.getMinutes())}`;
+	}
+
+	function fmtDayLabel(iso) {
+		const d = parseISODate(iso);
+		const wk = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][d.getDay()];
+		return `${wk} ${d.getMonth() + 1}/${d.getDate()}`;
+	}
+
+	function fmtPeriodLabel() {
+		if (!state.data) return '…';
+		const start = parseISODate(state.data.meta.start);
+		const end = addDays(parseISODate(state.data.meta.end), -1); // inclusive end for display
+		const monthName = (m) => ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'][m];
+		if (state.preset === 'today') {
+			return `${['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][start.getDay()]} ${monthName(start.getMonth())} ${start.getDate()}, ${start.getFullYear()}`;
+		}
+		if (state.preset === 'this-month') {
+			return `${monthName(start.getMonth())} ${start.getFullYear()}`;
+		}
+		// week / custom — show range
+		if (start.getMonth() === end.getMonth()) {
+			return `${monthName(start.getMonth())} ${start.getDate()} – ${end.getDate()}, ${start.getFullYear()}`;
+		}
+		return `${monthName(start.getMonth())} ${start.getDate()} – ${monthName(end.getMonth())} ${end.getDate()}, ${start.getFullYear()}`;
+	}
+
+	// ---- Period URL composition ----
+
+	function buildQuery() {
+		const params = new URLSearchParams();
+		if (state.preset === 'custom' && state.start && state.end) {
+			params.set('start', state.start);
+			params.set('end', state.end);
+		} else if (state.preset === 'custom') {
+			// Custom selected but no dates yet — fall back to this-week
+			params.set('period', 'this-week');
+		} else {
+			params.set('period', state.preset);
+			if (state.start) params.set('start', state.start);
+			if (state.end) params.set('end', state.end);
+		}
+		params.set('group', state.group);
+		return params.toString();
+	}
+
+	// ---- Period nav (prev / next / jump) ----
+
+	function shiftPeriod(direction) {
+		// direction = -1 for prev, +1 for next.
+		// Operate on the currently-rendered window, which the server returns
+		// in meta.start / meta.end. Once shifted, we send explicit start/end
+		// alongside the current preset so the server keeps the same shape.
+		if (!state.data) return;
+		const start = parseISODate(state.data.meta.start);
+		const end = parseISODate(state.data.meta.end);
+
+		if (state.preset === 'today' || state.preset === 'this-week' || state.preset === 'custom') {
+			const days = Math.round((end - start) / 86400000);
+			const newStart = addDays(start, direction * days);
+			const newEnd = addDays(end, direction * days);
+			state.start = fmtDate(newStart);
+			state.end = fmtDate(newEnd);
+		} else if (state.preset === 'this-month') {
+			const ref = new Date(start.getFullYear(), start.getMonth() + direction, 1);
+			state.start = fmtDate(startOfMonth(ref));
+			state.end = fmtDate(startOfNextMonth(ref));
+		}
+		load();
+	}
+
+	function jumpToDate(iso) {
+		if (!iso) return;
+		const target = parseISODate(iso);
+		if (state.preset === 'today') {
+			state.start = iso;
+			state.end = fmtDate(addDays(target, 1));
+		} else if (state.preset === 'this-week' || state.preset === 'custom') {
+			const sun = startOfWeekSunday(target);
+			state.start = fmtDate(sun);
+			state.end = fmtDate(addDays(sun, 7));
+		} else if (state.preset === 'this-month') {
+			state.start = fmtDate(startOfMonth(target));
+			state.end = fmtDate(startOfNextMonth(target));
+		}
+		load();
+	}
+
+	// ---- Rendering ----
+
+	function renderRollup() {
+		const root = document.getElementById('reportsRollup');
+		const data = state.data;
+		const total = data.meta.totals_seconds || 0;
+
+		if (!data.entries.length) {
+			root.innerHTML = '';
+			return;
+		}
+
+		let bucket;
+		if (state.group === 'area') {
+			bucket = data.totals.by_area;
+			renderBucketRows(root, bucket, total, { label: 'area' });
+		} else if (state.group === 'project') {
+			bucket = data.totals.by_project;
+			renderBucketRows(root, bucket, total, { label: 'project' });
+		} else if (state.group === 'day') {
+			renderDayRows(root, data.totals.by_day, total);
+		}
+	}
+
+	function renderBucketRows(root, bucket, total, opts) {
+		const rows = Object.entries(bucket)
+			.map(([id, info]) => ({ id, ...info }))
+			.filter((r) => r.seconds > 0)
+			.sort((a, b) => b.seconds - a.seconds);
+
+		if (!rows.length) {
+			root.innerHTML = '';
+			return;
+		}
+
+		const html = rows.map((r) => {
+			const pct = total > 0 ? Math.round((r.seconds / total) * 100) : 0;
+			const stripe = r.color || r.area_color || 'var(--cd-amber-lo)';
+			const sub = (opts.label === 'project' && r.area_title)
+				? `<span class="cd-reports-row-sub">${escapeHtml(r.area_title)}</span>`
+				: '';
+			return `
+				<div class="cd-reports-row">
+					<div class="cd-reports-row-stripe" style="background:${stripe}"></div>
+					<div class="cd-reports-row-title">
+						${escapeHtml(r.title || '—')}
+						${sub}
+					</div>
+					<div class="cd-reports-row-bar">
+						<div class="cd-reports-row-bar-fill" style="width:${pct}%; background:${stripe}"></div>
+					</div>
+					<div class="cd-reports-row-pct">${pct}%</div>
+					<div class="cd-reports-row-duration cd-num">${fmtSeconds(r.seconds)}</div>
+				</div>
+			`;
+		}).join('');
+		root.innerHTML = html;
+	}
+
+	function renderDayRows(root, byDay, total) {
+		const days = Object.entries(byDay).sort(); // ISO dates sort lexically
+		const html = days.map(([day, secs]) => {
+			const pct = total > 0 ? Math.round((secs / total) * 100) : 0;
+			const fill = secs > 0 ? `width:${pct}%; background:var(--cd-amber);` : 'width:0;';
+			return `
+				<div class="cd-reports-row">
+					<div class="cd-reports-row-stripe" style="background:var(--cd-amber-lo)"></div>
+					<div class="cd-reports-row-title">${fmtDayLabel(day)}</div>
+					<div class="cd-reports-row-bar">
+						<div class="cd-reports-row-bar-fill" style="${fill}"></div>
+					</div>
+					<div class="cd-reports-row-pct">${pct}%</div>
+					<div class="cd-reports-row-duration cd-num">${secs > 0 ? fmtSeconds(secs) : '—'}</div>
+				</div>
+			`;
+		}).join('');
+		root.innerHTML = html;
+	}
+
+	function renderEntries() {
+		const tbody = document.getElementById('reportsEntriesBody');
+		const data = state.data;
+		if (!data.entries.length) {
+			tbody.innerHTML = '<tr><td colspan="7" class="cd-reports-empty-cell">—</td></tr>';
+			document.getElementById('reportsTotalDuration').textContent = '0:00';
+			return;
+		}
+
+		const html = data.entries.map((e) => {
+			const startLocal = fmtTime(e.started_at);
+			const endLocal = fmtTime(e.ended_at);
+			const day = fmtDayLabel(e.started_at.slice(0, 10));
+			const stripe = e.area_color || 'var(--cd-amber-lo)';
+			let context = '—';
+			if (e.task_title) context = `task: ${escapeHtml(e.task_title)}`;
+			else if (e.checklist_item_text) context = `item: ${escapeHtml(e.checklist_item_text)}`;
+			const runningCls = e.running ? ' is-running' : '';
+			const runningGlyph = e.running ? ' <span class="cd-reports-running-dot" title="still running"></span>' : '';
+			return `
+				<tr class="cd-reports-entry${runningCls}">
+					<td>${day}</td>
+					<td><span class="cd-reports-area-stripe" style="background:${stripe}"></span>${escapeHtml(e.area_title || '—')}</td>
+					<td>${escapeHtml(e.project_title || '—')}</td>
+					<td>${context}</td>
+					<td>${escapeHtml(e.description || '')}</td>
+					<td>${startLocal} → ${endLocal}${runningGlyph}</td>
+					<td class="cd-num">${fmtSeconds(e.duration_seconds)}</td>
+				</tr>
+			`;
+		}).join('');
+		tbody.innerHTML = html;
+
+		document.getElementById('reportsTotalDuration').textContent = fmtSeconds(data.meta.totals_seconds);
+	}
+
+	function renderHeader() {
+		document.getElementById('reportsPeriodLabel').textContent = fmtPeriodLabel();
+
+		document.querySelectorAll('.cd-reports-preset').forEach((b) => {
+			b.classList.toggle('active', b.dataset.period === state.preset);
+		});
+		document.querySelectorAll('.cd-reports-group').forEach((b) => {
+			b.classList.toggle('active', b.dataset.group === state.group);
+		});
+	}
+
+	function renderPrivacyNote() {
+		const note = document.getElementById('reportsPrivacyNote');
+		const count = state.data?.meta?.hidden_private_count || 0;
+		if (count > 0 && !state.data?.meta?.include_private) {
+			document.getElementById('reportsPrivacyCount').textContent = count;
+			note.hidden = false;
+		} else {
+			note.hidden = true;
+		}
+	}
+
+	function renderEmpty() {
+		const empty = document.getElementById('reportsEmpty');
+		empty.hidden = (state.data && state.data.entries.length > 0);
+	}
+
+	function escapeHtml(s) {
+		return String(s)
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/"/g, '&quot;');
+	}
+
+	// ---- Fetch + load ----
+
+	async function load() {
+		try {
+			const resp = await fetch(`/command-deck/reports/data?${buildQuery()}`);
+			if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+			state.data = await resp.json();
+			renderHeader();
+			renderEmpty();
+			renderPrivacyNote();
+			renderRollup();
+			renderEntries();
+		} catch (e) {
+			console.error('reports load failed', e);
+			document.getElementById('reportsRollup').innerHTML =
+				`<div class="cd-reports-error">// failed to load report — ${escapeHtml(e.message)}</div>`;
+		}
+	}
+
+	// ---- Wiring ----
+
+	function setPreset(preset) {
+		if (!PRESETS.includes(preset)) return;
+		state.preset = preset;
+		state.start = null;
+		state.end = null;
+		localStorage.setItem('reportsPeriod', preset);
+
+		const customRow = document.getElementById('reportsCustom');
+		if (customRow) customRow.hidden = (preset !== 'custom');
+
+		// For custom, wait for the user to fill both inputs + click Apply
+		// before we fetch — otherwise we'd render this-week's data under a
+		// Custom-active toggle, which is confusing.
+		if (preset === 'custom') {
+			renderHeader();
+			return;
+		}
+		load();
+	}
+
+	function applyCustomRange() {
+		const startEl = document.getElementById('reportsCustomStart');
+		const endEl = document.getElementById('reportsCustomEnd');
+		if (!startEl.value || !endEl.value) return;
+		if (startEl.value > endEl.value) return;
+		state.start = startEl.value;
+		// Server treats `end` as exclusive; the input is conceptually inclusive.
+		const inclusive = parseISODate(endEl.value);
+		state.end = fmtDate(addDays(inclusive, 1));
+		load();
+	}
+
+	function setGroup(group) {
+		if (!VALID_GROUPS.includes(group)) return;
+		state.group = group;
+		localStorage.setItem('reportsGroup', group);
+		// No re-fetch — the endpoint returns all four shapes.
+		renderHeader();
+		renderRollup();
+	}
+
+	document.addEventListener('DOMContentLoaded', () => {
+		document.getElementById('reportsPrev').addEventListener('click', () => shiftPeriod(-1));
+		document.getElementById('reportsNext').addEventListener('click', () => shiftPeriod(+1));
+		document.getElementById('reportsJump').addEventListener('change', (e) => jumpToDate(e.target.value));
+
+		document.querySelectorAll('.cd-reports-preset').forEach((b) => {
+			b.addEventListener('click', () => setPreset(b.dataset.period));
+		});
+		document.getElementById('reportsCustomApply').addEventListener('click', applyCustomRange);
+
+		// Restore custom-row visibility when state.preset is already 'custom'
+		if (state.preset === 'custom') {
+			document.getElementById('reportsCustom').hidden = false;
+		}
+		document.querySelectorAll('.cd-reports-group').forEach((b) => {
+			b.addEventListener('click', () => setGroup(b.dataset.group));
+		});
+
+		// Below Deck badge — same dot pattern as the dashboard.
+		fetch('/below-deck/count').then((r) => r.json()).then((d) => {
+			const el = document.getElementById('bdBadge');
+			if (!el) return;
+			const n = d.count || 0;
+			if (n === 0) return;
+			el.classList.add(n <= 3 ? 'green' : (n <= 6 ? 'amber' : 'red'));
+		}).catch(() => {});
+
+		load();
+	});
+})();

--- a/static/command_deck_reports.js
+++ b/static/command_deck_reports.js
@@ -8,8 +8,8 @@
 	'use strict';
 
 	const PRESETS = ['today', 'this-week', 'this-month', 'custom'];
-	const GROUPS_PHASE_4 = ['area', 'project', 'day', 'timesheet']; // timesheet lands in commit 5
-	const VALID_GROUPS = ['area', 'project', 'day'];
+	const VALID_GROUPS = ['area', 'project', 'day', 'timesheet'];
+	const TIMESHEET_DAY_CAP = 31;
 
 	const state = {
 		preset: localStorage.getItem('reportsPeriod') || 'this-week',
@@ -174,7 +174,95 @@
 			renderBucketRows(root, bucket, total, { label: 'project' });
 		} else if (state.group === 'day') {
 			renderDayRows(root, data.totals.by_day, total);
+		} else if (state.group === 'timesheet') {
+			renderTimesheet(root, data);
 		}
+	}
+
+	function renderTimesheet(root, data) {
+		const dayKeys = Object.keys(data.totals.by_day).sort();
+
+		if (dayKeys.length > TIMESHEET_DAY_CAP) {
+			root.innerHTML = `
+				<div class="cd-reports-error">
+					// Timesheet view is capped at ${TIMESHEET_DAY_CAP} days
+					(this period spans ${dayKeys.length}). Switch to
+					<button class="cd-reports-inline-link" data-switch-group="day">Day group</button>
+					to see this range.
+				</div>
+			`;
+			root.querySelector('.cd-reports-inline-link')
+				.addEventListener('click', () => setGroup('day'));
+			return;
+		}
+
+		const projects = Object.entries(data.totals.by_timesheet)
+			.map(([id, info]) => ({ id, ...info }))
+			.filter((p) => p.total > 0)
+			.sort((a, b) => b.total - a.total);
+
+		if (!projects.length) {
+			root.innerHTML = '';
+			return;
+		}
+
+		const header = `
+			<thead>
+				<tr>
+					<th class="cd-timesheet-row-head">Project</th>
+					${dayKeys.map((d) => `<th class="cd-num">${escapeHtml(timesheetDayHead(d))}</th>`).join('')}
+					<th class="cd-num cd-timesheet-total-head">Total</th>
+				</tr>
+			</thead>
+		`;
+
+		const rows = projects.map((p) => {
+			const stripe = p.area_color || 'var(--cd-amber-lo)';
+			const cells = dayKeys.map((d) => {
+				const secs = p.days[d] || 0;
+				return `<td class="cd-num">${secs > 0 ? fmtSeconds(secs) : ''}</td>`;
+			}).join('');
+			return `
+				<tr>
+					<th scope="row" class="cd-timesheet-row-head">
+						<span class="cd-reports-area-stripe" style="background:${stripe}"></span>
+						${escapeHtml(p.title)}
+						<span class="cd-reports-row-sub">${escapeHtml(p.area_title || '')}</span>
+					</th>
+					${cells}
+					<td class="cd-num cd-timesheet-row-total">${fmtSeconds(p.total)}</td>
+				</tr>
+			`;
+		}).join('');
+
+		const footerCells = dayKeys.map((d) => {
+			const secs = data.totals.by_day[d] || 0;
+			return `<td class="cd-num">${secs > 0 ? fmtSeconds(secs) : ''}</td>`;
+		}).join('');
+
+		const totalSeconds = data.meta.totals_seconds || 0;
+
+		root.innerHTML = `
+			<div class="cd-timesheet-scroll">
+				<table class="cd-timesheet-table">
+					${header}
+					<tbody>${rows}</tbody>
+					<tfoot>
+						<tr>
+							<th scope="row" class="cd-timesheet-row-head">Daily total</th>
+							${footerCells}
+							<td class="cd-num cd-timesheet-row-total">${fmtSeconds(totalSeconds)}</td>
+						</tr>
+					</tfoot>
+				</table>
+			</div>
+		`;
+	}
+
+	function timesheetDayHead(iso) {
+		const d = parseISODate(iso);
+		const wk = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][d.getDay()];
+		return `${wk} ${d.getMonth() + 1}/${d.getDate()}`;
 	}
 
 	function renderBucketRows(root, bucket, total, opts) {

--- a/static/time_tracker_core.js
+++ b/static/time_tracker_core.js
@@ -29,6 +29,17 @@
   var tickTimer = null;
   var inFlight = null;
 
+  // Phase 2 §3.4 — today total. Subscribers are notified on every
+  // poll AND every tick with the live current value (server-fetched
+  // stopped_today_seconds + locally-computed elapsed of currently-
+  // running entries). This way the cockpit panel titlebar ticks up
+  // every second without polling /time/today/total at 1Hz.
+  var todaySubscribers = [];
+  var todayStoppedSeconds = 0;     // server-cached, refreshed on poll
+  var todayDate = null;
+  var todayLoaded = false;
+  var todayInFlight = null;
+
   function notify() {
     subscribers.forEach(function (cb) {
       try { cb(current); } catch (e) { console.error('TimeTrackerCore subscriber error:', e); }
@@ -54,10 +65,76 @@
   function tick() {
     // Re-emit so subscribers can recompute elapsed locally
     if (loaded) notify();
+    if (todayLoaded) notifyToday();
+  }
+
+  function fetchTodayTotal() {
+    if (todayInFlight) return todayInFlight;
+    todayInFlight = fetch('/time/today/total', { credentials: 'same-origin' })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (data) {
+        if (!data) return;
+        // ET day rolled over since last fetch — reset cached stopped total
+        if (todayDate && data.today_date !== todayDate) {
+          todayStoppedSeconds = 0;
+        }
+        todayStoppedSeconds = Math.max(0, data.stopped_today_seconds | 0);
+        todayDate = data.today_date;
+        todayLoaded = true;
+        notifyToday();
+      })
+      .catch(function () { /* network blip */ })
+      .then(function () { todayInFlight = null; });
+    return todayInFlight;
+  }
+
+  function liveTodayTotal() {
+    // stopped (server) + elapsed-so-far for any active timer started today
+    if (!todayLoaded) return 0;
+    var totalRunning = 0;
+    if (todayDate) {
+      current.forEach(function (e) {
+        if (!e || !e.started_at) return;
+        // Approximate ET-day membership by comparing the started_at's
+        // local-date to todayDate. Aaron's local TZ matches ET; this is
+        // close enough for the panel display.
+        var startedLocal = new Date(e.started_at);
+        var iso = startedLocal.getFullYear() + '-' +
+          pad(startedLocal.getMonth() + 1) + '-' +
+          pad(startedLocal.getDate());
+        if (iso === todayDate) {
+          totalRunning += elapsedSeconds(e);
+        }
+      });
+    }
+    return todayStoppedSeconds + totalRunning;
+  }
+
+  function notifyToday() {
+    var total = liveTodayTotal();
+    todaySubscribers.forEach(function (cb) {
+      try { cb(total, todayDate); }
+      catch (e) { console.error('TimeTrackerCore today subscriber error:', e); }
+    });
+  }
+
+  function subscribeToday(cb) {
+    todaySubscribers.push(cb);
+    if (todayLoaded) {
+      try { cb(liveTodayTotal(), todayDate); } catch (e) { console.error(e); }
+    }
+    fetchTodayTotal();
+    ensureRunning();
+    return function unsubscribe() {
+      todaySubscribers = todaySubscribers.filter(function (s) { return s !== cb; });
+    };
   }
 
   function ensureRunning() {
-    if (!pollTimer) pollTimer = setInterval(fetchActive, POLL_INTERVAL_MS);
+    if (!pollTimer) pollTimer = setInterval(function () {
+      fetchActive();
+      if (todaySubscribers.length) fetchTodayTotal();
+    }, POLL_INTERVAL_MS);
     if (!tickTimer) tickTimer = setInterval(tick, TICK_INTERVAL_MS);
   }
 
@@ -117,34 +194,36 @@
 
   function startTimer(projectId, description) {
     return postJson('/time/start', { project_id: projectId, description: description || '' })
-      .then(function (result) { if (result.ok) refresh(); return result; });
+      .then(function (result) { if (result.ok) { refresh(); fetchTodayTotal(); } return result; });
   }
 
   function stopTimer(entryId) {
     return postEmpty('/time/' + entryId + '/stop')
-      .then(function (result) { if (result.ok) refresh(); return result; });
+      .then(function (result) { if (result.ok) { refresh(); fetchTodayTotal(); } return result; });
   }
 
   function stopAllTimers() {
     var ids = current.map(function (e) { return e.id; });
     return Promise.all(ids.map(function (id) {
       return postEmpty('/time/' + id + '/stop').catch(function () { /* swallow */ });
-    })).then(refresh);
+    })).then(function () { refresh(); fetchTodayTotal(); });
   }
 
   function deleteTimer(entryId) {
     return postEmpty('/time/' + entryId + '/delete')
-      .then(function (result) { if (result.ok) refresh(); return result; });
+      .then(function (result) { if (result.ok) { refresh(); fetchTodayTotal(); } return result; });
   }
 
   function updateTimer(entryId, fields) {
     return postJson('/time/' + entryId + '/update', fields || {})
-      .then(function (result) { if (result.ok) refresh(); return result; });
+      .then(function (result) { if (result.ok) { refresh(); fetchTodayTotal(); } return result; });
   }
 
   window.TimeTrackerCore = {
     subscribe: subscribe,
+    subscribeToday: subscribeToday,
     refresh: refresh,
+    refreshToday: fetchTodayTotal,
     elapsedSeconds: elapsedSeconds,
     formatElapsed: formatElapsed,
     startTimer: startTimer,
@@ -154,5 +233,6 @@
     updateTimer: updateTimer,
     isLoaded: function () { return loaded; },
     current: function () { return current.slice(); },
+    todayTotalSeconds: liveTodayTotal,
   };
 })(window);

--- a/static/time_tracker_panel.js
+++ b/static/time_tracker_panel.js
@@ -403,6 +403,13 @@
 
 	if (window.TimeTrackerCore) {
 		window.TimeTrackerCore.subscribe(renderActive);
+		// Phase 2 §4.4 — today total in the titlebar
+		var todayEl = document.querySelector('[data-today-total]');
+		if (todayEl) {
+			window.TimeTrackerCore.subscribeToday(function (totalSecs) {
+				todayEl.textContent = window.TimeTrackerCore.formatElapsed(totalSecs);
+			});
+		}
 	}
 
 	// ---- Ctrl+K palette entries (consumed by cockpit_modes.js) ----

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -138,6 +138,9 @@
                         data-slug="{{ project.slug }}">
                       <label>{{ item.text }}</label>
                       {% if project.tracking_enabled %}
+                        <span class="cd-tt-today-tag cd-tt-tag-item" data-item-today-tag="{{ item.id }}" hidden></span>
+                        <span class="cd-tt-lifetime-tag cd-tt-tag-item" data-item-lifetime-tag="{{ item.id }}"
+                          {% if not item.lifetime_seconds %}hidden{% endif %}>{% if item.lifetime_seconds %}lifetime: {{ item.lifetime_text }}{% endif %}</span>
                         <button class="cd-tt-row-btn cd-tt-item-btn" data-tt-item-id="{{ item.id }}" data-tt-text="{{ item.text }}" title="Start timer on this item" type="button">⏱</button>
                       {% endif %}
                       <button class="cd-btn ghost sm checklist-item-delete" data-id="{{ item.id }}" data-slug="{{ project.slug }}">✕</button>
@@ -179,6 +182,8 @@
                   <span class="cd-task-title">{{ task.title }}</span>
                   {% if project.tracking_enabled %}
                     <span class="cd-tt-today-tag" data-task-today-tag="{{ task.id }}" hidden></span>
+                    <span class="cd-tt-lifetime-tag" data-task-lifetime-tag="{{ task.id }}"
+                      {% if not task.lifetime_seconds %}hidden{% endif %}>{% if task.lifetime_seconds %}lifetime: {{ task.lifetime_text }}{% endif %}</span>
                     <button class="cd-tt-row-btn cd-tt-task-btn" data-tt-task-id="{{ task.id }}" data-tt-text="{{ task.title }}" title="Start timer on this task" type="button">⏱</button>
                   {% endif %}
                   <button class="cd-task-edit" data-id="{{ task.id }}" title="Edit">✎</button>
@@ -681,7 +686,9 @@ document.getElementById('blocksContainer').addEventListener('click', function(e)
       // Phase 1.5: emit the same ⏱ markup Jinja would render, so newly-added
       // items are tracker-aware without a page reload.
       const ttMarkup = (typeof PROJECT_TRACKING !== 'undefined' && PROJECT_TRACKING)
-        ? `<button class="cd-tt-row-btn cd-tt-item-btn" data-tt-item-id="${data.item.id}" data-tt-text="${escapeHtml(data.item.text)}" title="Start timer on this item" type="button">⏱</button>`
+        ? `<span class="cd-tt-today-tag cd-tt-tag-item" data-item-today-tag="${data.item.id}" hidden></span>
+           <span class="cd-tt-lifetime-tag cd-tt-tag-item" data-item-lifetime-tag="${data.item.id}" hidden></span>
+           <button class="cd-tt-row-btn cd-tt-item-btn" data-tt-item-id="${data.item.id}" data-tt-text="${escapeHtml(data.item.text)}" title="Start timer on this item" type="button">⏱</button>`
         : '';
       li.innerHTML=`
         <input type="checkbox" data-item-id="${data.item.id}" data-slug="${PROJECT_SLUG}">
@@ -735,6 +742,7 @@ document.getElementById('blocksContainer').addEventListener('click', function(e)
       // page reload won't be tracker-aware.
       const ttMarkup = (typeof PROJECT_TRACKING !== 'undefined' && PROJECT_TRACKING)
         ? `<span class="cd-tt-today-tag" data-task-today-tag="${data.task.id}" hidden></span>
+           <span class="cd-tt-lifetime-tag" data-task-lifetime-tag="${data.task.id}" hidden></span>
            <button class="cd-tt-row-btn cd-tt-task-btn" data-tt-task-id="${data.task.id}" data-tt-text="${escapeHtml(data.task.title)}" title="Start timer on this task" type="button">⏱</button>`
         : '';
       li.innerHTML=`
@@ -1577,29 +1585,37 @@ function cdEditTask(id) {
     });
   }
 
-  // ---- Today-tag totals on task rows ----
+  // ---- Today-tag totals on task + checklist-item rows ----
   function syncTodayTags() {
     fetch('/time/today/' + PROJECT_ID, {credentials: 'same-origin'})
       .then(function (r) { return r.ok ? r.json() : {entries: []}; })
       .then(function (data) {
-        const totals = {};
+        const taskTotals = {};
+        const itemTotals = {};
         (data.entries || []).forEach(function (e) {
-          if (!e.task_id) return;
           const dur = e.duration_seconds != null
             ? e.duration_seconds
             : Math.floor((Date.now() - new Date(e.started_at).getTime()) / 1000);
-          totals[e.task_id] = (totals[e.task_id] || 0) + Math.max(0, dur);
-        });
-        document.querySelectorAll('[data-task-today-tag]').forEach(function (tag) {
-          const tid = tag.getAttribute('data-task-today-tag');
-          const total = totals[tid];
-          if (total && total > 0) {
-            tag.textContent = 'today: ' + fmt(total);
-            tag.hidden = false;
-          } else {
-            tag.hidden = true;
+          if (e.task_id) {
+            taskTotals[e.task_id] = (taskTotals[e.task_id] || 0) + Math.max(0, dur);
+          } else if (e.checklist_item_id) {
+            itemTotals[e.checklist_item_id] = (itemTotals[e.checklist_item_id] || 0) + Math.max(0, dur);
           }
         });
+        function applyTotals(attr, totals) {
+          document.querySelectorAll('[' + attr + ']').forEach(function (tag) {
+            const id = tag.getAttribute(attr);
+            const total = totals[id];
+            if (total && total > 0) {
+              tag.textContent = 'today: ' + fmt(total);
+              tag.hidden = false;
+            } else {
+              tag.hidden = true;
+            }
+          });
+        }
+        applyTotals('data-task-today-tag', taskTotals);
+        applyTotals('data-item-today-tag', itemTotals);
       })
       .catch(function () {});
   }

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -1423,11 +1423,23 @@ function cdEditTask(id) {
         const isRunning = !e.ended_at;
         const elapsed = e.duration_seconds != null ? e.duration_seconds : Math.floor((Date.now() - new Date(e.started_at).getTime()) / 1000);
         total += Math.max(0, elapsed|0);
-        let contextBadge = '';
+        // Phase 2: badge becomes a click-to-reassign trigger. Stopped entries
+        // get the dropdown; running entries stay static (re-assigning a live
+        // timer is fiddly UX, defer to v2.5+ if it surfaces).
+        let contextBadge;
+        const triggerCls = isRunning ? 'cd-tt-entry-context' : 'cd-tt-entry-context cd-tt-assign-trigger';
+        const triggerTag = isRunning ? 'span' : 'button';
+        const triggerAttrs = isRunning
+          ? ''
+          : ' type="button" data-entry-id="' + e.id + '"';
         if (e.task_title) {
-          contextBadge = '<span class="cd-tt-entry-context task">[task: ' + escHtml(e.task_title) + ']</span>';
+          contextBadge = '<' + triggerTag + ' class="' + triggerCls + ' task"' + triggerAttrs + '>[task: ' + escHtml(e.task_title) + ']' + (isRunning ? '' : ' ▾') + '</' + triggerTag + '>';
         } else if (e.checklist_item_text) {
-          contextBadge = '<span class="cd-tt-entry-context item">[item: ' + escHtml(e.checklist_item_text) + ']</span>';
+          contextBadge = '<' + triggerTag + ' class="' + triggerCls + ' item"' + triggerAttrs + '>[item: ' + escHtml(e.checklist_item_text) + ']' + (isRunning ? '' : ' ▾') + '</' + triggerTag + '>';
+        } else if (!isRunning) {
+          contextBadge = '<button type="button" class="cd-tt-entry-context cd-tt-assign-trigger unassigned" data-entry-id="' + e.id + '">[+ assign ▾]</button>';
+        } else {
+          contextBadge = '';
         }
         return '<div class="cd-tt-entry' + (isRunning ? ' is-running' : '') + '" data-id="' + e.id + '">' +
           '<span class="cd-tt-entry-time">' + fmtTimeOfDay(e.started_at) + '–' + (e.ended_at ? fmtTimeOfDay(e.ended_at) : 'now') + '</span>' +
@@ -1453,9 +1465,121 @@ function cdEditTask(id) {
         await window.TimeTrackerCore.deleteTimer(b.getAttribute('data-id'));
         loadTodayTime();
       }));
+      todayList.querySelectorAll('.cd-tt-assign-trigger').forEach(b => b.addEventListener('click', (ev) => {
+        ev.stopPropagation();
+        openAssignDropdown(b.getAttribute('data-entry-id'), b);
+      }));
     } catch (e) {
       todayList.innerHTML = '<div class="cd-text-dim" style="font-size:0.7rem;">Could not load.</div>';
     }
+  }
+
+  // ---- Phase 2: inline re-assign dropdown ----
+  // Click a [task: X] / [item: Y] / [+ assign ▾] badge on a stopped entry →
+  // dropdown of project tasks + checklist items. Selection POSTs to
+  // /time/<id>/update with mutually-exclusive task_id + checklist_item_id
+  // payload (always sends both — sets one, clears the other — so the server
+  // never sees a both-non-null payload from this UI).
+  let openDropdown = null;
+  function closeAssignDropdown() {
+    if (openDropdown) {
+      openDropdown.remove();
+      openDropdown = null;
+    }
+    document.removeEventListener('click', closeOnOutside, true);
+    document.removeEventListener('keydown', closeOnEsc, true);
+  }
+  function closeOnOutside(ev) {
+    if (!openDropdown) return;
+    if (openDropdown.contains(ev.target)) return;
+    closeAssignDropdown();
+  }
+  function closeOnEsc(ev) {
+    if (ev.key === 'Escape') {
+      ev.stopPropagation();
+      closeAssignDropdown();
+    }
+  }
+  function openAssignDropdown(entryId, anchorEl) {
+    closeAssignDropdown();
+
+    // Walk DOM for the project's tasks + items so newly-added rows are
+    // picked up without a re-render of the dropdown source data.
+    const tasks = Array.from(document.querySelectorAll('#projectTaskList .cd-task-item[data-id]'))
+      .map(li => ({
+        id: li.dataset.id,
+        title: (li.dataset.taskTitle || (li.querySelector('.cd-task-title') || {}).textContent || '').trim(),
+      }))
+      .filter(t => t.title);
+    const items = Array.from(document.querySelectorAll('.cd-checklist-item[data-item-id]'))
+      .map(li => ({
+        id: li.dataset.itemId,
+        text: (li.dataset.itemText || (li.querySelector('label') || {}).textContent || '').trim(),
+      }))
+      .filter(i => i.text);
+
+    const dd = document.createElement('div');
+    dd.className = 'cd-tt-assign-dropdown';
+    let html = '<div class="cd-tt-assign-header">// Change assignment</div>';
+    if (tasks.length) {
+      html += '<div class="cd-tt-assign-label">Tasks</div>';
+      tasks.forEach(t => {
+        html += '<button type="button" class="cd-tt-assign-option" data-task-id="' + t.id + '">' + escHtml(t.title) + '</button>';
+      });
+    }
+    if (items.length) {
+      html += '<div class="cd-tt-assign-label">Checklist items</div>';
+      items.forEach(i => {
+        html += '<button type="button" class="cd-tt-assign-option" data-item-id="' + i.id + '">' + escHtml(i.text) + '</button>';
+      });
+    }
+    if (!tasks.length && !items.length) {
+      html += '<div class="cd-tt-assign-empty">No tasks or checklist items on this project yet.</div>';
+    }
+    html += '<div class="cd-tt-assign-divider"></div>';
+    html += '<button type="button" class="cd-tt-assign-option clear" data-clear="1">Clear assignment</button>';
+    dd.innerHTML = html;
+
+    document.body.appendChild(dd);
+    const rect = anchorEl.getBoundingClientRect();
+    dd.style.position = 'absolute';
+    dd.style.top = (rect.bottom + window.scrollY + 4) + 'px';
+    dd.style.left = (rect.left + window.scrollX) + 'px';
+    // Clamp horizontally so the dropdown doesn't fall off the right edge
+    const ddRect = dd.getBoundingClientRect();
+    if (ddRect.right > window.innerWidth - 8) {
+      dd.style.left = (window.innerWidth - ddRect.width - 8 + window.scrollX) + 'px';
+    }
+    openDropdown = dd;
+
+    dd.addEventListener('click', async (ev) => {
+      const btn = ev.target.closest('.cd-tt-assign-option');
+      if (!btn) return;
+      btn.disabled = true;
+      const payload = { task_id: '', checklist_item_id: '' };
+      if (btn.dataset.taskId) payload.task_id = btn.dataset.taskId;
+      else if (btn.dataset.itemId) payload.checklist_item_id = btn.dataset.itemId;
+      // (data-clear sends both empty — already the default payload)
+      try {
+        const r = await fetch('/time/' + entryId + '/update', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify(payload),
+          credentials: 'same-origin',
+        });
+        closeAssignDropdown();
+        if (r.ok) loadTodayTime();
+      } catch (e) {
+        btn.disabled = false;
+      }
+    });
+
+    // Defer the listener attachment so the click that opened us doesn't
+    // immediately close us.
+    setTimeout(() => {
+      document.addEventListener('click', closeOnOutside, true);
+      document.addEventListener('keydown', closeOnEsc, true);
+    }, 0);
   }
 
   // Re-render on every tick + every TimeTrackerCore poll

--- a/templates/command_deck_reports.html
+++ b/templates/command_deck_reports.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <title>Reports · Command Deck</title>
+  <link rel="stylesheet" href="/static/command_deck.css">
+</head>
+<body class="command-deck">
+<div class="cd-shell">
+
+  <!-- HEADER -->
+  <header class="cd-header">
+    <div class="cd-header-left">
+      <a href="/command-deck/" class="cd-wordmark">COMMAND DECK</a>
+      <span class="cd-ident">REPORTS · TIME LOG</span>
+    </div>
+    <nav class="cd-header-nav">
+      <a href="/command-deck/" class="cd-nav-link">BRIDGE</a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/command-deck/projects/" class="cd-nav-link">PROJECTS</a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/below-deck" class="cd-nav-link">
+        BELOW DECK
+        <span class="cd-bd-badge" id="bdBadge"></span>
+      </a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/today/" class="cd-nav-link">TODAY</a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/command-deck/reports/" class="cd-nav-link active">REPORTS</a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/publish" class="cd-nav-link">COCKPIT</a>
+    </nav>
+  </header>
+
+  {% include 'includes/today_panel.html' %}
+  {% include 'includes/active_timer_strip.html' %}
+
+  <!-- MAIN -->
+  <div class="cd-main full-width">
+
+    <!-- REPORTS CONTROL BAR -->
+    <section class="cd-reports-controls">
+
+      <div class="cd-reports-period">
+        <button class="cd-reports-nav-btn" id="reportsPrev" title="Previous period">←</button>
+        <div class="cd-reports-period-label">
+          <span id="reportsPeriodLabel">…</span>
+          <input type="date" class="cd-reports-jump" id="reportsJump" title="Jump to week containing date">
+        </div>
+        <button class="cd-reports-nav-btn" id="reportsNext" title="Next period">→</button>
+      </div>
+
+      <div class="cd-reports-presets" role="tablist">
+        <button class="cd-reports-preset" data-period="today">Today</button>
+        <button class="cd-reports-preset active" data-period="this-week">Week</button>
+        <button class="cd-reports-preset" data-period="this-month">Month</button>
+        <button class="cd-reports-preset" data-period="custom">Custom</button>
+      </div>
+
+      <div class="cd-reports-custom" id="reportsCustom" hidden>
+        <input type="date" class="cd-reports-custom-input" id="reportsCustomStart" aria-label="Custom range start">
+        <span class="cd-reports-custom-sep">→</span>
+        <input type="date" class="cd-reports-custom-input" id="reportsCustomEnd" aria-label="Custom range end">
+        <button class="cd-reports-custom-apply" id="reportsCustomApply">Apply</button>
+      </div>
+
+      <div class="cd-reports-groups" role="tablist">
+        <span class="cd-reports-groups-label">Group:</span>
+        <button class="cd-reports-group active" data-group="area">Area</button>
+        <button class="cd-reports-group" data-group="project">Project</button>
+        <button class="cd-reports-group" data-group="day">Day</button>
+      </div>
+
+    </section>
+
+    <!-- PRIVACY NOTE (shown when private projects hidden) -->
+    <div class="cd-reports-privacy-note" id="reportsPrivacyNote" hidden>
+      // <span id="reportsPrivacyCount">0</span> private project(s) hidden — unlock via 🔒 to include
+    </div>
+
+    <!-- EMPTY STATE -->
+    <div class="cd-reports-empty" id="reportsEmpty" hidden>
+      No tracked time in this period.
+    </div>
+
+    <!-- ROLLUP (by area / project / day) -->
+    <section class="cd-reports-rollup" id="reportsRollup">
+      <div class="cd-reports-loading">loading…</div>
+    </section>
+
+    <!-- CHRONOLOGICAL ENTRIES -->
+    <section class="cd-reports-entries" id="reportsEntries">
+      <h2 class="cd-reports-entries-title">// Entries</h2>
+      <table class="cd-reports-entries-table">
+        <thead>
+          <tr>
+            <th>Day</th>
+            <th>Area</th>
+            <th>Project</th>
+            <th>Task / Item</th>
+            <th>Description</th>
+            <th>Start → End</th>
+            <th class="cd-num">Duration</th>
+          </tr>
+        </thead>
+        <tbody id="reportsEntriesBody">
+          <tr><td colspan="7" class="cd-reports-loading">loading…</td></tr>
+        </tbody>
+        <tfoot>
+          <tr>
+            <td colspan="6" class="cd-reports-total-label">Total</td>
+            <td class="cd-num" id="reportsTotalDuration">—</td>
+          </tr>
+        </tfoot>
+      </table>
+    </section>
+
+  </div><!-- .cd-main -->
+
+  <!-- FOOTER -->
+  <footer class="cd-footer">
+    <div class="cd-footer-links">
+      <a href="/command-deck/" class="cd-footer-link">Bridge</a>
+      <a href="/command-deck/projects/" class="cd-footer-link">Projects</a>
+      <a href="/publish" class="cd-footer-link">Cockpit</a>
+      {% if private_projects_enabled %}
+      <span class="cd-nav-sep">·</span>
+      <button class="cd-nav-link" id="unlockPrivateBtn" style="background:none;border:none;cursor:pointer;" title="Private projects">🔒</button>
+      {% endif %}
+    </div>
+    {% include 'includes/cd_footer_status.html' %}
+    <span class="cd-footer-ident">YT-1300F · COMMAND DECK · SECURE</span>
+  </footer>
+
+</div><!-- .cd-shell -->
+
+<script src="/static/command_deck_reports.js"></script>
+</body>
+</html>

--- a/templates/command_deck_reports.html
+++ b/templates/command_deck_reports.html
@@ -70,6 +70,7 @@
         <button class="cd-reports-group active" data-group="area">Area</button>
         <button class="cd-reports-group" data-group="project">Project</button>
         <button class="cd-reports-group" data-group="day">Day</button>
+        <button class="cd-reports-group" data-group="timesheet">Timesheet</button>
       </div>
 
     </section>

--- a/templates/includes/time_tracker_panel.html
+++ b/templates/includes/time_tracker_panel.html
@@ -12,6 +12,8 @@
 	<div id="ttp-titlebar">
 		<span id="ttp-title">⏱ TIME TRACKER</span>
 		<span id="ttp-summary"></span>
+		<a id="ttp-today-total" href="/command-deck/reports/?period=today"
+			title="Open today's report" target="_blank" rel="noopener">today: <span data-today-total>0:00</span></a>
 		<div id="ttp-actions">
 			<button class="ttp-tb-btn" id="ttp-collapse-btn" type="button" title="Collapse" aria-label="Collapse">□</button>
 			<button class="ttp-tb-btn" id="ttp-close-btn" type="button" title="Close" aria-label="Close">✕</button>


### PR DESCRIPTION
## Summary

Chunk B of Phase 2 of the time-tracking roadmap (Chunk A — ops confidence — shipped earlier today via #146). Eight commits, each independently shippable. Closes the reports surface that Phase 1 + 1.5 have been building toward.

Locked spec at `.kt/spec-time-tracking-phase-2.md` (gitignored — local-only). Decisions traced back to `.kt/phase-2-kickoff.md` §4 plus this session's follow-up locks.

## What's in

- **Phase 2 indexes** — composite `(project_id, started_at)` for date-range queries, partial `(task_id)` and `(checklist_item_id)` for lifetime sums. New `migrate_add_phase2_indexes.py`.
- **`/time/<id>/update` extension** — accepts `task_id` + `checklist_item_id` for re-assigning stopped entries, with same-project + mutual-exclusion validation matching the Phase 1.5 start-route logic.
- **`/command-deck/reports/data`** — single endpoint serving entries + four totals shapes (by_area, by_project, by_day, by_timesheet) so the client can flip group toggles without a re-fetch. Window keyed on `started_at` consistent with the Phase 1 midnight rule.
- **`/command-deck/reports/`** — new top-level page with period nav (←/→/jump/Today/Week/Month/Custom), group toggle (Area/Project/Day/Timesheet), inline CSS bars, chronological entries table. Sun–Sat default week. Privacy lock respected (`include_private=1` opt-in). CRT amber discipline preserved — no chart libraries.
- **Timesheet view** — project × day matrix with sticky first column + sticky header. The view Aaron transposes to his actual day-job timesheet. 31-day cap with a polite Day-group fallback if a custom range exceeds it.
- **Per-task + per-item lifetime tags** — `today: H:MM` + `lifetime: H:MM` on task rows (always-visible) and checklist items (hover-only on desktop, low-opacity always on touch — mirrors the Phase 1.5 ⏱-button density rule). Hide when zero.
- **Inline re-assign dropdown** — clicking the `[task: X]` / `[item: Y]` / `[+ assign ▾]` badge on a stopped entry in the project's today's-time list opens a combined dropdown (Tasks / Checklist items sections + Clear assignment). POSTs to `/time/<id>/update` with always-both payload to satisfy mutual exclusion.
- **Cockpit panel today total** — small dim `today: H:MM` link in the floating-panel titlebar, hyperlinked to `/command-deck/reports/?period=today`. Backed by a new `subscribeToday` channel on `TimeTrackerCore` that polls `/time/today/total` on the existing 30s cadence and ticks locally between polls — no double-poll.

## Test plan

Verified locally during build:
- [x] Migration idempotent across two runs; sqlite_master confirms 3 new indexes
- [x] `/time/<id>/update` extension — 7 cases pass (assign, clear, cross-project rejection, mutual-exclusion, 404, invalid int, regression)
- [x] `/command-deck/reports/data` — across periods + groups; cross-shape consistency holds (`meta.totals_seconds == sum(by_area) == sum(by_project) == sum(by_timesheet) == sum(by_day)`)
- [x] Reports page renders, JS asset served, custom range with exclusive-end translation working
- [x] Timesheet matrix: per-project totals match sum of day cells
- [x] Lifetime tags rendered server-side with computed values (e.g. `lifetime: 2:00` for a 7200s history)
- [x] Re-assign dropdown wiring: openAssignDropdown / closeAssignDropdown / closeOnEsc / closeOnOutside all present; mutual-exclusion payload pattern matches server expectations
- [x] Panel today total: endpoint returns `{stopped_today_seconds, today_total_seconds, today_date}`; subscribeToday channel exposed on TimeTrackerCore; panel JS subscribes
- [x] Aaron eyeballed the rendered surfaces locally — all tests good

After merge:
- [ ] On PA: `git pull origin main && python migrate_add_phase2_indexes.py && reload web app`
- [ ] First publish from prod runs the snapshot-on-publish hook + the `running` annotation in reports gives a live-elapsed view of any active timer

## KT doc sweep (gitignored, local-only)

- `.kt/spec-time-tracking-phase-2.md` — marked Status: ✅ Shipped
- `.kt/KT-command-deck.md` — Phase 2 routes added to URL table; phase roadmap line updated; Last updated bumped
- `.kt/PROJECT_KNOWLEDGE.md` — phase roadmap shipped; Last updated bumped
- `.kt/KT-cockpit.md` — TimeTrackerCore.subscribeToday channel + titlebar today total documented
- `.kt/phase-2-kickoff.md` — both chunks marked shipped; brief is now historical

## What's next

Phase 2.1 (immediately after this merges) — promotes checklist items to first-class Today-list citizens (★ button on items, items render in /today/ + the global today panel, same 4am-ET auto-clear). Plus: replaces `[item: <text>]` with `[Checklist: <block.title>]` across all timer surfaces so blocks read as the deliverable identity.

Phase 3 (mileage) and Phase 4 (idle detection + FTS5) remain in the longer roadmap.

## Merge strategy

Rebase-merge / fast-forward only. Eight commits stand on their own and the Han Solo voice runs through the bodies — squash would erase the narrative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)