### PR TITLE
Inline edit start/end time on stopped entries

### DIFF
--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -2317,6 +2317,92 @@ body.cd-strip-visible .cd-shell { padding-top: 32px; }
 	font-variant-numeric: tabular-nums;
 }
 .cd-tt-entry-desc { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* Inline start/end time-edit on stopped entries — project page today-list */
+button.cd-tt-time-edit-trigger {
+	background: none;
+	border: 1px dashed transparent;
+	cursor: pointer;
+	font: inherit;
+	color: inherit;
+	padding: 0 4px;
+	border-radius: 2px;
+	transition: border-color 0.15s, background 0.15s;
+}
+button.cd-tt-time-edit-trigger:hover,
+button.cd-tt-time-edit-trigger:focus-visible {
+	border-color: var(--cd-amber-lo);
+	background: rgba(212, 136, 10, 0.08);
+	outline: none;
+}
+.cd-tt-time-editor {
+	display: inline-flex;
+	gap: 0.3rem;
+	align-items: center;
+	font-family: var(--cd-font-ui);
+	font-size: 0.65rem;
+}
+.cd-tt-time-input {
+	background: var(--cd-bg-surface);
+	border: 1px solid var(--cd-amber-lo);
+	color: var(--cd-text);
+	font: inherit;
+	padding: 1px 4px;
+	border-radius: 2px;
+	font-variant-numeric: tabular-nums;
+}
+.cd-tt-time-input:focus { outline: none; border-color: var(--cd-amber-hi); }
+.cd-tt-time-sep { color: var(--cd-text-dim); }
+
+/* Same editor in the reports entries table */
+button.cd-reports-time-edit {
+	background: none;
+	border: 1px dashed transparent;
+	color: inherit;
+	font: inherit;
+	cursor: pointer;
+	padding: 0 4px;
+	border-radius: 2px;
+	transition: border-color 0.15s, background 0.15s;
+}
+button.cd-reports-time-edit:hover,
+button.cd-reports-time-edit:focus-visible {
+	border-color: var(--cd-amber-lo);
+	background: rgba(212, 136, 10, 0.08);
+	outline: none;
+}
+.cd-reports-time-editor {
+	display: inline-flex;
+	gap: 0.25rem;
+	align-items: center;
+	font-family: var(--cd-font-ui);
+	font-size: 0.7rem;
+}
+.cd-reports-time-input {
+	background: var(--cd-bg-surface);
+	border: 1px solid var(--cd-amber-lo);
+	color: var(--cd-text);
+	font: inherit;
+	padding: 1px 4px;
+	border-radius: 2px;
+	font-variant-numeric: tabular-nums;
+}
+.cd-reports-time-input:focus { outline: none; border-color: var(--cd-amber-hi); }
+.cd-reports-time-save,
+.cd-reports-time-cancel {
+	background: none;
+	border: 1px solid var(--cd-border);
+	color: var(--cd-amber-hi);
+	font-family: var(--cd-font-ui);
+	font-size: 0.55rem;
+	letter-spacing: 0.1em;
+	padding: 2px 6px;
+	border-radius: 2px;
+	cursor: pointer;
+}
+.cd-reports-time-save:hover,
+.cd-reports-time-cancel:hover { border-color: var(--cd-amber-lo); }
+.cd-reports-time-save:disabled { opacity: 0.5; cursor: not-allowed; }
+
 .cd-tt-entry-context {
 	font-family: var(--cd-font-ui, 'Share Tech Mono', monospace);
 	font-size: 0.55rem;

--- a/static/command_deck_reports.js
+++ b/static/command_deck_reports.js
@@ -345,14 +345,18 @@
 			}
 			const runningCls = e.running ? ' is-running' : '';
 			const runningGlyph = e.running ? ' <span class="cd-reports-running-dot" title="still running"></span>' : '';
+			// Click-to-edit on stopped entries; running entries stay static.
+			const timeCell = e.running
+				? `${startLocal} → ${endLocal}${runningGlyph}`
+				: `<button type="button" class="cd-reports-time-edit" data-entry-id="${e.id}" data-started="${e.started_at}" data-ended="${e.ended_at}" title="Edit start/end time">${startLocal} → ${endLocal}</button>`;
 			return `
-				<tr class="cd-reports-entry${runningCls}">
+				<tr class="cd-reports-entry${runningCls}" data-entry-id="${e.id}">
 					<td>${day}</td>
 					<td><span class="cd-reports-area-stripe" style="background:${stripe}"></span>${escapeHtml(e.area_title || '—')}</td>
 					<td>${escapeHtml(e.project_title || '—')}</td>
 					<td>${context}</td>
 					<td>${escapeHtml(e.description || '')}</td>
-					<td>${startLocal} → ${endLocal}${runningGlyph}</td>
+					<td>${timeCell}</td>
 					<td class="cd-num">${fmtSeconds(e.duration_seconds)}</td>
 				</tr>
 			`;
@@ -360,6 +364,84 @@
 		tbody.innerHTML = html;
 
 		document.getElementById('reportsTotalDuration').textContent = fmtSeconds(data.meta.totals_seconds);
+
+		tbody.querySelectorAll('.cd-reports-time-edit').forEach((btn) => {
+			btn.addEventListener('click', (ev) => {
+				ev.stopPropagation();
+				openTimeEditor(btn);
+			});
+		});
+	}
+
+	// Inline start/end time edit on stopped entries. Same UX as the
+	// project-page today-list editor; here we re-fetch on save instead of
+	// calling loadTodayTime().
+	function _localTimeOf(iso) {
+		if (!iso) return '';
+		const d = new Date(iso);
+		const pad = (n) => String(n).padStart(2, '0');
+		return pad(d.getHours()) + ':' + pad(d.getMinutes());
+	}
+	function _combineLocalTime(originalIso, hhmm) {
+		if (!hhmm) return null;
+		const d = new Date(originalIso);
+		const [h, m] = hhmm.split(':').map(Number);
+		d.setHours(h, m, 0, 0);
+		return d.toISOString();
+	}
+	function openTimeEditor(triggerBtn) {
+		const entryId = triggerBtn.getAttribute('data-entry-id');
+		const startedIso = triggerBtn.getAttribute('data-started');
+		const endedIso = triggerBtn.getAttribute('data-ended');
+		if (!startedIso || !endedIso) return;
+		const wrap = document.createElement('span');
+		wrap.className = 'cd-reports-time-editor';
+		wrap.innerHTML =
+			`<input type="time" class="cd-reports-time-input" data-which="start" value="${_localTimeOf(startedIso)}">` +
+			`<span> – </span>` +
+			`<input type="time" class="cd-reports-time-input" data-which="end" value="${_localTimeOf(endedIso)}">` +
+			`<button type="button" class="cd-reports-time-save">SAVE</button>` +
+			`<button type="button" class="cd-reports-time-cancel">CANCEL</button>`;
+		triggerBtn.replaceWith(wrap);
+
+		const cancel = () => load();
+		const save = async () => {
+			const sIn = wrap.querySelector('[data-which="start"]').value;
+			const eIn = wrap.querySelector('[data-which="end"]').value;
+			if (!sIn || !eIn) return;
+			const newStarted = _combineLocalTime(startedIso, sIn);
+			const newEnded = _combineLocalTime(endedIso, eIn);
+			if (new Date(newEnded) < new Date(newStarted)) {
+				alert('End must be after start.');
+				return;
+			}
+			wrap.querySelector('.cd-reports-time-save').disabled = true;
+			try {
+				const r = await fetch(`/time/${entryId}/update`, {
+					method: 'POST',
+					headers: {'Content-Type': 'application/json'},
+					body: JSON.stringify({started_at: newStarted, ended_at: newEnded}),
+					credentials: 'same-origin',
+				});
+				if (r.ok) {
+					load();
+				} else {
+					wrap.querySelector('.cd-reports-time-save').disabled = false;
+					alert('Could not save.');
+				}
+			} catch (e) {
+				wrap.querySelector('.cd-reports-time-save').disabled = false;
+				alert('Could not save.');
+			}
+		};
+		wrap.querySelector('.cd-reports-time-save').addEventListener('click', save);
+		wrap.querySelector('.cd-reports-time-cancel').addEventListener('click', cancel);
+		wrap.addEventListener('keydown', (ev) => {
+			if (ev.key === 'Enter') { ev.preventDefault(); save(); }
+			else if (ev.key === 'Escape') { ev.preventDefault(); cancel(); }
+		});
+		const firstInput = wrap.querySelector('[data-which="start"]');
+		if (firstInput) firstInput.focus();
 	}
 
 	function renderHeader() {

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -1467,8 +1467,14 @@ function cdEditTask(id) {
         } else {
           contextBadge = '';
         }
+        // Time range becomes an edit trigger on stopped entries; static
+        // span on running entries (running = fresh — edit after stop).
+        var timeText = fmtTimeOfDay(e.started_at) + '–' + (e.ended_at ? fmtTimeOfDay(e.ended_at) : 'now');
+        var timeMarkup = isRunning
+          ? '<span class="cd-tt-entry-time">' + timeText + '</span>'
+          : '<button type="button" class="cd-tt-entry-time cd-tt-time-edit-trigger" data-entry-id="' + e.id + '" data-started="' + e.started_at + '" data-ended="' + (e.ended_at || '') + '" title="Edit start/end time">' + timeText + '</button>';
         return '<div class="cd-tt-entry' + (isRunning ? ' is-running' : '') + '" data-id="' + e.id + '">' +
-          '<span class="cd-tt-entry-time">' + fmtTimeOfDay(e.started_at) + '–' + (e.ended_at ? fmtTimeOfDay(e.ended_at) : 'now') + '</span>' +
+          timeMarkup +
           contextBadge +
           '<span class="cd-tt-entry-desc">' + (escHtml(e.description) || '<em class="cd-text-dim">no description</em>') + '</span>' +
           '<span class="cd-tt-entry-elapsed">' + fmt(elapsed) + '</span>' +
@@ -1494,6 +1500,10 @@ function cdEditTask(id) {
       todayList.querySelectorAll('.cd-tt-assign-trigger').forEach(b => b.addEventListener('click', (ev) => {
         ev.stopPropagation();
         openAssignDropdown(b.getAttribute('data-entry-id'), b);
+      }));
+      todayList.querySelectorAll('.cd-tt-time-edit-trigger').forEach(b => b.addEventListener('click', (ev) => {
+        ev.stopPropagation();
+        openTimeEditor(b);
       }));
     } catch (e) {
       todayList.innerHTML = '<div class="cd-text-dim" style="font-size:0.7rem;">Could not load.</div>';
@@ -1606,6 +1616,83 @@ function cdEditTask(id) {
       document.addEventListener('click', closeOnOutside, true);
       document.addEventListener('keydown', closeOnEsc, true);
     }, 0);
+  }
+
+  // ---- Phase 2.x — inline start/end time edit on stopped entries ----
+  // Click `09:15→11:30` → swap to two <input type="time"> fields + save/cancel.
+  // Combines local HH:MM with the original entry's calendar day (preserves
+  // cross-midnight semantics — server validates and recomputes duration).
+  function _localTimeOf(iso) {
+    if (!iso) return '';
+    const d = new Date(iso);
+    const pad = (n) => String(n).padStart(2, '0');
+    return pad(d.getHours()) + ':' + pad(d.getMinutes());
+  }
+  function _combineLocalTime(originalIso, hhmm) {
+    if (!hhmm) return null;
+    const d = new Date(originalIso);
+    const [h, m] = hhmm.split(':').map(Number);
+    d.setHours(h, m, 0, 0);
+    return d.toISOString();
+  }
+  function openTimeEditor(triggerBtn) {
+    const entryId = triggerBtn.getAttribute('data-entry-id');
+    const startedIso = triggerBtn.getAttribute('data-started');
+    const endedIso = triggerBtn.getAttribute('data-ended');
+    if (!startedIso || !endedIso) return;  // running entries skip
+    const startLocal = _localTimeOf(startedIso);
+    const endLocal = _localTimeOf(endedIso);
+    const wrap = document.createElement('span');
+    wrap.className = 'cd-tt-time-editor';
+    wrap.innerHTML =
+      '<input type="time" class="cd-tt-time-input" data-which="start" value="' + startLocal + '">' +
+      '<span class="cd-tt-time-sep">–</span>' +
+      '<input type="time" class="cd-tt-time-input" data-which="end" value="' + endLocal + '">' +
+      '<button type="button" class="cd-btn ghost sm cd-tt-time-save">SAVE</button>' +
+      '<button type="button" class="cd-btn ghost sm cd-tt-time-cancel">CANCEL</button>';
+    triggerBtn.replaceWith(wrap);
+
+    function cancel() {
+      loadTodayTime();
+    }
+    async function save() {
+      const sIn = wrap.querySelector('[data-which="start"]').value;
+      const eIn = wrap.querySelector('[data-which="end"]').value;
+      if (!sIn || !eIn) return;
+      const newStarted = _combineLocalTime(startedIso, sIn);
+      const newEnded = _combineLocalTime(endedIso, eIn);
+      if (new Date(newEnded) < new Date(newStarted)) {
+        showToast('End must be after start.');
+        return;
+      }
+      wrap.querySelector('.cd-tt-time-save').disabled = true;
+      try {
+        const r = await fetch('/time/' + entryId + '/update', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({started_at: newStarted, ended_at: newEnded}),
+          credentials: 'same-origin',
+        });
+        if (r.ok) {
+          loadTodayTime();
+          if (window.TimeTrackerCore) window.TimeTrackerCore.refresh();
+        } else {
+          wrap.querySelector('.cd-tt-time-save').disabled = false;
+          showToast('Could not save.');
+        }
+      } catch (e) {
+        wrap.querySelector('.cd-tt-time-save').disabled = false;
+        showToast('Could not save.');
+      }
+    }
+    wrap.querySelector('.cd-tt-time-save').addEventListener('click', save);
+    wrap.querySelector('.cd-tt-time-cancel').addEventListener('click', cancel);
+    wrap.addEventListener('keydown', (ev) => {
+      if (ev.key === 'Enter') { ev.preventDefault(); save(); }
+      else if (ev.key === 'Escape') { ev.preventDefault(); cancel(); }
+    });
+    const firstInput = wrap.querySelector('[data-which="start"]');
+    if (firstInput) firstInput.focus();
   }
 
   // Re-render on every tick + every TimeTrackerCore poll


### PR DESCRIPTION
## Summary

Backend supported editing `started_at` + `ended_at` on time entries since Phase 1 (and recomputes duration cleanly). UI never exposed it. This adds inline edit on the two surfaces where you'd most want it: the project page today's-time list (fresh fix-it case) and the reports entries table (wider after-the-fact case).

Single commit, no schema changes.

## Behavior

- Click `09:15→11:30` on a stopped entry → row swaps to two `<input type="time">` + SAVE / CANCEL.
- ENTER saves, ESC cancels.
- Client validates end > start with a toast/alert before POSTing.
- Server (`/time/<id>/update`, unchanged) parses + recomputes duration.
- Running entries stay static — edit after stop. (Running = fresh anyway.)
- Cross-midnight handled correctly: each timestamp keeps its own calendar day; only the time-of-day changes.

## Test plan

- [x] Server regression: POST `{started_at, ended_at}` returns 200 with recomputed `duration_seconds`
- [x] Project page emits `cd-tt-time-edit-trigger` button on stopped entries; `openTimeEditor` + `_combineLocalTime` + end-after-start guard all wired
- [x] Reports JS has `cd-reports-time-edit` + `openTimeEditor` + save/cancel handlers
- [x] CSS classes for both editor variants
- [ ] Aaron: click time on a stopped entry on `/command-deck/projects/<slug>/`, edit, save, see updated row; same on `/command-deck/reports/`
- [ ] Aaron: ESC cancels, ENTER saves
- [ ] Aaron: end < start shows the guard message

## Merge strategy

Single commit; rebase-merge for consistency with the rest of the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)