### PR TITLE
Phase 2.1 — checklist items in Today + block-title context badges

### DIFF
--- a/blueprints/reports.py
+++ b/blueprints/reports.py
@@ -246,12 +246,15 @@ def reports_data():
 		       parent.title      AS area_title,
 		       parent.area_color AS area_color,
 		       t.title           AS task_title,
-		       ci.text           AS checklist_item_text
+		       ci.text           AS checklist_item_text,
+		       b.id              AS block_id,
+		       b.title           AS block_title
 		FROM time_entries te
-		JOIN projects p           ON te.project_id = p.id
-		LEFT JOIN projects parent ON p.parent_project_id = parent.id
-		LEFT JOIN tasks t         ON te.task_id = t.id
+		JOIN projects p              ON te.project_id = p.id
+		LEFT JOIN projects parent    ON p.parent_project_id = parent.id
+		LEFT JOIN tasks t            ON te.task_id = t.id
 		LEFT JOIN checklist_items ci ON te.checklist_item_id = ci.id
+		LEFT JOIN blocks b           ON ci.block_id = b.id
 		WHERE {where_sql}
 		ORDER BY te.started_at ASC
 	''', args).fetchall()
@@ -297,6 +300,8 @@ def reports_data():
 			'task_title': r['task_title'],
 			'checklist_item_id': r['checklist_item_id'],
 			'checklist_item_text': r['checklist_item_text'],
+			'block_id': r['block_id'],
+			'block_title': r['block_title'],
 			'description': r['description'],
 			'started_at': r['started_at'],
 			'ended_at': ended,

--- a/blueprints/time_tracking.py
+++ b/blueprints/time_tracking.py
@@ -76,18 +76,27 @@ def _row_get(row, key, default=None):
 
 
 def _fetch_entry_with_context(conn, entry_id):
-	"""Re-fetch a time_entries row with task + checklist_item context joined."""
+	"""Re-fetch a time_entries row with task + checklist_item + parent-block
+	context joined. Phase 2.1 added the blocks JOIN so client renderers can
+	display [Checklist: <block.title>] for item-scoped entries instead of
+	the raw item text."""
 	return conn.execute('''
-		SELECT te.*, t.title AS task_title, ci.text AS checklist_item_text
+		SELECT te.*,
+		       t.title  AS task_title,
+		       ci.text  AS checklist_item_text,
+		       b.id     AS block_id,
+		       b.title  AS block_title
 		FROM time_entries te
-		LEFT JOIN tasks t ON te.task_id = t.id
+		LEFT JOIN tasks t            ON te.task_id = t.id
 		LEFT JOIN checklist_items ci ON te.checklist_item_id = ci.id
+		LEFT JOIN blocks b           ON ci.block_id = b.id
 		WHERE te.id = ?
 	''', (entry_id,)).fetchone()
 
 
 def _serialize_active_entry(row):
-	"""Active-entry shape — Phase 1 §3.1 + Phase 1.5 task/item context."""
+	"""Active-entry shape — Phase 1 §3.1 + Phase 1.5 task/item context +
+	Phase 2.1 block context for item-scoped entries."""
 	started = _parse_iso_utc(row['started_at'])
 	elapsed = int((datetime.now(pytz.UTC) - started).total_seconds()) if started else 0
 	return {
@@ -104,6 +113,8 @@ def _serialize_active_entry(row):
 		'task_title': _row_get(row, 'task_title'),
 		'checklist_item_id': _row_get(row, 'checklist_item_id'),
 		'checklist_item_text': _row_get(row, 'checklist_item_text'),
+		'block_id': _row_get(row, 'block_id'),
+		'block_title': _row_get(row, 'block_title'),
 	}
 
 
@@ -116,6 +127,8 @@ def _serialize_entry(row):
 		'checklist_item_id': _row_get(row, 'checklist_item_id'),
 		'task_title': _row_get(row, 'task_title'),
 		'checklist_item_text': _row_get(row, 'checklist_item_text'),
+		'block_id': _row_get(row, 'block_id'),
+		'block_title': _row_get(row, 'block_title'),
 		'description': row['description'],
 		'started_at': row['started_at'],
 		'ended_at': row['ended_at'],
@@ -142,12 +155,15 @@ def time_active():
 		       parent.title        AS area_title,
 		       parent.area_color   AS area_color,
 		       t.title             AS task_title,
-		       ci.text             AS checklist_item_text
+		       ci.text             AS checklist_item_text,
+		       b.id                AS block_id,
+		       b.title             AS block_title
 		FROM time_entries te
 		JOIN projects p ON te.project_id = p.id
-		LEFT JOIN projects parent ON p.parent_project_id = parent.id
-		LEFT JOIN tasks t ON te.task_id = t.id
+		LEFT JOIN projects parent    ON p.parent_project_id = parent.id
+		LEFT JOIN tasks t            ON te.task_id = t.id
 		LEFT JOIN checklist_items ci ON te.checklist_item_id = ci.id
+		LEFT JOIN blocks b           ON ci.block_id = b.id
 		WHERE te.ended_at IS NULL
 		ORDER BY te.started_at ASC
 	''').fetchall()
@@ -534,10 +550,15 @@ def time_today(project_id):
 	start_utc, end_utc = _et_today_bounds_utc()
 	conn = get_db()
 	rows = conn.execute('''
-		SELECT te.*, t.title AS task_title, ci.text AS checklist_item_text
+		SELECT te.*,
+		       t.title  AS task_title,
+		       ci.text  AS checklist_item_text,
+		       b.id     AS block_id,
+		       b.title  AS block_title
 		FROM time_entries te
-		LEFT JOIN tasks t ON te.task_id = t.id
+		LEFT JOIN tasks t            ON te.task_id = t.id
 		LEFT JOIN checklist_items ci ON te.checklist_item_id = ci.id
+		LEFT JOIN blocks b           ON ci.block_id = b.id
 		WHERE te.project_id = ?
 		  AND te.started_at >= ?
 		  AND te.started_at <  ?

--- a/blueprints/today.py
+++ b/blueprints/today.py
@@ -1,4 +1,10 @@
-"""Today blueprint — daily focus master view + per-task star/complete + 4am ET auto-clear."""
+"""Today blueprint — daily focus master view + per-task/item star/complete + 4am ET auto-clear.
+
+Phase 2.1 (.kt/spec-time-tracking-phase-2-1.md): checklist items are first-
+class Today citizens alongside tasks. /today/star, /today/complete, and
+/today/data all accept task_id OR item_id (mutually exclusive); the
+auto-clear pass clears today=0 on checked items past 4am ET.
+"""
 from datetime import datetime, timedelta
 import pytz
 from flask import Blueprint, request, redirect, url_for, jsonify, render_template
@@ -11,7 +17,16 @@ today_bp = Blueprint('today', __name__)
 
 
 def _today_autoclear(conn):
-	"""Clear today flags on completed tasks before the 4am ET boundary."""
+	"""Clear today flags on completed-and-old rows.
+
+	Tasks: cleared when status='completed' AND completed_date < today's
+	       4am ET cutoff.
+	Items: cleared when checked=1, simply rolled off at every autoclear
+	       pass past 4am. checklist_items has no checked_at column yet
+	       (Phase 2.2 adds it for stricter timing) — for v1, accept the
+	       sloppiness: an item checked at 11pm + starred at 11:55pm
+	       would lose the star at 4am. Documented in spec §5.5.
+	"""
 	eastern = pytz.timezone('US/Eastern')
 	now_et = datetime.now(eastern)
 	if now_et.hour < 4:
@@ -27,6 +42,10 @@ def _today_autoclear(conn):
 		  AND completed_date IS NOT NULL
 		  AND completed_date < ?
 	''', (cutoff,))
+	conn.execute('''
+		UPDATE checklist_items SET today = 0
+		WHERE today = 1 AND checked = 1
+	''')
 	conn.commit()
 
 
@@ -40,14 +59,18 @@ def today_page():
 
 @today_bp.route('/today/count')
 def today_count():
+	"""Open today count — tasks + items combined for the global pill."""
 	if not is_authenticated():
 		return jsonify({'count': 0})
 	conn = get_db()
-	row = conn.execute(
+	task_count = conn.execute(
 		"SELECT COUNT(*) as cnt FROM tasks WHERE today = 1 AND status = 'open'"
-	).fetchone()
+	).fetchone()['cnt']
+	item_count = conn.execute(
+		"SELECT COUNT(*) as cnt FROM checklist_items WHERE today = 1 AND checked = 0"
+	).fetchone()['cnt']
 	conn.close()
-	return jsonify({'count': row['cnt']})
+	return jsonify({'count': task_count + item_count})
 
 
 @today_bp.route('/today/data')
@@ -56,22 +79,48 @@ def today_data():
 		return jsonify({'error': 'unauthorized'}), 403
 	conn = get_db()
 	_today_autoclear(conn)
-	today_open = conn.execute('''
+
+	# Today section — open: tasks (status='open') + items (checked=0)
+	today_tasks_open = conn.execute('''
 		SELECT t.id, t.title, t.status, t.today, t.project_id,
-		       p.title as project_title, p.slug as project_slug
+		       p.title AS project_title, p.slug AS project_slug
 		FROM tasks t
 		LEFT JOIN projects p ON t.project_id = p.id
 		WHERE t.today = 1 AND t.status = 'open'
 		ORDER BY t.id ASC
 	''').fetchall()
-	today_done = conn.execute('''
+	today_items_open = conn.execute('''
+		SELECT ci.id, ci.text, ci.checked, ci.today, ci.block_id,
+		       b.title AS block_title, b.project_id,
+		       p.title AS project_title, p.slug AS project_slug
+		FROM checklist_items ci
+		JOIN blocks b ON ci.block_id = b.id
+		JOIN projects p ON b.project_id = p.id
+		WHERE ci.today = 1 AND ci.checked = 0
+		ORDER BY ci.id ASC
+	''').fetchall()
+
+	# Today section — done: completed tasks + checked items still flagged
+	today_tasks_done = conn.execute('''
 		SELECT t.id, t.title, t.status, t.today, t.project_id,
-		       p.title as project_title, p.slug as project_slug
+		       p.title AS project_title, p.slug AS project_slug
 		FROM tasks t
 		LEFT JOIN projects p ON t.project_id = p.id
 		WHERE t.today = 1 AND t.status = 'completed'
 		ORDER BY t.completed_date DESC
 	''').fetchall()
+	today_items_done = conn.execute('''
+		SELECT ci.id, ci.text, ci.checked, ci.today, ci.block_id,
+		       b.title AS block_title, b.project_id,
+		       p.title AS project_title, p.slug AS project_slug
+		FROM checklist_items ci
+		JOIN blocks b ON ci.block_id = b.id
+		JOIN projects p ON b.project_id = p.id
+		WHERE ci.today = 1 AND ci.checked = 1
+		ORDER BY ci.id DESC
+	''').fetchall()
+
+	# Master browse — Below Deck (project_id NULL) + per-project task lists
 	below_deck_tasks = conn.execute('''
 		SELECT id, title, status, today, project_id
 		FROM tasks
@@ -81,7 +130,7 @@ def today_data():
 	projects = conn.execute(
 		'SELECT id, title, slug FROM projects ORDER BY title ASC'
 	).fetchall()
-	project_tasks = {}
+	project_groups = []
 	for proj in projects:
 		tasks = conn.execute('''
 			SELECT id, title, status, today, project_id
@@ -90,37 +139,80 @@ def today_data():
 			ORDER BY "order" ASC, id ASC
 		''', (proj['id'],)).fetchall()
 		if tasks:
-			project_tasks[proj['id']] = {
+			project_groups.append({
 				'title': proj['title'],
 				'slug': proj['slug'],
-				'tasks': [dict(t) for t in tasks]
-			}
+				'tasks': [dict(t) for t in tasks],
+			})
+
 	conn.close()
+
+	def _serialize_task(row):
+		d = dict(row)
+		d['kind'] = 'task'
+		return d
+
+	def _serialize_item(row):
+		d = dict(row)
+		d['kind'] = 'item'
+		return d
+
 	return jsonify({
-		'today_open': [dict(t) for t in today_open],
-		'today_done': [dict(t) for t in today_done],
+		# Mixed lists — kind='task' or kind='item' on each entry. Renderers
+		# branch on kind to draw the right row shape.
+		'today_open': (
+			[_serialize_task(r) for r in today_tasks_open] +
+			[_serialize_item(r) for r in today_items_open]
+		),
+		'today_done': (
+			[_serialize_task(r) for r in today_tasks_done] +
+			[_serialize_item(r) for r in today_items_done]
+		),
 		'below_deck': [dict(t) for t in below_deck_tasks],
-		'projects': list(project_tasks.values())
+		'projects': project_groups,
 	})
 
 
 @today_bp.route('/today/star', methods=['POST'])
 def today_star():
+	"""Toggle the today flag on a task OR a checklist item.
+
+	Phase 2.1: accepts either task_id or item_id (mutually exclusive).
+	Form-encoded for parity with the existing star UI; either field is
+	picked up via request.form. 400 if neither field present, OR if both."""
 	if not is_authenticated():
 		return jsonify({'error': 'unauthorized'}), 403
-	task_id = request.form.get('id')
-	if not task_id:
-		return jsonify({'error': 'id required'}), 400
+
+	task_id = request.form.get('task_id') or request.form.get('id')  # legacy fallback
+	item_id = request.form.get('item_id')
+
+	if task_id and item_id:
+		return jsonify({'error': 'task_or_item_not_both'}), 400
+	if not task_id and not item_id:
+		return jsonify({'error': 'task_id_or_item_id_required'}), 400
+
 	conn = get_db()
-	task = conn.execute('SELECT * FROM tasks WHERE id = ?', (task_id,)).fetchone()
-	if not task:
-		conn.close()
-		return jsonify({'error': 'not found'}), 404
-	new_today = 0 if task['today'] else 1
-	conn.execute('UPDATE tasks SET today = ? WHERE id = ?', (new_today, task_id))
+	if task_id:
+		row = conn.execute('SELECT id, today FROM tasks WHERE id = ?', (task_id,)).fetchone()
+		if not row:
+			conn.close()
+			return jsonify({'error': 'not_found'}), 404
+		new_today = 0 if row['today'] else 1
+		conn.execute('UPDATE tasks SET today = ? WHERE id = ?', (new_today, task_id))
+	else:
+		row = conn.execute('SELECT id, today FROM checklist_items WHERE id = ?', (item_id,)).fetchone()
+		if not row:
+			conn.close()
+			return jsonify({'error': 'not_found'}), 404
+		new_today = 0 if row['today'] else 1
+		conn.execute('UPDATE checklist_items SET today = ? WHERE id = ?', (new_today, item_id))
+
 	conn.commit()
+	# Combined open count for the badge
 	count = conn.execute(
-		"SELECT COUNT(*) as cnt FROM tasks WHERE today = 1 AND status = 'open'"
+		"SELECT (SELECT COUNT(*) FROM tasks WHERE today = 1 AND status = 'open') + "
+		"       (SELECT COUNT(*) FROM checklist_items WHERE today = 1 AND checked = 0) "
+		"AS cnt"
 	).fetchone()['cnt']
 	conn.close()
 	return jsonify({'success': True, 'today': new_today, 'count': count})
@@ -128,26 +220,56 @@ def today_star():
 
 @today_bp.route('/today/complete', methods=['POST'])
 def today_complete():
+	"""Complete a task (sets status='completed'), or check a checklist item
+	(sets checked=1). For items, the existing Phase 1.5 auto-stop hook will
+	stop any timer scoped to the item — but that runs client-side via the
+	'change' event on the checkbox. From this server-side path, we just
+	set the state; the auto-stop is a separate code path on the project
+	page when the user un/checks via the checkbox itself."""
 	if not is_authenticated():
 		return jsonify({'error': 'unauthorized'}), 403
-	task_id = request.form.get('id')
-	if not task_id:
-		return jsonify({'error': 'id required'}), 400
+
+	task_id = request.form.get('task_id') or request.form.get('id')  # legacy fallback
+	item_id = request.form.get('item_id')
+
+	if task_id and item_id:
+		return jsonify({'error': 'task_or_item_not_both'}), 400
+	if not task_id and not item_id:
+		return jsonify({'error': 'task_id_or_item_id_required'}), 400
+
 	conn = get_db()
-	task = conn.execute('SELECT * FROM tasks WHERE id = ?', (task_id,)).fetchone()
-	if not task:
-		conn.close()
-		return jsonify({'error': 'not found'}), 404
 	now = et_now()
-	conn.execute(
-		"UPDATE tasks SET status = 'completed', completed_date = ? WHERE id = ?",
-		(now, task_id)
-	)
-	if task['project_id']:
+
+	if task_id:
+		task = conn.execute('SELECT * FROM tasks WHERE id = ?', (task_id,)).fetchone()
+		if not task:
+			conn.close()
+			return jsonify({'error': 'not_found'}), 404
+		conn.execute(
+			"UPDATE tasks SET status = 'completed', completed_date = ? WHERE id = ?",
+			(now, task_id)
+		)
+		if task['project_id']:
+			conn.execute(
+				'UPDATE projects SET updated = ? WHERE id = ?',
+				(now, task['project_id'])
+			)
+	else:
+		item = conn.execute('''
+			SELECT ci.id, b.project_id
+			FROM checklist_items ci
+			JOIN blocks b ON ci.block_id = b.id
+			WHERE ci.id = ?
+		''', (item_id,)).fetchone()
+		if not item:
+			conn.close()
+			return jsonify({'error': 'not_found'}), 404
+		conn.execute('UPDATE checklist_items SET checked = 1 WHERE id = ?', (item_id,))
 		conn.execute(
 			'UPDATE projects SET updated = ? WHERE id = ?',
-			(now, task['project_id'])
+			(now, item['project_id'])
 		)
+
 	conn.commit()
 	conn.close()
 	return jsonify({'success': True})

--- a/migrate_add_today_on_items.py
+++ b/migrate_add_today_on_items.py
@@ -1,0 +1,83 @@
+"""
+migrate_add_today_on_items.py
+Phase 2.1 of the time-tracking spec — see .kt/spec-time-tracking-phase-2-1.md.
+
+What it does (idempotent — safe to run multiple times):
+  - Adds checklist_items.today INTEGER NOT NULL DEFAULT 0.
+    Same semantics as tasks.today: 1 = item appears in the Today list,
+    0 = does not. Cleared by manual unstar OR by the 4am ET autoclear
+    pass on checked items.
+
+Companion to migrate_add_today.py (which added the column on tasks).
+Phase 2.1 elevates checklist items to first-class Today citizens —
+this column is the schema piece that makes that possible.
+
+Prints a summary. Running it again prints "no changes."
+
+Run from PythonAnywhere bash:
+    cd /home/aaronaiken/status_update
+    python migrate_add_today_on_items.py
+"""
+
+import os
+import sqlite3
+
+DB_FILE = os.path.join(
+	os.environ.get('COCKPIT_REPO_ROOT', '/home/aaronaiken/status_update'),
+	'assets/data/command_deck.db'
+)
+
+
+def column_exists(cur, table, col):
+	cols = [row[1] for row in cur.execute(f"PRAGMA table_info({table})").fetchall()]
+	return col in cols
+
+
+def run():
+	if not os.path.exists(DB_FILE):
+		print(f"× DB not found at {DB_FILE}")
+		print("  Run migrate_to_sqlite.py first.")
+		return
+
+	conn = sqlite3.connect(DB_FILE)
+	cur = conn.cursor()
+
+	ci_exists = cur.execute(
+		"SELECT name FROM sqlite_master WHERE type='table' AND name='checklist_items'"
+	).fetchone() is not None
+	if not ci_exists:
+		print("× checklist_items table not found. Run migrate_to_sqlite.py first.")
+		conn.close()
+		return
+
+	added = []
+	skipped = []
+
+	if column_exists(cur, 'checklist_items', 'today'):
+		skipped.append('checklist_items.today')
+	else:
+		cur.execute("ALTER TABLE checklist_items ADD COLUMN today INTEGER NOT NULL DEFAULT 0")
+		added.append('checklist_items.today')
+
+	conn.commit()
+	conn.close()
+
+	print()
+	print("Migration: migrate_add_today_on_items.py")
+	print(f"DB:        {DB_FILE}")
+	print()
+	if added:
+		print(f"✓ Added ({len(added)}):")
+		for item in added:
+			print(f"    + {item}")
+	if skipped:
+		print(f"— Already in place ({len(skipped)}):")
+		for item in skipped:
+			print(f"    · {item}")
+	if not added:
+		print("No changes — schema already up to date.")
+	print()
+
+
+if __name__ == '__main__':
+	run()

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -2568,6 +2568,29 @@ button.cd-tt-entry-context.unassigned {
 	.cd-checklist-item.cd-tt-running .cd-tt-tag-item { opacity: 1; }
 }
 
+/* Phase 2.1 — ★ Today toggle on task + checklist-item rows */
+.cd-today-star {
+	background: none;
+	border: none;
+	cursor: pointer;
+	padding: 0 4px;
+	font-size: 0.95rem;
+	line-height: 1;
+	color: rgba(212, 136, 10, 0.25);
+	transition: color 0.15s, transform 0.15s, text-shadow 0.15s;
+	flex-shrink: 0;
+}
+.cd-today-star:hover,
+.cd-today-star:focus-visible {
+	color: rgba(212, 136, 10, 0.7);
+	transform: scale(1.15);
+	outline: none;
+}
+.cd-today-star.starred {
+	color: var(--cd-amber-hi);
+	text-shadow: 0 0 6px rgba(245, 179, 50, 0.35);
+}
+
 /* Toast — bottom-center, brief */
 .cd-tt-toast {
 	position: fixed;

--- a/static/command_deck_reports.js
+++ b/static/command_deck_reports.js
@@ -336,7 +336,13 @@
 			const stripe = e.area_color || 'var(--cd-amber-lo)';
 			let context = '—';
 			if (e.task_title) context = `task: ${escapeHtml(e.task_title)}`;
-			else if (e.checklist_item_text) context = `item: ${escapeHtml(e.checklist_item_text)}`;
+			else if (e.checklist_item_id) {
+				// Phase 2.1: block-title as deliverable identity. Fall back
+				// to plain "Checklist" when the block has no title.
+				context = e.block_title
+					? `Checklist: ${escapeHtml(e.block_title)}`
+					: 'Checklist';
+			}
 			const runningCls = e.running ? ' is-running' : '';
 			const runningGlyph = e.running ? ' <span class="cd-reports-running-dot" title="still running"></span>' : '';
 			return `

--- a/static/time_tracker_panel.js
+++ b/static/time_tracker_panel.js
@@ -150,7 +150,13 @@
 						var isEditing = state.editingId === e.id;
 						var ctxLine = '';
 						if (e.task_title) ctxLine = '<span class="ttp-row-ctx">task · ' + escHtml(e.task_title) + '</span>';
-						else if (e.checklist_item_text) ctxLine = '<span class="ttp-row-ctx">item · ' + escHtml(e.checklist_item_text) + '</span>';
+						else if (e.checklist_item_id) {
+							// Phase 2.1: block-title as deliverable identity
+							var blockLabel = e.block_title
+								? 'Checklist · ' + escHtml(e.block_title)
+								: 'Checklist';
+							ctxLine = '<span class="ttp-row-ctx">' + blockLabel + '</span>';
+						}
 						var descNode = isEditing
 							? '<input class="ttp-row-desc-input" data-id="' + e.id + '" value="' + escHtml(desc) + '">'
 							: '<span class="ttp-row-desc" data-id="' + e.id + '">' + escHtml(desc) + '</span>';

--- a/templates/command_deck_area.html
+++ b/templates/command_deck_area.html
@@ -30,6 +30,8 @@
       <span class="cd-nav-sep">·</span>
       <a href="/today/" class="cd-nav-link">TODAY</a>
       <span class="cd-nav-sep">·</span>
+      <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
+      <span class="cd-nav-sep">·</span>
       <a href="/publish" class="cd-nav-link">COCKPIT</a>
     </nav>
   </header>

--- a/templates/command_deck_dashboard.html
+++ b/templates/command_deck_dashboard.html
@@ -27,6 +27,8 @@
       <span class="cd-nav-sep">·</span>
       <a href="/today/" class="cd-nav-link">TODAY</a>
       <span class="cd-nav-sep">·</span>
+      <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
+      <span class="cd-nav-sep">·</span>
       <a href="/publish" class="cd-nav-link">COCKPIT</a>
     </nav>
   </header>

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -137,6 +137,10 @@
                         data-item-id="{{ item.id }}"
                         data-slug="{{ project.slug }}">
                       <label>{{ item.text }}</label>
+                      <button class="cd-today-star cd-tt-tag-item{% if item.today %} starred{% endif %}"
+                              data-kind="item" data-id="{{ item.id }}"
+                              title="{% if item.today %}Remove from Today{% else %}Add to Today{% endif %}"
+                              type="button">{{ '★' if item.today else '☆' }}</button>
                       {% if project.tracking_enabled %}
                         <span class="cd-tt-today-tag cd-tt-tag-item" data-item-today-tag="{{ item.id }}" hidden></span>
                         <span class="cd-tt-lifetime-tag cd-tt-tag-item" data-item-lifetime-tag="{{ item.id }}"
@@ -180,6 +184,10 @@
                 <li class="cd-task-item" data-id="{{ task.id }}" data-task-title="{{ task.title }}">
                   <input type="checkbox" class="cd-task-check project-task-check" data-id="{{ task.id }}" data-slug="{{ project.slug }}">
                   <span class="cd-task-title">{{ task.title }}</span>
+                  <button class="cd-today-star{% if task.today %} starred{% endif %}"
+                          data-kind="task" data-id="{{ task.id }}"
+                          title="{% if task.today %}Remove from Today{% else %}Add to Today{% endif %}"
+                          type="button">{{ '★' if task.today else '☆' }}</button>
                   {% if project.tracking_enabled %}
                     <span class="cd-tt-today-tag" data-task-today-tag="{{ task.id }}" hidden></span>
                     <span class="cd-tt-lifetime-tag" data-task-lifetime-tag="{{ task.id }}"
@@ -685,6 +693,7 @@ document.getElementById('blocksContainer').addEventListener('click', function(e)
       li.dataset.itemText=data.item.text;
       // Phase 1.5: emit the same ⏱ markup Jinja would render, so newly-added
       // items are tracker-aware without a page reload.
+      const starMarkup = `<button class="cd-today-star cd-tt-tag-item" data-kind="item" data-id="${data.item.id}" title="Add to Today" type="button">☆</button>`;
       const ttMarkup = (typeof PROJECT_TRACKING !== 'undefined' && PROJECT_TRACKING)
         ? `<span class="cd-tt-today-tag cd-tt-tag-item" data-item-today-tag="${data.item.id}" hidden></span>
            <span class="cd-tt-lifetime-tag cd-tt-tag-item" data-item-lifetime-tag="${data.item.id}" hidden></span>
@@ -693,6 +702,7 @@ document.getElementById('blocksContainer').addEventListener('click', function(e)
       li.innerHTML=`
         <input type="checkbox" data-item-id="${data.item.id}" data-slug="${PROJECT_SLUG}">
         <label>${escapeHtml(data.item.text)}</label>
+        ${starMarkup}
         ${ttMarkup}
         <button class="cd-btn ghost sm checklist-item-delete" data-id="${data.item.id}" data-slug="${PROJECT_SLUG}">✕</button>`;
       ul.appendChild(li);
@@ -740,6 +750,7 @@ document.getElementById('blocksContainer').addEventListener('click', function(e)
       // Phase 1.5: dynamically-added rows must include the same ⏱ button +
       // today-tag markup that Jinja emits, otherwise tasks added without a
       // page reload won't be tracker-aware.
+      const starMarkup = `<button class="cd-today-star" data-kind="task" data-id="${data.task.id}" title="Add to Today" type="button">☆</button>`;
       const ttMarkup = (typeof PROJECT_TRACKING !== 'undefined' && PROJECT_TRACKING)
         ? `<span class="cd-tt-today-tag" data-task-today-tag="${data.task.id}" hidden></span>
            <span class="cd-tt-lifetime-tag" data-task-lifetime-tag="${data.task.id}" hidden></span>
@@ -749,6 +760,7 @@ document.getElementById('blocksContainer').addEventListener('click', function(e)
         <input type="checkbox" class="cd-task-check project-task-check"
           data-id="${data.task.id}" data-slug="${PROJECT_SLUG}">
         <span class="cd-task-title">${escapeHtml(data.task.title)}</span>
+        ${starMarkup}
         ${ttMarkup}
         <button class="cd-task-edit" data-id="${data.task.id}" title="Edit">✎</button>
         <button class="cd-btn ghost sm project-task-delete"
@@ -1814,6 +1826,42 @@ function cdEditTask(id) {
       const sig = entries.filter(function (e) { return String(e.project_id) === String(PROJECT_ID); }).length;
       if (sig !== lastSig) { lastSig = sig; syncTodayTags(); }
     });
+  });
+})();
+
+// ============================================================
+// PHASE 2.1 — ★ Today toggle on task + checklist-item rows
+// ============================================================
+(function () {
+  'use strict';
+  document.addEventListener('click', function (ev) {
+    const btn = ev.target.closest('.cd-today-star');
+    if (!btn) return;
+    ev.preventDefault();
+    const kind = btn.getAttribute('data-kind');  // 'task' or 'item'
+    const id = btn.getAttribute('data-id');
+    if (!kind || !id) return;
+    const wasStarred = btn.classList.contains('starred');
+    // Optimistic UI flip
+    btn.classList.toggle('starred', !wasStarred);
+    btn.textContent = !wasStarred ? '★' : '☆';
+    btn.title = !wasStarred ? 'Remove from Today' : 'Add to Today';
+    const fd = new FormData();
+    fd.append(kind === 'item' ? 'item_id' : 'task_id', id);
+    fetch('/today/star', { method: 'POST', body: fd, credentials: 'same-origin' })
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (!data || !data.success) {
+          btn.classList.toggle('starred', wasStarred);
+          btn.textContent = wasStarred ? '★' : '☆';
+          btn.title = wasStarred ? 'Remove from Today' : 'Add to Today';
+        }
+      })
+      .catch(function () {
+        btn.classList.toggle('starred', wasStarred);
+        btn.textContent = wasStarred ? '★' : '☆';
+        btn.title = wasStarred ? 'Remove from Today' : 'Add to Today';
+      });
   });
 })();
 </script>

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -29,6 +29,8 @@
       <span class="cd-nav-sep">·</span>
       <a href="/today/" class="cd-nav-link">TODAY</a>
       <span class="cd-nav-sep">·</span>
+      <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
+      <span class="cd-nav-sep">·</span>
       <a href="/publish" class="cd-nav-link">COCKPIT</a>
     </nav>
   </header>

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -1434,8 +1434,13 @@ function cdEditTask(id) {
           : ' type="button" data-entry-id="' + e.id + '"';
         if (e.task_title) {
           contextBadge = '<' + triggerTag + ' class="' + triggerCls + ' task"' + triggerAttrs + '>[task: ' + escHtml(e.task_title) + ']' + (isRunning ? '' : ' ▾') + '</' + triggerTag + '>';
-        } else if (e.checklist_item_text) {
-          contextBadge = '<' + triggerTag + ' class="' + triggerCls + ' item"' + triggerAttrs + '>[item: ' + escHtml(e.checklist_item_text) + ']' + (isRunning ? '' : ' ▾') + '</' + triggerTag + '>';
+        } else if (e.checklist_item_id) {
+          // Phase 2.1: prefer block-title as the deliverable identity. Falls
+          // back to plain [Checklist] when the parent block has no title.
+          const blockLabel = e.block_title
+            ? 'Checklist: ' + escHtml(e.block_title)
+            : 'Checklist';
+          contextBadge = '<' + triggerTag + ' class="' + triggerCls + ' item"' + triggerAttrs + '>[' + blockLabel + ']' + (isRunning ? '' : ' ▾') + '</' + triggerTag + '>';
         } else if (!isRunning) {
           contextBadge = '<button type="button" class="cd-tt-entry-context cd-tt-assign-trigger unassigned" data-entry-id="' + e.id + '">[+ assign ▾]</button>';
         } else {

--- a/templates/command_deck_projects.html
+++ b/templates/command_deck_projects.html
@@ -27,6 +27,8 @@
       <span class="cd-nav-sep">·</span>
       <a href="/today/" class="cd-nav-link">TODAY</a>
       <span class="cd-nav-sep">·</span>
+      <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
+      <span class="cd-nav-sep">·</span>
       <a href="/publish" class="cd-nav-link">COCKPIT</a>
     </nav>
   </header>

--- a/templates/includes/active_timer_strip.html
+++ b/templates/includes/active_timer_strip.html
@@ -252,7 +252,14 @@
       var desc = e.description || e.project_title || '';
       var ctx = '';
       if (e.task_title) ctx = '<span class="tt-row-ctx">[task: ' + escHtml(e.task_title) + ']</span>';
-      else if (e.checklist_item_text) ctx = '<span class="tt-row-ctx">[item: ' + escHtml(e.checklist_item_text) + ']</span>';
+      else if (e.checklist_item_id) {
+        // Phase 2.1: block title is the deliverable identity. Fall back
+        // to plain [Checklist] when the block has no title.
+        var blockLabel = e.block_title
+          ? 'Checklist: ' + escHtml(e.block_title)
+          : 'Checklist';
+        ctx = '<span class="tt-row-ctx">[' + blockLabel + ']</span>';
+      }
       return '<div class="tt-row" data-id="' + e.id + '">' +
         '<span class="tt-row-dot" style="background:' + color + ';"></span>' +
         '<span class="tt-row-area">' + escHtml(areaName) + '</span>' +

--- a/templates/includes/today_panel.html
+++ b/templates/includes/today_panel.html
@@ -180,6 +180,14 @@
   color: rgba(212, 136, 10, 0.3);
   white-space: nowrap;
 }
+/* Phase 2.1 — block-title prefix on item rows in the Today panel */
+.today-task-block-context {
+  font-family: 'Share Tech Mono', 'Courier New', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.05em;
+  color: rgba(212, 136, 10, 0.55);
+  text-transform: uppercase;
+}
 .today-check-btn {
   width: 16px;
   height: 16px;
@@ -419,36 +427,51 @@
     }
     var html = '';
     open.forEach(function(t) {
-      var source = t.project_title || 'Below Deck';
-      html += '<div class="today-task-row" data-id="' + t.id + '">' +
-        '<button class="today-check-btn" data-id="' + t.id + '" title="Mark complete">' +
-          '<svg viewBox="0 0 12 10"><polyline points="1.5,5 4.5,8.5 10.5,1.5"/></svg>' +
-        '</button>' +
-        '<span class="today-task-title">' + escHtml(t.title) + '</span>' +
-        '<span class="today-task-source">' + escHtml(source) + '</span>' +
-        '</div>';
+      html += todayRowMarkup(t, false);
     });
     done.forEach(function(t) {
-      var source = t.project_title || 'Below Deck';
-      html += '<div class="today-task-row is-done" data-id="' + t.id + '">' +
-        '<button class="today-check-btn checked" disabled title="Completed">' +
-          '<svg viewBox="0 0 12 10"><polyline points="1.5,5 4.5,8.5 10.5,1.5"/></svg>' +
-        '</button>' +
-        '<span class="today-task-title">' + escHtml(t.title) + '</span>' +
-        '<span class="today-task-source">' + escHtml(source) + '</span>' +
-        '</div>';
+      html += todayRowMarkup(t, true);
     });
     body.innerHTML = html;
     body.querySelectorAll('.today-check-btn:not([disabled])').forEach(function(btn) {
-      btn.addEventListener('click', function() { completeTask(btn.getAttribute('data-id'), btn); });
+      btn.addEventListener('click', function() {
+        completeRow(btn.getAttribute('data-kind'), btn.getAttribute('data-id'), btn);
+      });
     });
   }
 
-  function completeTask(id, btn) {
+  function todayRowMarkup(entry, isDone) {
+    // Phase 2.1 — entry.kind is 'task' or 'item'. Tasks use entry.title;
+    // items use entry.text prefixed by the parent block title (or plain
+    // "Checklist" when blocks.title is null).
+    var kind = entry.kind || 'task';
+    var source = entry.project_title || 'Below Deck';
+    var titleHtml;
+    if (kind === 'item') {
+      var blockLabel = entry.block_title
+        ? escHtml(entry.block_title)
+        : 'Checklist';
+      titleHtml = '<span class="today-task-block-context">' + blockLabel + ' · </span>' + escHtml(entry.text);
+    } else {
+      titleHtml = escHtml(entry.title);
+    }
+    var btnAttrs = 'data-id="' + entry.id + '" data-kind="' + kind + '"';
+    var btnInner = '<svg viewBox="0 0 12 10"><polyline points="1.5,5 4.5,8.5 10.5,1.5"/></svg>';
+    var btnHtml = isDone
+      ? '<button class="today-check-btn checked" disabled title="Completed">' + btnInner + '</button>'
+      : '<button class="today-check-btn" ' + btnAttrs + ' title="Mark complete">' + btnInner + '</button>';
+    return '<div class="today-task-row' + (isDone ? ' is-done' : '') + '" data-id="' + entry.id + '" data-kind="' + kind + '">' +
+      btnHtml +
+      '<span class="today-task-title">' + titleHtml + '</span>' +
+      '<span class="today-task-source">' + escHtml(source) + '</span>' +
+      '</div>';
+  }
+
+  function completeRow(kind, id, btn) {
     btn.classList.add('checked');
     btn.disabled = true;
     var fd = new FormData();
-    fd.append('id', id);
+    fd.append(kind === 'item' ? 'item_id' : 'task_id', id);
     fetch('/today/complete', { method: 'POST', body: fd })
       .then(function(r) { return r.json(); })
       .then(function(data) {

--- a/templates/today.html
+++ b/templates/today.html
@@ -153,7 +153,8 @@
     currentCount = n;
     var el = document.getElementById('todayCountLabel');
     if (el) {
-      el.textContent = n === 1 ? '1 task selected' : n + ' tasks selected';
+      // Phase 2.1 — today_open mixes tasks and items; label now reflects both.
+      el.textContent = n === 1 ? '1 item selected' : n + ' items selected';
     }
   }
 
@@ -171,8 +172,13 @@
   }
 
   function renderMasterList(belowDeck, projects, todayOpen) {
+    // Phase 2.1 — todayOpen now mixes tasks AND items (kind discriminator).
+    // The master browse is task-only, so build the lookup from task entries
+    // only to avoid task-id vs item-id collisions.
     var todayIds = {};
-    todayOpen.forEach(function(t) { todayIds[t.id] = true; });
+    todayOpen.forEach(function(t) {
+      if ((t.kind || 'task') === 'task') todayIds[t.id] = true;
+    });
 
     var totalTasks = belowDeck.length + projects.reduce(function(s, p) { return s + p.tasks.length; }, 0);
 

--- a/templates/today.html
+++ b/templates/today.html
@@ -27,6 +27,8 @@
       <span class="cd-nav-sep">·</span>
       <a href="/today/" class="cd-nav-link active">TODAY</a>
       <span class="cd-nav-sep">·</span>
+      <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
+      <span class="cd-nav-sep">·</span>
       <a href="/publish" class="cd-nav-link">COCKPIT</a>
     </nav>
   </header>


### PR DESCRIPTION
## Summary

Phase 2.1 closes the "checklist items behave like tasks in every manner" principle by elevating items to first-class Today citizens and tightening the deliverable identity that surfaces on timer entries. Spec: `.kt/spec-time-tracking-phase-2-1.md`.

Five commits, in order:

1. **`chore(db)`** — `checklist_items.today INTEGER NOT NULL DEFAULT 0` via new idempotent migration. Same semantics as `tasks.today`.
2. **`feat(today)` backend** — `/today/star`, `/today/complete`, `/today/data`, and `/today/count` all accept `task_id` OR `item_id`. Auto-clear pass clears `today=0` on every checked item past 4am ET (sloppy v1 behavior addressed by Phase 2.2's `checked_at` column).
3. **`feat(time-tracking)` block-title context badges** — backend serializers JOIN through `blocks`; `[item: <text>]` becomes `[Checklist: <block.title>]` (or plain `[Checklist]` when null) across the project page today's-time list, active timer strip, floating panel rows, and reports entries table. Re-assign dropdown unchanged — still lists items by their text since you're picking which item.
4. **`feat(today)` UI** — ★ on task rows (closes the gap noted during planning — tasks couldn't be starred from project page before) AND on checklist item rows. Today panel renders mixed task+item rows with block-title prefixed item titles. Subtle correctness fixes to `/today/` master browse so item-id vs task-id collisions don't false-positive on starred state. Count label reads "N items selected" since the list mixes both kinds.
5. **`feat(nav)`** — REPORTS in main CD nav across dashboard, projects, project detail, area, and today pages.

## Decisions locked during planning

| # | Decision | Pick |
|---|---|---|
| 1 | Items in Today: full task parity? | Yes — schema, routes, all UI surfaces |
| 2 | Block-title badge: show item text too? | No — block title alone is the badge |
| 3 | No-title block — render? | Plain `[Checklist]` |
| 4 | Auto-clear at 4am ET | Mirror tasks (sloppy for items in v1; tightened in Phase 2.2 via `checked_at`) |
| 5 | Star UI for items + parity for tasks | ★ on the item row AND task row in project page (parallels existing ⏱ density rule); also via /today/ |
| 6 | Today list display | Unified mixed list, peers (no section split) |
| 7 | Item check + Today | Auto-stops running timer (Phase 1.5 behavior); rolls off Today at next 4am |

## Test plan

Verified locally during build:
- [x] Migration idempotent across two runs; `PRAGMA table_info` confirms column with INTEGER NOT NULL DEFAULT 0
- [x] `/today/star` accepts `task_id`, `item_id`, legacy `id` (= task_id); rejects both fields together with 400 task_or_item_not_both; rejects neither with 400 task_id_or_item_id_required; 404 on nonexistent
- [x] `/today/data` returns mixed `kind: 'task'` and `kind: 'item'` rows with appropriate context (block_title, project_title)
- [x] `/today/count` combined open count (tasks + items)
- [x] `/today/complete` with item_id checks the item; autoclear pass rolls off checked items past 4am
- [x] `block_title` resolves correctly through all three backend payloads (`/time/active`, `/time/today/<project>`, `/command-deck/reports/data`); both titled and untitled blocks tested
- [x] Project page renders ★ on task and item rows when `today=1`, `cd-today-star` CSS present
- [x] Today panel renderer has `todayRowMarkup()` with block_title branch
- [x] /today/ count label reads "items selected"
- [x] All six CD pages (dashboard, projects, project, area, today, reports) render REPORTS in main nav
- [x] Aaron eyeballed all surfaces during local testing — "testing so good, so so good"

After merge:
- [ ] On PA: `git pull origin main && python migrate_add_today_on_items.py && reload web app`

## KT doc sweep (gitignored, local-only — bundled into the PR body since the docs aren't tracked)

- `.kt/spec-time-tracking-phase-2-1.md` — Status: ✅ Shipped 2026-05-05; bumped Last updated
- `.kt/KT-command-deck.md` — `checklist_items.today` documented in schema; new migration listed in setup; Last updated bumped; Deferred Features marks 2.1 as ✅
- `.kt/PROJECT_KNOWLEDGE.md` — Today description rewritten to include items; Last updated bumped
- `.kt/KT-cockpit.md` — block-title context note on panel rows; Last updated bumped

There's no 5th doc-only commit because all `.kt/` docs are gitignored — that commit would have been empty, and rebase-merge drops empty commits.

## What's next

Phase 2.2 (queued — Aaron has use of those features today) — `blocks.today` for block-level Today citizens + `checklist_items.checked_at` for stricter 4am autoclear. Spec: `.kt/spec-time-tracking-phase-2-2.md`.

## Merge strategy

Rebase-merge / fast-forward only. Five commits in narrative order, Han Solo voice runs through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)