### PR TITLE
Phase 2.2 — block-level Today + checked_at + area grouping

### DIFF
--- a/blueprints/command_deck.py
+++ b/blueprints/command_deck.py
@@ -644,7 +644,16 @@ def cd_checklist_toggle(slug, item_id):
 	item = conn.execute('SELECT * FROM checklist_items WHERE id = ?', (item_id,)).fetchone()
 	if item:
 		new_state = 0 if item['checked'] else 1
-		conn.execute('UPDATE checklist_items SET checked = ? WHERE id = ?', (new_state, item_id))
+		# Phase 2.2 — stamp checked_at on check, clear on uncheck. Drives the
+		# tightened 4am autoclear query (see blueprints/today.py).
+		checked_at = (
+			datetime.now(pytz.UTC).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+			if new_state else None
+		)
+		conn.execute(
+			'UPDATE checklist_items SET checked = ?, checked_at = ? WHERE id = ?',
+			(new_state, checked_at, item_id)
+		)
 
 		project = conn.execute('SELECT * FROM projects WHERE slug = ?', (slug,)).fetchone()
 		if project:

--- a/blueprints/today.py
+++ b/blueprints/today.py
@@ -1,9 +1,9 @@
-"""Today blueprint — daily focus master view + per-task/item star/complete + 4am ET auto-clear.
+"""Today blueprint — daily focus master view + per-task/item/block star/complete + 4am ET auto-clear.
 
-Phase 2.1 (.kt/spec-time-tracking-phase-2-1.md): checklist items are first-
-class Today citizens alongside tasks. /today/star, /today/complete, and
-/today/data all accept task_id OR item_id (mutually exclusive); the
-auto-clear pass clears today=0 on checked items past 4am ET.
+Phase 2.1 (.kt/spec-time-tracking-phase-2-1.md): checklist items as Today
+citizens. Phase 2.2 (.kt/spec-time-tracking-phase-2-2.md): blocks join the
+party as their own peer rows; checklist_items.checked_at stamped on every
+toggle drives a precise (vs sloppy) 4am autoclear cutoff.
 """
 from datetime import datetime, timedelta
 import pytz
@@ -11,6 +11,13 @@ from flask import Blueprint, request, redirect, url_for, jsonify, render_templat
 
 from helpers.auth import is_authenticated
 from helpers.db import get_db, et_now
+
+
+_UTC_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
+
+
+def _utc_now_iso():
+	return datetime.now(pytz.UTC).strftime(_UTC_FORMAT)
 
 
 today_bp = Blueprint('today', __name__)
@@ -21,11 +28,14 @@ def _today_autoclear(conn):
 
 	Tasks: cleared when status='completed' AND completed_date < today's
 	       4am ET cutoff.
-	Items: cleared when checked=1, simply rolled off at every autoclear
-	       pass past 4am. checklist_items has no checked_at column yet
-	       (Phase 2.2 adds it for stricter timing) — for v1, accept the
-	       sloppiness: an item checked at 11pm + starred at 11:55pm
-	       would lose the star at 4am. Documented in spec §5.5.
+	Items (Phase 2.2): cleared when checked=1 AND checked_at IS NOT NULL
+	       AND checked_at < UTC(4am ET cutoff). Items with NULL
+	       checked_at survive — we don't know when they were checked,
+	       so we don't presume.
+	Blocks (Phase 2.2): cleared when (a) the block has at least one
+	       item, (b) every item is checked, AND (c) every item's
+	       checked_at is non-null AND before the 4am cutoff. Empty
+	       starred blocks persist (no surprise removal).
 	"""
 	eastern = pytz.timezone('US/Eastern')
 	now_et = datetime.now(eastern)
@@ -33,7 +43,14 @@ def _today_autoclear(conn):
 		cutoff_date = (now_et - timedelta(days=1)).strftime('%Y-%m-%d')
 	else:
 		cutoff_date = now_et.strftime('%Y-%m-%d')
-	cutoff = f"{cutoff_date}T04:00:00"
+	# Tasks compare against an ET-local string (their completed_date is also
+	# stored as an ET-local ISO from et_now()). Items compare against UTC
+	# (their checked_at is stored in UTC by the toggle handler).
+	cutoff_et = f"{cutoff_date}T04:00:00"
+	cutoff_utc_dt = eastern.localize(
+		datetime.strptime(cutoff_et, '%Y-%m-%dT%H:%M:%S')
+	).astimezone(pytz.UTC)
+	cutoff_utc = cutoff_utc_dt.strftime(_UTC_FORMAT)
 
 	conn.execute('''
 		UPDATE tasks SET today = 0
@@ -41,11 +58,35 @@ def _today_autoclear(conn):
 		  AND status = 'completed'
 		  AND completed_date IS NOT NULL
 		  AND completed_date < ?
-	''', (cutoff,))
+	''', (cutoff_et,))
 	conn.execute('''
 		UPDATE checklist_items SET today = 0
-		WHERE today = 1 AND checked = 1
-	''')
+		WHERE today = 1
+		  AND checked = 1
+		  AND checked_at IS NOT NULL
+		  AND checked_at < ?
+	''', (cutoff_utc,))
+	conn.execute('''
+		UPDATE blocks SET today = 0
+		WHERE today = 1
+		  AND id IN (
+		    SELECT b.id FROM blocks b
+		    WHERE b.today = 1
+		      AND EXISTS (
+		        SELECT 1 FROM checklist_items ci WHERE ci.block_id = b.id
+		      )
+		      AND NOT EXISTS (
+		        SELECT 1 FROM checklist_items ci
+		        WHERE ci.block_id = b.id AND ci.checked = 0
+		      )
+		      AND NOT EXISTS (
+		        SELECT 1 FROM checklist_items ci
+		        WHERE ci.block_id = b.id
+		          AND ci.checked = 1
+		          AND (ci.checked_at IS NULL OR ci.checked_at >= ?)
+		      )
+		  )
+	''', (cutoff_utc,))
 	conn.commit()
 
 
@@ -264,7 +305,13 @@ def today_complete():
 		if not item:
 			conn.close()
 			return jsonify({'error': 'not_found'}), 404
-		conn.execute('UPDATE checklist_items SET checked = 1 WHERE id = ?', (item_id,))
+		# Phase 2.2 — stamp checked_at parallel to the project-page toggle
+		# handler so the autoclear precision works regardless of which
+		# surface the item gets checked from.
+		conn.execute(
+			'UPDATE checklist_items SET checked = 1, checked_at = ? WHERE id = ?',
+			(_utc_now_iso(), item_id)
+		)
 		conn.execute(
 			'UPDATE projects SET updated = ? WHERE id = ?',
 			(now, item['project_id'])

--- a/blueprints/today.py
+++ b/blueprints/today.py
@@ -194,6 +194,9 @@ def today_data():
 			today_blocks_open.append(d)
 
 	# Master browse — Below Deck (project_id NULL) + per-project task lists
+	# Phase 2.2 fix: each project group now also surfaces its checklist
+	# blocks + open items so they can be starred from /today/ alongside
+	# tasks. Items already-checked are excluded (no action to take).
 	below_deck_tasks = conn.execute('''
 		SELECT id, title, status, today, project_id
 		FROM tasks
@@ -211,11 +214,37 @@ def today_data():
 			WHERE project_id = ? AND status = 'open'
 			ORDER BY "order" ASC, id ASC
 		''', (proj['id'],)).fetchall()
-		if tasks:
+		# Phase 2.2 — per-project checklist blocks (open items only)
+		blocks_raw = conn.execute('''
+			SELECT b.id, b.title, b.today,
+			       (SELECT COUNT(*) FROM checklist_items ci WHERE ci.block_id = b.id) AS total_count,
+			       (SELECT COUNT(*) FROM checklist_items ci WHERE ci.block_id = b.id AND ci.checked = 1) AS checked_count
+			FROM blocks b
+			WHERE b.project_id = ? AND b.type = 'checklist'
+			ORDER BY b.id ASC
+		''', (proj['id'],)).fetchall()
+		blocks_with_items = []
+		for b in blocks_raw:
+			b_dict = dict(b)
+			b_dict['open_count'] = b_dict['total_count'] - b_dict['checked_count']
+			open_items = conn.execute('''
+				SELECT id, text, checked, today, block_id
+				FROM checklist_items
+				WHERE block_id = ? AND checked = 0
+				ORDER BY id ASC
+			''', (b_dict['id'],)).fetchall()
+			b_dict['open_items'] = [dict(i) for i in open_items]
+			# Surface only blocks with at least one open item OR an empty
+			# starred block (the latter for symmetry with the autoclear
+			# rule — empty starred blocks persist).
+			if b_dict['open_items'] or b_dict['today']:
+				blocks_with_items.append(b_dict)
+		if tasks or blocks_with_items:
 			project_groups.append({
 				'title': proj['title'],
 				'slug': proj['slug'],
 				'tasks': [dict(t) for t in tasks],
+				'blocks': blocks_with_items,
 			})
 
 	conn.close()

--- a/blueprints/today.py
+++ b/blueprints/today.py
@@ -126,22 +126,31 @@ def today_data():
 	conn = get_db()
 	_today_autoclear(conn)
 
-	# Today section — open: tasks (status='open') + items (checked=0)
+	# Today section — open: tasks (status='open') + items (checked=0).
+	# All today queries JOIN through to the parent area (when the project
+	# is a work_subproject) so the rendering surfaces can show area context
+	# alongside project context.
 	today_tasks_open = conn.execute('''
 		SELECT t.id, t.title, t.status, t.today, t.project_id,
-		       p.title AS project_title, p.slug AS project_slug
+		       p.title AS project_title, p.slug AS project_slug,
+		       parent.id AS area_id, parent.title AS area_title,
+		       parent.area_color AS area_color
 		FROM tasks t
-		LEFT JOIN projects p ON t.project_id = p.id
+		LEFT JOIN projects p      ON t.project_id = p.id
+		LEFT JOIN projects parent ON p.parent_project_id = parent.id
 		WHERE t.today = 1 AND t.status = 'open'
 		ORDER BY t.id ASC
 	''').fetchall()
 	today_items_open = conn.execute('''
 		SELECT ci.id, ci.text, ci.checked, ci.today, ci.block_id,
 		       b.title AS block_title, b.project_id,
-		       p.title AS project_title, p.slug AS project_slug
+		       p.title AS project_title, p.slug AS project_slug,
+		       parent.id AS area_id, parent.title AS area_title,
+		       parent.area_color AS area_color
 		FROM checklist_items ci
-		JOIN blocks b ON ci.block_id = b.id
-		JOIN projects p ON b.project_id = p.id
+		JOIN blocks b             ON ci.block_id = b.id
+		JOIN projects p           ON b.project_id = p.id
+		LEFT JOIN projects parent ON p.parent_project_id = parent.id
 		WHERE ci.today = 1 AND ci.checked = 0
 		ORDER BY ci.id ASC
 	''').fetchall()
@@ -149,19 +158,25 @@ def today_data():
 	# Today section — done: completed tasks + checked items still flagged
 	today_tasks_done = conn.execute('''
 		SELECT t.id, t.title, t.status, t.today, t.project_id,
-		       p.title AS project_title, p.slug AS project_slug
+		       p.title AS project_title, p.slug AS project_slug,
+		       parent.id AS area_id, parent.title AS area_title,
+		       parent.area_color AS area_color
 		FROM tasks t
-		LEFT JOIN projects p ON t.project_id = p.id
+		LEFT JOIN projects p      ON t.project_id = p.id
+		LEFT JOIN projects parent ON p.parent_project_id = parent.id
 		WHERE t.today = 1 AND t.status = 'completed'
 		ORDER BY t.completed_date DESC
 	''').fetchall()
 	today_items_done = conn.execute('''
 		SELECT ci.id, ci.text, ci.checked, ci.today, ci.block_id,
 		       b.title AS block_title, b.project_id,
-		       p.title AS project_title, p.slug AS project_slug
+		       p.title AS project_title, p.slug AS project_slug,
+		       parent.id AS area_id, parent.title AS area_title,
+		       parent.area_color AS area_color
 		FROM checklist_items ci
-		JOIN blocks b ON ci.block_id = b.id
-		JOIN projects p ON b.project_id = p.id
+		JOIN blocks b             ON ci.block_id = b.id
+		JOIN projects p           ON b.project_id = p.id
+		LEFT JOIN projects parent ON p.parent_project_id = parent.id
 		WHERE ci.today = 1 AND ci.checked = 1
 		ORDER BY ci.id DESC
 	''').fetchall()
@@ -174,10 +189,13 @@ def today_data():
 	today_blocks = conn.execute('''
 		SELECT b.id, b.title, b.today, b.project_id,
 		       p.title AS project_title, p.slug AS project_slug,
+		       parent.id AS area_id, parent.title AS area_title,
+		       parent.area_color AS area_color,
 		       (SELECT COUNT(*) FROM checklist_items ci WHERE ci.block_id = b.id) AS total_count,
 		       (SELECT COUNT(*) FROM checklist_items ci WHERE ci.block_id = b.id AND ci.checked = 1) AS checked_count
 		FROM blocks b
-		JOIN projects p ON b.project_id = p.id
+		JOIN projects p           ON b.project_id = p.id
+		LEFT JOIN projects parent ON p.parent_project_id = parent.id
 		WHERE b.today = 1 AND b.type = 'checklist'
 		ORDER BY b.id ASC
 	''').fetchall()
@@ -193,28 +211,32 @@ def today_data():
 		else:
 			today_blocks_open.append(d)
 
-	# Master browse — Below Deck (project_id NULL) + per-project task lists
-	# Phase 2.2 fix: each project group now also surfaces its checklist
-	# blocks + open items so they can be starred from /today/ alongside
-	# tasks. Items already-checked are excluded (no action to take).
+	# Master browse — Below Deck (project_id NULL) +
+	# per-area groups for work sub-projects + Personal group.
+	# Each project carries tasks + checklist blocks (with open items).
 	below_deck_tasks = conn.execute('''
 		SELECT id, title, status, today, project_id
 		FROM tasks
 		WHERE project_id IS NULL AND status = 'open'
 		ORDER BY "order" ASC, id ASC
 	''').fetchall()
-	projects = conn.execute(
-		'SELECT id, title, slug FROM projects ORDER BY title ASC'
-	).fetchall()
-	project_groups = []
-	for proj in projects:
+	all_projects = conn.execute('''
+		SELECT p.id, p.title, p.slug, p.project_type, p.parent_project_id,
+		       parent.title AS area_title, parent.slug AS area_slug,
+		       parent.area_color AS area_color
+		FROM projects p
+		LEFT JOIN projects parent ON p.parent_project_id = parent.id
+		WHERE p.project_type IN ('personal', 'work_subproject')
+		ORDER BY parent.title ASC, p.title ASC
+	''').fetchall()
+
+	def _project_payload(proj):
 		tasks = conn.execute('''
 			SELECT id, title, status, today, project_id
 			FROM tasks
 			WHERE project_id = ? AND status = 'open'
 			ORDER BY "order" ASC, id ASC
 		''', (proj['id'],)).fetchall()
-		# Phase 2.2 — per-project checklist blocks (open items only)
 		blocks_raw = conn.execute('''
 			SELECT b.id, b.title, b.today,
 			       (SELECT COUNT(*) FROM checklist_items ci WHERE ci.block_id = b.id) AS total_count,
@@ -234,18 +256,44 @@ def today_data():
 				ORDER BY id ASC
 			''', (b_dict['id'],)).fetchall()
 			b_dict['open_items'] = [dict(i) for i in open_items]
-			# Surface only blocks with at least one open item OR an empty
-			# starred block (the latter for symmetry with the autoclear
-			# rule — empty starred blocks persist).
+			# Empty unstarred blocks excluded; starred blocks always shown
+			# (consistent with autoclear rule that empty starred blocks
+			# persist).
 			if b_dict['open_items'] or b_dict['today']:
 				blocks_with_items.append(b_dict)
-		if tasks or blocks_with_items:
-			project_groups.append({
-				'title': proj['title'],
-				'slug': proj['slug'],
-				'tasks': [dict(t) for t in tasks],
-				'blocks': blocks_with_items,
-			})
+		return tasks, blocks_with_items
+
+	# Group sub-projects by their parent area; personal projects in their own bucket.
+	area_groups_by_id = {}      # area_id → {area_title, area_color, area_slug, projects: []}
+	personal_projects = []
+	for proj in all_projects:
+		tasks, blocks = _project_payload(proj)
+		if not tasks and not blocks:
+			continue
+		entry = {
+			'title': proj['title'],
+			'slug': proj['slug'],
+			'tasks': [dict(t) for t in tasks],
+			'blocks': blocks,
+		}
+		if proj['project_type'] == 'work_subproject':
+			aid = proj['parent_project_id']
+			if aid not in area_groups_by_id:
+				area_groups_by_id[aid] = {
+					'area_id': aid,
+					'area_title': proj['area_title'] or 'Work',
+					'area_slug': proj['area_slug'],
+					'area_color': proj['area_color'] or '',
+					'projects': [],
+				}
+			area_groups_by_id[aid]['projects'].append(entry)
+		else:
+			personal_projects.append(entry)
+
+	# Stable area order — alpha by title (mirrors the dashboard's area list).
+	area_groups = sorted(
+		area_groups_by_id.values(), key=lambda g: g['area_title']
+	)
 
 	conn.close()
 
@@ -267,7 +315,7 @@ def today_data():
 
 	return jsonify({
 		# Mixed lists — kind='task' / 'item' / 'block' on each entry.
-		# Renderers branch on kind to draw the right row shape.
+		# Each carries area_title + area_color when under a sub-project.
 		'today_open': (
 			[_serialize_task(r) for r in today_tasks_open] +
 			[_serialize_item(r) for r in today_items_open] +
@@ -279,7 +327,17 @@ def today_data():
 			[_serialize_block(r) for r in today_blocks_done]
 		),
 		'below_deck': [dict(t) for t in below_deck_tasks],
-		'projects': project_groups,
+		# Phase 2.2 — master browse grouped by parent area for sub-projects;
+		# personal projects in their own bucket. Below Deck stays its own
+		# top-level group above all of this.
+		'area_groups': area_groups,
+		'personal_projects': personal_projects,
+		# Backward-compat: legacy 'projects' field kept for any consumer
+		# still expecting flat per-project shape. Equals area_groups
+		# flattened + personal_projects appended.
+		'projects': [
+			p for ag in area_groups for p in ag['projects']
+		] + personal_projects,
 	})
 
 

--- a/blueprints/today.py
+++ b/blueprints/today.py
@@ -100,7 +100,9 @@ def today_page():
 
 @today_bp.route('/today/count')
 def today_count():
-	"""Open today count — tasks + items combined for the global pill."""
+	"""Open today count — tasks + items + blocks combined for the global pill.
+	Phase 2.2: blocks count too. A starred block contributes 1 regardless of
+	how many items it has."""
 	if not is_authenticated():
 		return jsonify({'count': 0})
 	conn = get_db()
@@ -110,8 +112,11 @@ def today_count():
 	item_count = conn.execute(
 		"SELECT COUNT(*) as cnt FROM checklist_items WHERE today = 1 AND checked = 0"
 	).fetchone()['cnt']
+	block_count = conn.execute(
+		"SELECT COUNT(*) as cnt FROM blocks WHERE today = 1"
+	).fetchone()['cnt']
 	conn.close()
-	return jsonify({'count': task_count + item_count})
+	return jsonify({'count': task_count + item_count + block_count})
 
 
 @today_bp.route('/today/data')
@@ -161,6 +166,33 @@ def today_data():
 		ORDER BY ci.id DESC
 	''').fetchall()
 
+	# Phase 2.2 — block rows. A block row carries title + project context +
+	# a progress triple (total / checked / open). "Open" placement: blocks
+	# with any unchecked items OR no items go in today_open; blocks with
+	# every item checked go in today_done (post-completion limbo until
+	# the autoclear pass on the next 4am rollover).
+	today_blocks = conn.execute('''
+		SELECT b.id, b.title, b.today, b.project_id,
+		       p.title AS project_title, p.slug AS project_slug,
+		       (SELECT COUNT(*) FROM checklist_items ci WHERE ci.block_id = b.id) AS total_count,
+		       (SELECT COUNT(*) FROM checklist_items ci WHERE ci.block_id = b.id AND ci.checked = 1) AS checked_count
+		FROM blocks b
+		JOIN projects p ON b.project_id = p.id
+		WHERE b.today = 1 AND b.type = 'checklist'
+		ORDER BY b.id ASC
+	''').fetchall()
+	today_blocks_open = []
+	today_blocks_done = []
+	for row in today_blocks:
+		d = dict(row)
+		d['open_count'] = d['total_count'] - d['checked_count']
+		# Empty starred blocks count as "open" (something to do — even if just
+		# adding items). Done = at least one item exists AND all are checked.
+		if d['total_count'] > 0 and d['open_count'] == 0:
+			today_blocks_done.append(d)
+		else:
+			today_blocks_open.append(d)
+
 	# Master browse — Below Deck (project_id NULL) + per-project task lists
 	below_deck_tasks = conn.execute('''
 		SELECT id, title, status, today, project_id
@@ -198,16 +230,24 @@ def today_data():
 		d['kind'] = 'item'
 		return d
 
+	def _serialize_block(d):
+		# Already a dict (built above with computed fields)
+		d = dict(d)
+		d['kind'] = 'block'
+		return d
+
 	return jsonify({
-		# Mixed lists — kind='task' or kind='item' on each entry. Renderers
-		# branch on kind to draw the right row shape.
+		# Mixed lists — kind='task' / 'item' / 'block' on each entry.
+		# Renderers branch on kind to draw the right row shape.
 		'today_open': (
 			[_serialize_task(r) for r in today_tasks_open] +
-			[_serialize_item(r) for r in today_items_open]
+			[_serialize_item(r) for r in today_items_open] +
+			[_serialize_block(r) for r in today_blocks_open]
 		),
 		'today_done': (
 			[_serialize_task(r) for r in today_tasks_done] +
-			[_serialize_item(r) for r in today_items_done]
+			[_serialize_item(r) for r in today_items_done] +
+			[_serialize_block(r) for r in today_blocks_done]
 		),
 		'below_deck': [dict(t) for t in below_deck_tasks],
 		'projects': project_groups,
@@ -216,21 +256,24 @@ def today_data():
 
 @today_bp.route('/today/star', methods=['POST'])
 def today_star():
-	"""Toggle the today flag on a task OR a checklist item.
+	"""Toggle the today flag on a task OR a checklist item OR a checklist block.
 
-	Phase 2.1: accepts either task_id or item_id (mutually exclusive).
-	Form-encoded for parity with the existing star UI; either field is
-	picked up via request.form. 400 if neither field present, OR if both."""
+	Phase 2.1: accepts task_id or item_id.
+	Phase 2.2: also accepts block_id. All three mutually exclusive.
+	Form-encoded for parity with existing star UIs; fields picked up via
+	request.form. 400 if zero or 2+ fields, 404 if not found."""
 	if not is_authenticated():
 		return jsonify({'error': 'unauthorized'}), 403
 
-	task_id = request.form.get('task_id') or request.form.get('id')  # legacy fallback
+	task_id = request.form.get('task_id') or request.form.get('id')  # legacy fallback = task
 	item_id = request.form.get('item_id')
+	block_id = request.form.get('block_id')
 
-	if task_id and item_id:
-		return jsonify({'error': 'task_or_item_not_both'}), 400
-	if not task_id and not item_id:
-		return jsonify({'error': 'task_id_or_item_id_required'}), 400
+	provided = [x for x in (task_id, item_id, block_id) if x]
+	if len(provided) > 1:
+		return jsonify({'error': 'one_of_task_item_or_block_only'}), 400
+	if not provided:
+		return jsonify({'error': 'task_id_or_item_id_or_block_id_required'}), 400
 
 	conn = get_db()
 	if task_id:
@@ -240,19 +283,33 @@ def today_star():
 			return jsonify({'error': 'not_found'}), 404
 		new_today = 0 if row['today'] else 1
 		conn.execute('UPDATE tasks SET today = ? WHERE id = ?', (new_today, task_id))
-	else:
+	elif item_id:
 		row = conn.execute('SELECT id, today FROM checklist_items WHERE id = ?', (item_id,)).fetchone()
 		if not row:
 			conn.close()
 			return jsonify({'error': 'not_found'}), 404
 		new_today = 0 if row['today'] else 1
 		conn.execute('UPDATE checklist_items SET today = ? WHERE id = ?', (new_today, item_id))
+	else:
+		# block_id
+		row = conn.execute(
+			"SELECT id, today, type FROM blocks WHERE id = ?", (block_id,)
+		).fetchone()
+		if not row:
+			conn.close()
+			return jsonify({'error': 'not_found'}), 404
+		if row['type'] != 'checklist':
+			conn.close()
+			return jsonify({'error': 'block_not_checklist'}), 400
+		new_today = 0 if row['today'] else 1
+		conn.execute('UPDATE blocks SET today = ? WHERE id = ?', (new_today, block_id))
 
 	conn.commit()
-	# Combined open count for the badge
+	# Combined open count for the badge — tasks + items + blocks
 	count = conn.execute(
 		"SELECT (SELECT COUNT(*) FROM tasks WHERE today = 1 AND status = 'open') + "
-		"       (SELECT COUNT(*) FROM checklist_items WHERE today = 1 AND checked = 0) "
+		"       (SELECT COUNT(*) FROM checklist_items WHERE today = 1 AND checked = 0) + "
+		"       (SELECT COUNT(*) FROM blocks WHERE today = 1) "
 		"AS cnt"
 	).fetchone()['cnt']
 	conn.close()

--- a/migrate_add_today_on_blocks_and_checked_at.py
+++ b/migrate_add_today_on_blocks_and_checked_at.py
@@ -17,10 +17,26 @@ What it does (idempotent — safe to run multiple times):
 
   - Backfill on existing checked items:
       For checklist_items where checked = 1 AND checked_at IS NULL,
-      copy the parent block's `created` timestamp into checked_at.
-      Best-available proxy for "we don't know when this was checked,
-      but it was sometime after the block existed." Future checks
-      stamp accurately.
+      stamp checked_at with a canonical-format sentinel
+      ('1970-01-01T00:00:00.000000Z'). Why a sentinel rather than
+      block.created: blocks.created is ET-localized via et_now()
+      (offset format like '...T10:55:34.021411-04:00'); the autoclear
+      cutoff is canonical UTC ISO ('...T08:00:00.000000Z'). A
+      lexicographic compare between those two formats produces
+      wrong "before cutoff" verdicts. The sentinel sidesteps this
+      by being unambiguously old in any string compare against
+      canonical UTC. Net effect: backfilled items roll off on the
+      first autoclear pass, which is the right behavior for "we
+      don't know when this was checked."
+
+      Future checks stamp via _utc_now_iso() in the toggle handler,
+      always canonical format.
+
+  - Format-repair on already-migrated DBs:
+      If a previous run of this migration stamped checked_at in a
+      non-canonical format (e.g. ET-localized from an earlier
+      script version), re-stamp those rows with the sentinel too.
+      Detected via NOT LIKE '%Z'.
 
 Companion to migrate_add_today_on_items.py (Phase 2.1, which added
 checklist_items.today).
@@ -79,17 +95,24 @@ def run():
 		cur.execute("ALTER TABLE checklist_items ADD COLUMN checked_at TEXT")
 		added.append('checklist_items.checked_at')
 
-	# Backfill — only touches rows that need it. Idempotent: if the column
-	# was just added the predicate matches every checked row; if the column
-	# was already there from a prior run, the WHERE checked_at IS NULL
-	# clause skips already-stamped rows.
+	# Backfill with a canonical-format sentinel so the autoclear lex compare
+	# produces the right verdict. See the docstring for why we don't use
+	# block.created here (different timestamp format).
+	SENTINEL = '1970-01-01T00:00:00.000000Z'
 	backfilled = cur.execute('''
 		UPDATE checklist_items
-		SET checked_at = (
-			SELECT created FROM blocks WHERE blocks.id = checklist_items.block_id
-		)
+		SET checked_at = ?
 		WHERE checked = 1 AND checked_at IS NULL
-	''').rowcount
+	''', (SENTINEL,)).rowcount
+
+	# Format-repair: any row stamped by a previous run of this migration in
+	# a non-canonical format (e.g. ET-localized) gets re-stamped with the
+	# sentinel. Canonical UTC ISO ends with 'Z'; anything else is wrong.
+	repaired = cur.execute('''
+		UPDATE checklist_items
+		SET checked_at = ?
+		WHERE checked_at IS NOT NULL AND checked_at NOT LIKE '%Z'
+	''', (SENTINEL,)).rowcount
 
 	conn.commit()
 	conn.close()
@@ -107,8 +130,10 @@ def run():
 		for item in skipped:
 			print(f"    · {item}")
 	if backfilled:
-		print(f"✓ Backfilled checked_at on {backfilled} existing checked item(s)")
-	if not added and not backfilled:
+		print(f"✓ Backfilled checked_at on {backfilled} existing checked item(s) (sentinel)")
+	if repaired:
+		print(f"✓ Repaired {repaired} non-canonical checked_at value(s) → sentinel")
+	if not added and not backfilled and not repaired:
 		print("No changes — schema already up to date.")
 	print()
 

--- a/migrate_add_today_on_blocks_and_checked_at.py
+++ b/migrate_add_today_on_blocks_and_checked_at.py
@@ -1,0 +1,117 @@
+"""
+migrate_add_today_on_blocks_and_checked_at.py
+Phase 2.2 of the time-tracking spec — see .kt/spec-time-tracking-phase-2-2.md.
+
+What it does (idempotent — safe to run multiple times):
+
+  - blocks.today INTEGER NOT NULL DEFAULT 0
+      Block-level Today flag. A starred block renders as a peer in
+      /today/ with progress (`3/8 done`). Mirrors tasks.today and
+      checklist_items.today.
+
+  - checklist_items.checked_at TEXT
+      Stamps when an item was checked. ISO 8601 UTC with microseconds
+      and Z suffix (matches time_entries.started_at convention).
+      Replaces Phase 2.1's "clear every checked item past 4am"
+      sloppiness with `checked_at < cutoff` precision.
+
+  - Backfill on existing checked items:
+      For checklist_items where checked = 1 AND checked_at IS NULL,
+      copy the parent block's `created` timestamp into checked_at.
+      Best-available proxy for "we don't know when this was checked,
+      but it was sometime after the block existed." Future checks
+      stamp accurately.
+
+Companion to migrate_add_today_on_items.py (Phase 2.1, which added
+checklist_items.today).
+
+Prints a summary. Running it again prints "no changes."
+
+Run from PythonAnywhere bash:
+    cd /home/aaronaiken/status_update
+    python migrate_add_today_on_blocks_and_checked_at.py
+"""
+
+import os
+import sqlite3
+
+DB_FILE = os.path.join(
+	os.environ.get('COCKPIT_REPO_ROOT', '/home/aaronaiken/status_update'),
+	'assets/data/command_deck.db'
+)
+
+
+def column_exists(cur, table, col):
+	cols = [row[1] for row in cur.execute(f"PRAGMA table_info({table})").fetchall()]
+	return col in cols
+
+
+def run():
+	if not os.path.exists(DB_FILE):
+		print(f"× DB not found at {DB_FILE}")
+		print("  Run migrate_to_sqlite.py first.")
+		return
+
+	conn = sqlite3.connect(DB_FILE)
+	cur = conn.cursor()
+
+	for table in ('blocks', 'checklist_items'):
+		exists = cur.execute(
+			"SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+		).fetchone() is not None
+		if not exists:
+			print(f"× {table} table not found. Run migrate_to_sqlite.py first.")
+			conn.close()
+			return
+
+	added = []
+	skipped = []
+
+	if column_exists(cur, 'blocks', 'today'):
+		skipped.append('blocks.today')
+	else:
+		cur.execute("ALTER TABLE blocks ADD COLUMN today INTEGER NOT NULL DEFAULT 0")
+		added.append('blocks.today')
+
+	if column_exists(cur, 'checklist_items', 'checked_at'):
+		skipped.append('checklist_items.checked_at')
+	else:
+		cur.execute("ALTER TABLE checklist_items ADD COLUMN checked_at TEXT")
+		added.append('checklist_items.checked_at')
+
+	# Backfill — only touches rows that need it. Idempotent: if the column
+	# was just added the predicate matches every checked row; if the column
+	# was already there from a prior run, the WHERE checked_at IS NULL
+	# clause skips already-stamped rows.
+	backfilled = cur.execute('''
+		UPDATE checklist_items
+		SET checked_at = (
+			SELECT created FROM blocks WHERE blocks.id = checklist_items.block_id
+		)
+		WHERE checked = 1 AND checked_at IS NULL
+	''').rowcount
+
+	conn.commit()
+	conn.close()
+
+	print()
+	print("Migration: migrate_add_today_on_blocks_and_checked_at.py")
+	print(f"DB:        {DB_FILE}")
+	print()
+	if added:
+		print(f"✓ Added ({len(added)}):")
+		for item in added:
+			print(f"    + {item}")
+	if skipped:
+		print(f"— Already in place ({len(skipped)}):")
+		for item in skipped:
+			print(f"    · {item}")
+	if backfilled:
+		print(f"✓ Backfilled checked_at on {backfilled} existing checked item(s)")
+	if not added and not backfilled:
+		print("No changes — schema already up to date.")
+	print()
+
+
+if __name__ == '__main__':
+	run()

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -114,6 +114,12 @@
                 data-type="{{ block.type }}"
                 data-custom-title="{{ block.title | default('', true) }}">{% if block.title %}{{ block.title }}{% elif block.type == 'note' %}Untitled Note{% else %}Untitled Checklist{% endif %}</span>
               <div class="cd-panel-actions">
+                {% if block.type == 'checklist' %}
+                <button class="cd-today-star{% if block.today %} starred{% endif %}"
+                        data-kind="block" data-id="{{ block.id }}"
+                        title="{% if block.today %}Remove from Today{% else %}Add to Today{% endif %}"
+                        type="button">{{ '★' if block.today else '☆' }}</button>
+                {% endif %}
                 <button class="cd-block-collapse-btn" data-block-id="{{ block.id }}" title="Collapse">▾</button>
                 <button class="cd-btn ghost sm block-delete-btn" data-id="{{ block.id }}">REMOVE</button>
               </div>
@@ -596,6 +602,7 @@ fetch('/below-deck/count').then(r=>r.json()).then(data=>{
             <span class="cd-block-drag-handle" title="Drag to reorder">⠿</span>
             <span class="cd-block-title-display" data-block-id="${block.id}" data-type="checklist" data-custom-title="">${placeholder}</span>
             <div class="cd-panel-actions">
+              <button class="cd-today-star" data-kind="block" data-id="${block.id}" title="Add to Today" type="button">☆</button>
               <button class="cd-block-collapse-btn" data-block-id="${block.id}" title="Collapse">▾</button>
               <button class="cd-btn ghost sm block-delete-btn" data-id="${block.id}">REMOVE</button>
             </div>
@@ -1849,7 +1856,11 @@ function cdEditTask(id) {
     btn.textContent = !wasStarred ? '★' : '☆';
     btn.title = !wasStarred ? 'Remove from Today' : 'Add to Today';
     const fd = new FormData();
-    fd.append(kind === 'item' ? 'item_id' : 'task_id', id);
+    // Phase 2.2 — dispatch by kind: task_id / item_id / block_id
+    var fieldName = 'task_id';
+    if (kind === 'item') fieldName = 'item_id';
+    else if (kind === 'block') fieldName = 'block_id';
+    fd.append(fieldName, id);
     fetch('/today/star', { method: 'POST', body: fd, credentials: 'same-origin' })
       .then(function (r) { return r.json(); })
       .then(function (data) {

--- a/templates/includes/today_panel.html
+++ b/templates/includes/today_panel.html
@@ -188,6 +188,19 @@
   color: rgba(212, 136, 10, 0.55);
   text-transform: uppercase;
 }
+/* Phase 2.2 — block row spacer (no checkbox; block completes
+   implicitly via item checks). Same width as the checkbox so the
+   row stays aligned with task + item rows. */
+.today-block-spacer {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  font-size: 0.85rem;
+  color: rgba(212, 136, 10, 0.45);
+}
 .today-check-btn {
   width: 16px;
   height: 16px;
@@ -441,12 +454,36 @@
   }
 
   function todayRowMarkup(entry, isDone) {
-    // Phase 2.1 — entry.kind is 'task' or 'item'. Tasks use entry.title;
-    // items use entry.text prefixed by the parent block title (or plain
-    // "Checklist" when blocks.title is null).
+    // Phase 2.1: entry.kind is 'task' or 'item'.
+    // Phase 2.2: also 'block' — rendered with progress (`3/8 done`)
+    // and no checkbox (block completes implicitly via item checks).
     var kind = entry.kind || 'task';
     var source = entry.project_title || 'Below Deck';
     var titleHtml;
+    var btnHtml;
+    var btnInner = '<svg viewBox="0 0 12 10"><polyline points="1.5,5 4.5,8.5 10.5,1.5"/></svg>';
+
+    if (kind === 'block') {
+      // Block row: title + progress, no checkbox. Progress is the source-
+      // line content; project title shifts to a small dim suffix line.
+      var blockTitle = entry.title || 'Untitled Checklist';
+      var progressText;
+      if (entry.total_count === 0) {
+        progressText = 'no items';
+      } else {
+        progressText = entry.checked_count + '/' + entry.total_count + ' done';
+      }
+      titleHtml = '<span class="today-task-block-context">CHECKLIST · </span>' + escHtml(blockTitle);
+      // Use a non-clickable spacer in the checkbox slot so the row layout
+      // stays aligned with task and item rows.
+      btnHtml = '<span class="today-block-spacer" aria-hidden="true">▣</span>';
+      return '<div class="today-task-row today-block-row' + (isDone ? ' is-done' : '') + '" data-id="' + entry.id + '" data-kind="block">' +
+        btnHtml +
+        '<span class="today-task-title">' + titleHtml + '</span>' +
+        '<span class="today-task-source">' + escHtml(progressText) + ' · ' + escHtml(source) + '</span>' +
+        '</div>';
+    }
+
     if (kind === 'item') {
       var blockLabel = entry.block_title
         ? escHtml(entry.block_title)
@@ -456,8 +493,7 @@
       titleHtml = escHtml(entry.title);
     }
     var btnAttrs = 'data-id="' + entry.id + '" data-kind="' + kind + '"';
-    var btnInner = '<svg viewBox="0 0 12 10"><polyline points="1.5,5 4.5,8.5 10.5,1.5"/></svg>';
-    var btnHtml = isDone
+    btnHtml = isDone
       ? '<button class="today-check-btn checked" disabled title="Completed">' + btnInner + '</button>'
       : '<button class="today-check-btn" ' + btnAttrs + ' title="Mark complete">' + btnInner + '</button>';
     return '<div class="today-task-row' + (isDone ? ' is-done' : '') + '" data-id="' + entry.id + '" data-kind="' + kind + '">' +

--- a/templates/includes/today_panel.html
+++ b/templates/includes/today_panel.html
@@ -457,8 +457,14 @@
     // Phase 2.1: entry.kind is 'task' or 'item'.
     // Phase 2.2: also 'block' — rendered with progress (`3/8 done`)
     // and no checkbox (block completes implicitly via item checks).
+    // Source line prefixes the area name when the entry sits under a
+    // work sub-project, so the user sees PennDOT · Bridge 47 calc rather
+    // than just Bridge 47 calc.
     var kind = entry.kind || 'task';
-    var source = entry.project_title || 'Below Deck';
+    var projectTitle = entry.project_title || 'Below Deck';
+    var source = entry.area_title
+      ? entry.area_title + ' · ' + projectTitle
+      : projectTitle;
     var titleHtml;
     var btnHtml;
     var btnInner = '<svg viewBox="0 0 12 10"><polyline points="1.5,5 4.5,8.5 10.5,1.5"/></svg>';

--- a/templates/today.html
+++ b/templates/today.html
@@ -144,6 +144,24 @@
 .today-master-row.is-item-indent .today-master-title {
   font-size: 0.72rem;
 }
+/* Phase 2.2 — area-grouped sections in /today/ master browse */
+.today-area-header {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+.today-project-subsection {
+  margin: 4px 0 10px;
+}
+.today-project-header {
+  font-family: var(--cd-font-ui);
+  font-size: 0.55rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--cd-text-dim);
+  padding: 6px 12px 2px;
+  border-bottom: 1px dotted rgba(212, 136, 10, 0.08);
+  margin-bottom: 2px;
+}
 </style>
 
 <script>
@@ -171,7 +189,12 @@
     fetch('/today/data')
       .then(function(r) { return r.json(); })
       .then(function(data) {
-        renderMasterList(data.below_deck || [], data.projects || [], data.today_open || []);
+        renderMasterList(
+          data.below_deck || [],
+          data.area_groups || [],
+          data.personal_projects || [],
+          data.today_open || []
+        );
         updateCountLabel((data.today_open || []).length);
       })
       .catch(function() {
@@ -180,7 +203,7 @@
       });
   }
 
-  function renderMasterList(belowDeck, projects, todayOpen) {
+  function renderMasterList(belowDeck, areaGroups, personalProjects, todayOpen) {
     // Phase 2.1+2.2 — todayOpen mixes tasks/items/blocks. Build per-kind
     // lookups so the starred-state on master rows is unambiguous.
     var todayTaskIds = {};
@@ -193,13 +216,27 @@
       else if (kind === 'block') todayBlockIds[e.id] = true;
     });
 
-    var totalTasks = belowDeck.length + projects.reduce(function(s, p) {
-      var n = (p.tasks || []).length;
-      (p.blocks || []).forEach(function(b) { n += 1 + (b.open_items || []).length; });
-      return s + n;
-    }, 0);
+    function projectHasContent(p) {
+      return (p.tasks || []).length > 0 || (p.blocks || []).length > 0;
+    }
 
-    if (totalTasks === 0) {
+    var totalThings = belowDeck.length;
+    areaGroups.forEach(function(ag) {
+      ag.projects.forEach(function(p) {
+        totalThings += (p.tasks || []).length;
+        (p.blocks || []).forEach(function(b) {
+          totalThings += 1 + (b.open_items || []).length;
+        });
+      });
+    });
+    personalProjects.forEach(function(p) {
+      totalThings += (p.tasks || []).length;
+      (p.blocks || []).forEach(function(b) {
+        totalThings += 1 + (b.open_items || []).length;
+      });
+    });
+
+    if (totalThings === 0) {
       document.getElementById('masterList').innerHTML =
         '<div class="cd-panel"><div class="cd-panel-body"><div class="cd-empty">No open tasks anywhere. You\'re all clear.</div></div></div>';
       return;
@@ -207,7 +244,7 @@
 
     var html = '';
 
-    // Below Deck group
+    // Below Deck — top-level group
     if (belowDeck.length > 0) {
       html += '<div class="cd-panel cd-mb today-group">';
       html += '<div class="cd-panel-header"><span class="cd-panel-title">// Below Deck</span></div>';
@@ -219,32 +256,37 @@
       html += '</div></div>';
     }
 
-    // Project groups — tasks + checklist blocks (with open items underneath)
-    projects.forEach(function(proj) {
-      var hasTasks = (proj.tasks || []).length > 0;
-      var hasBlocks = (proj.blocks || []).length > 0;
-      if (!hasTasks && !hasBlocks) return;
-      html += '<div class="cd-panel cd-mb today-group">';
-      html += '<div class="cd-panel-header"><span class="cd-panel-title">// ' + escHtml(proj.title) + '</span></div>';
+    // Area groups — each contains its sub-projects
+    areaGroups.forEach(function(ag) {
+      var hasContent = ag.projects.some(projectHasContent);
+      if (!hasContent) return;
+      var stripeStyle = ag.area_color
+        ? ' style="border-left:3px solid ' + ag.area_color + '; padding-left:8px;"'
+        : '';
+      html += '<div class="cd-panel cd-mb today-area-group">';
+      html += '<div class="cd-panel-header"' + stripeStyle + '>' +
+              '<span class="cd-panel-title today-area-header">' + escHtml(ag.area_title) + '</span>' +
+              '</div>';
       html += '<div class="cd-panel-body" style="padding:4px 0;">';
-      (proj.tasks || []).forEach(function(t) {
-        var starred = todayTaskIds[t.id] || t.today == 1;
-        html += masterRow('task', t.id, t.title, starred, false);
-      });
-      (proj.blocks || []).forEach(function(b) {
-        var bStarred = todayBlockIds[b.id] || b.today == 1;
-        var blockTitle = b.title || 'Untitled Checklist';
-        var progress = b.total_count > 0
-          ? ' (' + b.checked_count + '/' + b.total_count + ' done)'
-          : '';
-        html += masterRow('block', b.id, '▣ ' + blockTitle + progress, bStarred, false);
-        (b.open_items || []).forEach(function(item) {
-          var iStarred = todayItemIds[item.id] || item.today == 1;
-          html += masterRow('item', item.id, item.text, iStarred, true);
-        });
+      ag.projects.forEach(function(proj) {
+        if (!projectHasContent(proj)) return;
+        html += renderProjectSubsection(proj, todayTaskIds, todayItemIds, todayBlockIds);
       });
       html += '</div></div>';
     });
+
+    // Personal projects — own group, flat
+    var personalHasContent = personalProjects.some(projectHasContent);
+    if (personalHasContent) {
+      html += '<div class="cd-panel cd-mb today-area-group">';
+      html += '<div class="cd-panel-header"><span class="cd-panel-title today-area-header">Personal</span></div>';
+      html += '<div class="cd-panel-body" style="padding:4px 0;">';
+      personalProjects.forEach(function(proj) {
+        if (!projectHasContent(proj)) return;
+        html += renderProjectSubsection(proj, todayTaskIds, todayItemIds, todayBlockIds);
+      });
+      html += '</div></div>';
+    }
 
     document.getElementById('masterList').innerHTML = html;
 
@@ -254,6 +296,29 @@
         starEntity(btn.getAttribute('data-kind'), btn.getAttribute('data-id'), btn);
       });
     });
+  }
+
+  function renderProjectSubsection(proj, todayTaskIds, todayItemIds, todayBlockIds) {
+    var html = '<div class="today-project-subsection">';
+    html += '<div class="today-project-header">' + escHtml(proj.title) + '</div>';
+    (proj.tasks || []).forEach(function(t) {
+      var starred = todayTaskIds[t.id] || t.today == 1;
+      html += masterRow('task', t.id, t.title, starred, false);
+    });
+    (proj.blocks || []).forEach(function(b) {
+      var bStarred = todayBlockIds[b.id] || b.today == 1;
+      var blockTitle = b.title || 'Untitled Checklist';
+      var progress = b.total_count > 0
+        ? ' (' + b.checked_count + '/' + b.total_count + ' done)'
+        : '';
+      html += masterRow('block', b.id, '▣ ' + blockTitle + progress, bStarred, false);
+      (b.open_items || []).forEach(function(item) {
+        var iStarred = todayItemIds[item.id] || item.today == 1;
+        html += masterRow('item', item.id, item.text, iStarred, true);
+      });
+    });
+    html += '</div>';
+    return html;
   }
 
   function masterRow(kind, id, label, starred, indent) {

--- a/templates/today.html
+++ b/templates/today.html
@@ -137,6 +137,13 @@
   color: var(--cd-text-dim);
   letter-spacing: 0.08em;
 }
+/* Phase 2.2 — checklist items render indented under their parent block */
+.today-master-row.is-item-indent {
+  padding-left: 32px;
+}
+.today-master-row.is-item-indent .today-master-title {
+  font-size: 0.72rem;
+}
 </style>
 
 <script>
@@ -174,15 +181,23 @@
   }
 
   function renderMasterList(belowDeck, projects, todayOpen) {
-    // Phase 2.1 — todayOpen now mixes tasks AND items (kind discriminator).
-    // The master browse is task-only, so build the lookup from task entries
-    // only to avoid task-id vs item-id collisions.
-    var todayIds = {};
-    todayOpen.forEach(function(t) {
-      if ((t.kind || 'task') === 'task') todayIds[t.id] = true;
+    // Phase 2.1+2.2 — todayOpen mixes tasks/items/blocks. Build per-kind
+    // lookups so the starred-state on master rows is unambiguous.
+    var todayTaskIds = {};
+    var todayItemIds = {};
+    var todayBlockIds = {};
+    todayOpen.forEach(function(e) {
+      var kind = e.kind || 'task';
+      if (kind === 'task') todayTaskIds[e.id] = true;
+      else if (kind === 'item') todayItemIds[e.id] = true;
+      else if (kind === 'block') todayBlockIds[e.id] = true;
     });
 
-    var totalTasks = belowDeck.length + projects.reduce(function(s, p) { return s + p.tasks.length; }, 0);
+    var totalTasks = belowDeck.length + projects.reduce(function(s, p) {
+      var n = (p.tasks || []).length;
+      (p.blocks || []).forEach(function(b) { n += 1 + (b.open_items || []).length; });
+      return s + n;
+    }, 0);
 
     if (totalTasks === 0) {
       document.getElementById('masterList').innerHTML =
@@ -198,55 +213,72 @@
       html += '<div class="cd-panel-header"><span class="cd-panel-title">// Below Deck</span></div>';
       html += '<div class="cd-panel-body" style="padding:4px 0;">';
       belowDeck.forEach(function(t) {
-        var starred = todayIds[t.id] || t.today == 1;
-        html += taskRow(t, starred);
+        var starred = todayTaskIds[t.id] || t.today == 1;
+        html += masterRow('task', t.id, t.title, starred, false);
       });
       html += '</div></div>';
     }
 
-    // Project groups
+    // Project groups — tasks + checklist blocks (with open items underneath)
     projects.forEach(function(proj) {
-      if (!proj.tasks || proj.tasks.length === 0) return;
+      var hasTasks = (proj.tasks || []).length > 0;
+      var hasBlocks = (proj.blocks || []).length > 0;
+      if (!hasTasks && !hasBlocks) return;
       html += '<div class="cd-panel cd-mb today-group">';
       html += '<div class="cd-panel-header"><span class="cd-panel-title">// ' + escHtml(proj.title) + '</span></div>';
       html += '<div class="cd-panel-body" style="padding:4px 0;">';
-      proj.tasks.forEach(function(t) {
-        var starred = todayIds[t.id] || t.today == 1;
-        html += taskRow(t, starred);
+      (proj.tasks || []).forEach(function(t) {
+        var starred = todayTaskIds[t.id] || t.today == 1;
+        html += masterRow('task', t.id, t.title, starred, false);
+      });
+      (proj.blocks || []).forEach(function(b) {
+        var bStarred = todayBlockIds[b.id] || b.today == 1;
+        var blockTitle = b.title || 'Untitled Checklist';
+        var progress = b.total_count > 0
+          ? ' (' + b.checked_count + '/' + b.total_count + ' done)'
+          : '';
+        html += masterRow('block', b.id, '▣ ' + blockTitle + progress, bStarred, false);
+        (b.open_items || []).forEach(function(item) {
+          var iStarred = todayItemIds[item.id] || item.today == 1;
+          html += masterRow('item', item.id, item.text, iStarred, true);
+        });
       });
       html += '</div></div>';
     });
 
     document.getElementById('masterList').innerHTML = html;
 
-    // Bind star buttons
+    // Bind star buttons (delegated handler picks up data-kind + data-id)
     document.querySelectorAll('.today-star-btn').forEach(function(btn) {
       btn.addEventListener('click', function() {
-        starTask(btn.getAttribute('data-id'), btn);
+        starEntity(btn.getAttribute('data-kind'), btn.getAttribute('data-id'), btn);
       });
     });
   }
 
-  function taskRow(t, starred) {
-    return '<div class="today-master-row" data-id="' + t.id + '">' +
+  function masterRow(kind, id, label, starred, indent) {
+    var rowCls = 'today-master-row' + (indent ? ' is-item-indent' : '');
+    var titleCls = 'today-master-title' + (starred ? ' is-starred' : '');
+    return '<div class="' + rowCls + '" data-id="' + id + '" data-kind="' + kind + '">' +
       '<button class="today-star-btn' + (starred ? ' starred' : '') + '" ' +
-              'data-id="' + t.id + '" ' +
+              'data-id="' + id + '" data-kind="' + kind + '" ' +
               'title="' + (starred ? 'Remove from Today' : 'Add to Today') + '">' +
         (starred ? '★' : '☆') +
       '</button>' +
-      '<span class="today-master-title' + (starred ? ' is-starred' : '') + '">' +
-        escHtml(t.title) +
-      '</span>' +
+      '<span class="' + titleCls + '">' + escHtml(label) + '</span>' +
       '</div>';
   }
 
-  function starTask(id, btn) {
+  function starEntity(kind, id, btn) {
     var wasStarred = btn.classList.contains('starred');
     // Optimistic UI
     toggleStar(btn, !wasStarred);
 
     var fd = new FormData();
-    fd.append('id', id);
+    var fieldName = 'task_id';
+    if (kind === 'item') fieldName = 'item_id';
+    else if (kind === 'block') fieldName = 'block_id';
+    fd.append(fieldName, id);
     fetch('/today/star', { method: 'POST', body: fd })
       .then(function(r) { return r.json(); })
       .then(function(data) {


### PR DESCRIPTION
## Summary

Phase 2.2 closes "checklist blocks behave like tasks" and tightens the Today system's autoclear precision. Spec: `.kt/spec-time-tracking-phase-2-2.md`. Original plan was 4 commits — grew to 7 over the course of testing as Aaron flagged real-use gaps and one self-caught format bug.

Seven commits:

1. **`chore(db)`** — `blocks.today INTEGER NOT NULL DEFAULT 0` + `checklist_items.checked_at TEXT` via new idempotent migration. Backfills existing checked items so they roll off cleanly on next autoclear.
2. **`feat(today)` checked_at + tighten autoclear** — toggle handler stamps `checked_at` on check, clears on uncheck. `_today_autoclear` switches from "clear every checked item past 4am" to a precise `checked_at < cutoff` compare. Block autoclear added (rolls off when all items checked + all stale).
3. **`fix(db)`** — caught during smoke testing: original migration backfilled `block.created` (ET-localized with offset) into `checked_at`, but the autoclear cutoff is canonical UTC ISO. Lex compare between the two formats lies. Replaced with `'1970-01-01T00:00:00.000000Z'` sentinel. Format-repair pass also catches DBs migrated against the buggy first version.
4. **`feat(today)` block routes** — `/today/star` accepts `block_id` (mutually exclusive with task_id and item_id). `/today/data` returns `kind: 'block'` rows with progress counts. `/today/count` includes blocks.
5. **`feat(today)` block UI** — ★ button on checklist block headers (note blocks excluded). Block rows render in the global Today panel as `CHECKLIST · <title>` with `N/M done · <project>`. Existing project-page star handler refactored to dispatch task_id/item_id/block_id by `data-kind`.
6. **`feat(today)` master browse surfaces checklists** — caught during local verification: `/today/` master browse stayed task-only because earlier specs deferred it. Aaron's planning workflow lives on /today/, so deferring chafed. Project groups now also surface checklist blocks + open items, with items indented under their parent block.
7. **`feat(today)` group by parent area** — Aaron's request after testing. Master browse and slim panel both now surface area context. Master browse becomes Below Deck → Corporate → PennDOT → FDOT → Personal nested headers (sub-projects under each area, color-stripe on area panels). Slim panel rows prefix the source line with area name (`Corporate · test1`).

## Test plan

Verified locally during build:
- [x] Migration idempotent + format-repair pass catches the 2 pre-existing rows on Aaron's local DB; canonical sentinel applied
- [x] Toggle handler stamps `checked_at` on check, clears on uncheck
- [x] `/today/complete` for items also stamps (parallel path)
- [x] `_today_autoclear` precision: just-checked item kept, yesterday-checked item rolled off; block with all items checked + all stale rolls off; block with one unchecked stays starred; empty starred block persists
- [x] `/today/star` rejects 0 or 2+ ID fields with 400; rejects note-block stars with 400 block_not_checklist; 404 on nonexistent
- [x] `/today/data` returns `kind: 'block'` rows with title + progress + project + area context
- [x] `/today/count` combined total includes blocks
- [x] Project page renders ★ on checklist block headers (not on note blocks); newly-added blocks include ★ markup
- [x] Slim Today panel renders block rows with `▣` spacer and progress; source line prefixed with area name
- [x] `/today/` master browse renders area-grouped sections (Corporate, PennDOT, FDOT, Personal); each area's sub-projects nested with project headers; tasks + blocks + indented items
- [x] Aaron eyeballed all surfaces: "a gentleman and a scholar"

After merge:
- [ ] On PA: `git pull origin main && python migrate_add_today_on_blocks_and_checked_at.py && reload web app`

## KT doc sweep (gitignored, local-only)

- `.kt/spec-time-tracking-phase-2-2.md` — Status: ✅ Shipped 2026-05-05; Last updated bumped (note the 5→7 commit count growth)
- `.kt/KT-command-deck.md` — `blocks.today` + `checklist_items.checked_at` documented in schema; new migration listed in setup; Last updated bumped; Deferred Features marks 2.2 as ✅
- `.kt/PROJECT_KNOWLEDGE.md` — Today description rewritten to include blocks; Last updated bumped
- (Already covered: `.kt/KT-cockpit.md` block-title rendering note from 2.1)

## What's next

Phase 2.3 (queued, spec ready) — reusable project + checklist templates. Spec: `.kt/spec-time-tracking-phase-2-3.md`.

## Merge strategy

Rebase-merge / fast-forward only. Seven commits in narrative order, Han Solo voice runs through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)