### PR TITLE
Phase 2.3 — reusable project + checklist templates + nav streamline

### DIFF
--- a/blueprints/command_deck.py
+++ b/blueprints/command_deck.py
@@ -765,6 +765,8 @@ def cd_area_subproject_new(slug):
 	title = (data.get('title') or '').strip()
 	description = (data.get('description') or '').strip() or None
 	tracking_enabled = 1 if data.get('tracking_enabled') in (True, '1', 1, 'true', 'True') else 0
+	# Phase 2.3 (post-ship fix) — sub-projects can spawn from a template too.
+	template_id = data.get('template_id') or None
 	if not title:
 		return jsonify({'error': 'title required'}), 400
 
@@ -787,6 +789,10 @@ def cd_area_subproject_new(slug):
 		VALUES (?, ?, ?, 0, 'work_subproject', ?, ?, 0, NULL, ?, ?)
 	''', (title, new_slug, description, area['id'], tracking_enabled, now, now))
 	new_id = cur.lastrowid
+
+	if template_id:
+		_apply_project_template(conn, new_id, template_id, now)
+
 	conn.commit()
 	sp = conn.execute('SELECT * FROM projects WHERE id = ?', (new_id,)).fetchone()
 	conn.close()

--- a/blueprints/command_deck.py
+++ b/blueprints/command_deck.py
@@ -95,6 +95,47 @@ def _fetch_subprojects(conn, area_id=None, favorites_only=False):
 
 # ---- Templates (Phase 2.3) ----
 
+@command_deck_bp.route('/command-deck/templates/')
+@command_deck_bp.route('/command-deck/templates')
+@cd_auth_required
+def cd_templates_page():
+	"""Manager page — lists project + checklist templates with rename + delete."""
+	conn = get_db()
+	rows = conn.execute('''
+		SELECT id, kind, name, description, body_json, created, updated
+		FROM templates
+		ORDER BY kind ASC, updated DESC
+	''').fetchall()
+	project_templates = []
+	checklist_templates = []
+	for r in rows:
+		entry = dict(r)
+		# Compute lightweight summary fields for the manager UI; never expose
+		# raw body_json into the rendered HTML beyond what we use for counts.
+		try:
+			body = json.loads(entry['body_json'] or '{}')
+		except (ValueError, TypeError):
+			body = {}
+		if entry['kind'] == 'project':
+			entry['block_count'] = len(body.get('blocks') or [])
+			entry['task_count'] = len(body.get('tasks') or [])
+			project_templates.append(entry)
+		else:
+			entry['item_count'] = len(body.get('items') or [])
+			entry['title_in_body'] = (body.get('title') or '').strip()
+			checklist_templates.append(entry)
+		# Drop the raw JSON before passing to the template — manager UI
+		# doesn't render it.
+		entry.pop('body_json', None)
+	conn.close()
+	return render_template(
+		'command_deck_templates.html',
+		project_templates=project_templates,
+		checklist_templates=checklist_templates,
+		private_projects_enabled=bool(PRIVATE_PROJECTS_PIN),
+	)
+
+
 @command_deck_bp.route('/command-deck/templates/list', methods=['GET'])
 @cd_auth_required
 def cd_templates_list():

--- a/blueprints/command_deck.py
+++ b/blueprints/command_deck.py
@@ -93,6 +93,165 @@ def _fetch_subprojects(conn, area_id=None, favorites_only=False):
 
 # ---- COMMAND DECK ROUTES ----
 
+# ---- Templates (Phase 2.3) ----
+
+@command_deck_bp.route('/command-deck/templates/list', methods=['GET'])
+@cd_auth_required
+def cd_templates_list():
+	"""Picker-friendly template list (no body_json). Filter by kind."""
+	kind = request.args.get('kind')
+	if kind not in ('project', 'checklist'):
+		return jsonify({'error': 'kind_required'}), 400
+	conn = get_db()
+	rows = conn.execute(
+		'SELECT id, name, description, updated FROM templates '
+		'WHERE kind = ? ORDER BY updated DESC',
+		(kind,)
+	).fetchall()
+	conn.close()
+	return jsonify({'templates': [dict(r) for r in rows]})
+
+
+@command_deck_bp.route('/command-deck/projects/<slug>/save-as-template', methods=['POST'])
+@cd_auth_required
+def cd_project_save_as_template(slug):
+	"""Snapshot a project's structure (blocks, items, tasks) into a project
+	template. Auto-strips per-instance state — checked, completed, today,
+	and similar flags are dropped per spec §1."""
+	data = request.get_json(silent=True) or request.form
+	name = (data.get('name') or '').strip()
+	if not name:
+		return jsonify({'error': 'name_required'}), 400
+
+	conn = get_db()
+	project = conn.execute('SELECT * FROM projects WHERE slug = ?', (slug,)).fetchone()
+	if not project:
+		conn.close()
+		return jsonify({'error': 'not_found'}), 404
+
+	blocks = conn.execute(
+		'SELECT * FROM blocks WHERE project_id = ? ORDER BY "order" ASC, id ASC',
+		(project['id'],)
+	).fetchall()
+	body_blocks = []
+	for b in blocks:
+		entry = {'type': b['type']}
+		if b['title']:
+			entry['title'] = b['title']
+		if b['type'] == 'note':
+			entry['content'] = b['content'] or ''
+		else:
+			items = conn.execute(
+				'SELECT text FROM checklist_items WHERE block_id = ? ORDER BY id ASC',
+				(b['id'],)
+			).fetchall()
+			entry['items'] = [{'text': i['text']} for i in items]
+		body_blocks.append(entry)
+
+	tasks = conn.execute(
+		'SELECT title FROM tasks WHERE project_id = ? AND status = \'open\' '
+		'ORDER BY "order" ASC, id ASC',
+		(project['id'],)
+	).fetchall()
+	body = {
+		'blocks': body_blocks,
+		'tasks': [{'title': t['title']} for t in tasks],
+	}
+
+	now = et_now()
+	cur = conn.execute('''
+		INSERT INTO templates (kind, name, description, body_json, created, updated)
+		VALUES ('project', ?, ?, ?, ?, ?)
+	''', (name, project['description'], json.dumps(body), now, now))
+	template_id = cur.lastrowid
+	conn.commit()
+	conn.close()
+	return jsonify({'success': True, 'template_id': template_id})
+
+
+@command_deck_bp.route('/command-deck/projects/<slug>/blocks/<int:block_id>/save-as-template', methods=['POST'])
+@cd_auth_required
+def cd_block_save_as_template(slug, block_id):
+	"""Snapshot a checklist block (title + item texts only) into a checklist
+	template. 400 if block isn't a checklist."""
+	data = request.get_json(silent=True) or request.form
+	name = (data.get('name') or '').strip()
+	if not name:
+		return jsonify({'error': 'name_required'}), 400
+
+	conn = get_db()
+	block = conn.execute('SELECT * FROM blocks WHERE id = ?', (block_id,)).fetchone()
+	if not block:
+		conn.close()
+		return jsonify({'error': 'not_found'}), 404
+	if block['type'] != 'checklist':
+		conn.close()
+		return jsonify({'error': 'block_not_checklist'}), 400
+
+	items = conn.execute(
+		'SELECT text FROM checklist_items WHERE block_id = ? ORDER BY id ASC',
+		(block_id,)
+	).fetchall()
+	body = {
+		'title': block['title'] or '',
+		'items': [{'text': i['text']} for i in items],
+	}
+	now = et_now()
+	cur = conn.execute('''
+		INSERT INTO templates (kind, name, description, body_json, created, updated)
+		VALUES ('checklist', ?, NULL, ?, ?, ?)
+	''', (name, json.dumps(body), now, now))
+	template_id = cur.lastrowid
+	conn.commit()
+	conn.close()
+	return jsonify({'success': True, 'template_id': template_id})
+
+
+@command_deck_bp.route('/command-deck/templates/<int:template_id>/update', methods=['POST'])
+@cd_auth_required
+def cd_template_update(template_id):
+	"""Rename / re-describe. Body editing deferred to a later phase."""
+	data = request.get_json(silent=True) or request.form
+	conn = get_db()
+	row = conn.execute('SELECT * FROM templates WHERE id = ?', (template_id,)).fetchone()
+	if not row:
+		conn.close()
+		return jsonify({'error': 'not_found'}), 404
+
+	name = row['name']
+	description = row['description']
+	if 'name' in data:
+		new_name = (data.get('name') or '').strip()
+		if not new_name:
+			conn.close()
+			return jsonify({'error': 'name_required'}), 400
+		name = new_name
+	if 'description' in data:
+		description = (data.get('description') or '').strip() or None
+
+	conn.execute(
+		'UPDATE templates SET name = ?, description = ?, updated = ? WHERE id = ?',
+		(name, description, et_now(), template_id)
+	)
+	conn.commit()
+	conn.close()
+	return jsonify({'success': True})
+
+
+@command_deck_bp.route('/command-deck/templates/<int:template_id>/delete', methods=['POST'])
+@cd_auth_required
+def cd_template_delete(template_id):
+	conn = get_db()
+	row = conn.execute('SELECT id FROM templates WHERE id = ?', (template_id,)).fetchone()
+	if not row:
+		conn.close()
+		return jsonify({'error': 'not_found'}), 404
+	conn.execute('DELETE FROM templates WHERE id = ?', (template_id,))
+	conn.commit()
+	conn.close()
+	return jsonify({'success': True})
+
+
 @command_deck_bp.route('/command-deck/verify-pin', methods=['POST'])
 @cd_auth_required
 def cd_verify_pin():
@@ -196,6 +355,8 @@ def cd_project_new():
 	description = request.form.get('description', '').strip() or None
 	is_private = 1 if request.form.get('is_private') == '1' else 0
 	tracking_enabled = 1 if request.form.get('tracking_enabled') in ('1', 'true', 'on') else 0
+	# Phase 2.3 — optional template_id spawns blocks/items/tasks from a saved template.
+	template_id = request.form.get('template_id') or None
 
 	if not title:
 		return redirect(url_for('command_deck.cd_projects'))
@@ -203,14 +364,103 @@ def cd_project_new():
 	conn = get_db()
 	slug = unique_slug(title, conn)
 	now = et_now()
-	conn.execute('''
+	cur = conn.execute('''
 		INSERT INTO projects (title, slug, description, is_private,
 		                      project_type, tracking_enabled, created, updated)
 		VALUES (?, ?, ?, ?, 'personal', ?, ?, ?)
 	''', (title, slug, description, is_private, tracking_enabled, now, now))
+	new_project_id = cur.lastrowid
+
+	if template_id:
+		_apply_project_template(conn, new_project_id, template_id, now)
+
 	conn.commit()
 	conn.close()
 	return redirect(url_for('command_deck.cd_project', slug=slug))
+
+
+def _apply_project_template(conn, project_id, template_id, now):
+	"""Parse a project-kind template body and INSERT blocks/items/tasks.
+	Best-effort: malformed JSON or missing template logs + skips silently
+	rather than failing the whole project create."""
+	row = conn.execute(
+		"SELECT kind, body_json FROM templates WHERE id = ?", (template_id,)
+	).fetchone()
+	if not row or row['kind'] != 'project':
+		return
+	try:
+		body = json.loads(row['body_json'] or '{}')
+	except (ValueError, TypeError):
+		return
+
+	# Blocks (with checklist items)
+	for order_idx, b in enumerate(body.get('blocks', []) or []):
+		btype = b.get('type', 'note')
+		if btype not in ('note', 'checklist'):
+			continue
+		block_cur = conn.execute('''
+			INSERT INTO blocks (project_id, type, content, "order", created, title)
+			VALUES (?, ?, ?, ?, ?, ?)
+		''', (
+			project_id,
+			btype,
+			b.get('content', '') if btype == 'note' else '',
+			order_idx,
+			now,
+			b.get('title') or None,
+		))
+		block_id = block_cur.lastrowid
+		if btype == 'checklist':
+			for item in (b.get('items', []) or []):
+				text = (item.get('text') or '').strip()
+				if not text:
+					continue
+				conn.execute(
+					"INSERT INTO checklist_items (block_id, text, checked) VALUES (?, ?, 0)",
+					(block_id, text),
+				)
+
+	# Tasks
+	for task_order, t in enumerate(body.get('tasks', []) or []):
+		title = (t.get('title') or '').strip()
+		if not title:
+			continue
+		conn.execute('''
+			INSERT INTO tasks (title, status, created, project_id, "order")
+			VALUES (?, 'open', ?, ?, ?)
+		''', (title, now, project_id, task_order))
+
+
+def _apply_checklist_template(conn, block_id, template_id):
+	"""Parse a checklist-kind template body and INSERT items into the block.
+	Returns the count of items inserted, 0 on missing/malformed."""
+	row = conn.execute(
+		"SELECT kind, body_json FROM templates WHERE id = ?", (template_id,)
+	).fetchone()
+	if not row or row['kind'] != 'checklist':
+		return 0
+	try:
+		body = json.loads(row['body_json'] or '{}')
+	except (ValueError, TypeError):
+		return 0
+	count = 0
+	for item in (body.get('items', []) or []):
+		text = (item.get('text') or '').strip()
+		if not text:
+			continue
+		conn.execute(
+			"INSERT INTO checklist_items (block_id, text, checked) VALUES (?, ?, 0)",
+			(block_id, text),
+		)
+		count += 1
+	# If the template has a title and the block doesn't yet, adopt it.
+	tpl_title = (body.get('title') or '').strip()
+	if tpl_title:
+		conn.execute(
+			"UPDATE blocks SET title = ? WHERE id = ? AND (title IS NULL OR title = '')",
+			(tpl_title, block_id),
+		)
+	return count
 
 
 # --- Individual project ---
@@ -525,6 +775,11 @@ def cd_block_add(slug):
 	block_type = request.form.get('type', 'note')
 	if block_type not in ('note', 'checklist'):
 		return jsonify({'error': 'invalid type'}), 400
+	# Phase 2.3 — optional template_id spawns items into the new block.
+	# Only meaningful for checklist blocks.
+	template_id = request.form.get('template_id') or None
+	if template_id and block_type != 'checklist':
+		return jsonify({'error': 'template_only_on_checklist'}), 400
 
 	conn = get_db()
 	project = conn.execute('SELECT * FROM projects WHERE slug = ?', (slug,)).fetchone()
@@ -543,8 +798,19 @@ def cd_block_add(slug):
 	''', (project['id'], block_type, max_order + 1, et_now()))
 
 	block_id = cursor.lastrowid
+
+	if template_id:
+		_apply_checklist_template(conn, block_id, template_id)
+
 	block = dict(conn.execute('SELECT * FROM blocks WHERE id = ?', (block_id,)).fetchone())
-	block['items'] = []
+	if block_type == 'checklist':
+		items = conn.execute(
+			'SELECT * FROM checklist_items WHERE block_id = ? ORDER BY id ASC',
+			(block_id,)
+		).fetchall()
+		block['items'] = [dict(i) for i in items]
+	else:
+		block['items'] = []
 
 	conn.execute('UPDATE projects SET updated = ? WHERE id = ?', (et_now(), project['id']))
 	conn.commit()

--- a/migrate_add_templates.py
+++ b/migrate_add_templates.py
@@ -1,0 +1,110 @@
+"""
+migrate_add_templates.py
+Phase 2.3 of the time-tracking spec — see .kt/spec-time-tracking-phase-2-3.md.
+
+What it does (idempotent — safe to run multiple times):
+
+  - templates table:
+      id          INTEGER PRIMARY KEY AUTOINCREMENT
+      kind        TEXT NOT NULL CHECK(kind IN ('project', 'checklist'))
+      name        TEXT NOT NULL
+      description TEXT
+      body_json   TEXT NOT NULL    -- JSON: blocks/items/tasks for project
+                                    -- kind, items for checklist kind
+      created     TEXT NOT NULL
+      updated     TEXT NOT NULL
+
+  - idx_templates_kind on templates(kind) — supports the
+    GET /command-deck/templates/list?kind=… picker queries.
+
+Single-table design: templates aren't queried granularly. The body
+is read whole at spawn time + parsed in app code. JSON in a TEXT
+column buys us schema flexibility (variants of project vs checklist
+body shapes) without 5 tables. Per spec §1 Decision #1.
+
+Prints a summary. Running it again prints "no changes."
+
+Run from PythonAnywhere bash:
+    cd /home/aaronaiken/status_update
+    python migrate_add_templates.py
+"""
+
+import os
+import sqlite3
+
+DB_FILE = os.path.join(
+	os.environ.get('COCKPIT_REPO_ROOT', '/home/aaronaiken/status_update'),
+	'assets/data/command_deck.db'
+)
+
+
+def table_exists(cur, name):
+	row = cur.execute(
+		"SELECT name FROM sqlite_master WHERE type='table' AND name=?", (name,)
+	).fetchone()
+	return row is not None
+
+
+def index_exists(cur, name):
+	row = cur.execute(
+		"SELECT name FROM sqlite_master WHERE type='index' AND name=?", (name,)
+	).fetchone()
+	return row is not None
+
+
+def run():
+	if not os.path.exists(DB_FILE):
+		print(f"× DB not found at {DB_FILE}")
+		print("  Run migrate_to_sqlite.py first.")
+		return
+
+	conn = sqlite3.connect(DB_FILE)
+	cur = conn.cursor()
+
+	added = []
+	skipped = []
+
+	if table_exists(cur, 'templates'):
+		skipped.append('templates table')
+	else:
+		cur.execute('''
+			CREATE TABLE templates (
+				id          INTEGER PRIMARY KEY AUTOINCREMENT,
+				kind        TEXT NOT NULL CHECK(kind IN ('project', 'checklist')),
+				name        TEXT NOT NULL,
+				description TEXT,
+				body_json   TEXT NOT NULL,
+				created     TEXT NOT NULL,
+				updated     TEXT NOT NULL
+			)
+		''')
+		added.append('templates table')
+
+	if index_exists(cur, 'idx_templates_kind'):
+		skipped.append('idx_templates_kind')
+	else:
+		cur.execute('CREATE INDEX idx_templates_kind ON templates(kind)')
+		added.append('idx_templates_kind')
+
+	conn.commit()
+	conn.close()
+
+	print()
+	print("Migration: migrate_add_templates.py")
+	print(f"DB:        {DB_FILE}")
+	print()
+	if added:
+		print(f"✓ Added ({len(added)}):")
+		for item in added:
+			print(f"    + {item}")
+	if skipped:
+		print(f"— Already in place ({len(skipped)}):")
+		for item in skipped:
+			print(f"    · {item}")
+	if not added:
+		print("No changes — schema already up to date.")
+	print()
+
+
+if __name__ == '__main__':
+	run()

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -2400,6 +2400,50 @@ body.cd-strip-visible .cd-shell { padding-top: 32px; }
   margin-left: 0.5rem;
 }
 
+/* Add-block-from-template dropdown */
+.cd-template-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: 4px;
+  min-width: 14em;
+  max-width: 22em;
+  max-height: 50vh;
+  overflow-y: auto;
+  background: var(--cd-bg-raised);
+  border: 1px solid var(--cd-border-amber);
+  border-radius: var(--cd-radius);
+  box-shadow: 0 8px 24px var(--cd-shadow);
+  padding: 0.3rem 0;
+  z-index: 200;
+}
+.cd-template-dropdown-option {
+  display: block;
+  width: 100%;
+  background: none;
+  border: none;
+  text-align: left;
+  font-family: var(--cd-font-body);
+  font-size: 0.78rem;
+  color: var(--cd-text);
+  padding: 0.4rem 0.85rem;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+.cd-template-dropdown-option:hover,
+.cd-template-dropdown-option:focus-visible {
+  background: rgba(245, 179, 50, 0.10);
+  color: var(--cd-amber-hi);
+  outline: none;
+}
+.cd-template-dropdown-empty {
+  padding: 0.6rem 0.85rem;
+  font-family: var(--cd-font-ui);
+  font-size: 0.62rem;
+  color: var(--cd-text-dim);
+  letter-spacing: 0.06em;
+}
+
 /* Inline start/end time-edit on stopped entries — project page today-list */
 button.cd-tt-time-edit-trigger {
 	background: none;

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -2330,6 +2330,47 @@ body.cd-strip-visible .cd-shell { padding-top: 32px; }
   max-width: 60ch;
 }
 
+/* Phase 2.3 polish — MORE ▾ overflow menu in the CD header nav */
+.cd-nav-more {
+  position: relative;
+  display: inline-block;
+}
+.cd-nav-more > summary.cd-nav-more-trigger {
+  list-style: none;
+  cursor: pointer;
+  user-select: none;
+  display: inline-block;
+}
+.cd-nav-more > summary.cd-nav-more-trigger::-webkit-details-marker {
+  display: none;
+}
+.cd-nav-more-menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 6px;
+  min-width: 9em;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 0.4rem 0;
+  background: var(--cd-bg-raised);
+  border: 1px solid var(--cd-border-amber);
+  border-radius: var(--cd-radius);
+  box-shadow: 0 8px 24px var(--cd-shadow);
+  z-index: 200;
+}
+.cd-nav-more-menu .cd-nav-link {
+  display: block;
+  padding: 0.35rem 0.85rem;
+  white-space: nowrap;
+}
+.cd-nav-more-menu .cd-nav-link:hover,
+.cd-nav-more-menu .cd-nav-link:focus-visible {
+  background: rgba(245, 179, 50, 0.10);
+  outline: none;
+}
+
 .cd-templates-welcome {
   background: var(--cd-bg-surface);
   border: 1px dashed var(--cd-border-amber);

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -2317,6 +2317,89 @@ body.cd-strip-visible .cd-shell { padding-top: 32px; }
 	font-variant-numeric: tabular-nums;
 }
 .cd-tt-entry-desc { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* ============================================================
+   TEMPLATES MANAGER PAGE — Phase 2.3
+   ============================================================ */
+
+.cd-templates-intro {
+  font-family: var(--cd-font-body);
+  font-size: 0.85rem;
+  color: var(--cd-text-dim);
+  line-height: 1.5;
+  margin: 0 0 1.25rem;
+  max-width: 60ch;
+}
+
+.cd-templates-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--cd-gap);
+}
+@media (max-width: 720px) {
+  .cd-templates-grid { grid-template-columns: 1fr; }
+}
+
+.cd-templates-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.cd-template-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.65rem 0.75rem;
+  border-bottom: 1px solid var(--cd-border);
+}
+.cd-template-row:last-child { border-bottom: none; }
+.cd-template-row:hover { background: rgba(212, 136, 10, 0.04); }
+
+.cd-template-row-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.cd-template-name {
+  font-family: var(--cd-font-heading);
+  font-size: 0.95rem;
+  color: var(--cd-text);
+  word-break: break-word;
+}
+
+.cd-template-desc {
+  font-family: var(--cd-font-body);
+  font-size: 0.78rem;
+  color: var(--cd-text-dim);
+  margin-top: 0.15rem;
+  word-break: break-word;
+}
+
+.cd-template-meta {
+  font-family: var(--cd-font-ui);
+  font-size: 0.55rem;
+  letter-spacing: 0.08em;
+  color: var(--cd-text-dim);
+  text-transform: uppercase;
+  margin-top: 0.3rem;
+}
+
+.cd-template-row-actions {
+  display: flex;
+  gap: 0.35rem;
+  flex-shrink: 0;
+}
+
+.cd-panel-count {
+  font-family: var(--cd-font-ui);
+  font-size: 0.55rem;
+  letter-spacing: 0.1em;
+  color: var(--cd-text-dim);
+  margin-left: 0.5rem;
+}
+
 /* Inline start/end time-edit on stopped entries — project page today-list */
 button.cd-tt-time-edit-trigger {
 	background: none;

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -2330,6 +2330,38 @@ body.cd-strip-visible .cd-shell { padding-top: 32px; }
   max-width: 60ch;
 }
 
+.cd-templates-welcome {
+  background: var(--cd-bg-surface);
+  border: 1px dashed var(--cd-border-amber);
+  border-radius: var(--cd-radius-lg);
+  padding: 2rem 1.75rem;
+  text-align: center;
+  max-width: 50ch;
+  margin: 1rem auto;
+}
+.cd-templates-welcome-title {
+  font-family: var(--cd-font-display);
+  font-size: 1.4rem;
+  color: var(--cd-amber-hi);
+  letter-spacing: 0.05em;
+  margin-bottom: 0.6rem;
+}
+.cd-templates-welcome-body {
+  font-family: var(--cd-font-body);
+  font-size: 0.85rem;
+  color: var(--cd-text);
+  line-height: 1.55;
+  margin-bottom: 1.25rem;
+}
+.cd-templates-welcome-body strong {
+  color: var(--cd-amber-hi);
+  font-weight: 600;
+}
+.cd-templates-welcome-actions {
+  display: flex;
+  justify-content: center;
+}
+
 .cd-templates-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -249,6 +249,11 @@ body.cd-strip-visible .cd-shell { padding-top: 32px; }
 
 .cd-main.full-width {
   grid-template-columns: 1fr;
+  /* Anchor short-content pages (templates manager) to the top instead of
+     distributing extra vertical space across the auto rows. Doesn't affect
+     content-rich full-width pages like /today/ and /reports/ where rows
+     fill the height naturally. */
+  align-content: start;
 }
 
 .cd-content {

--- a/static/command_deck_nav.js
+++ b/static/command_deck_nav.js
@@ -1,0 +1,33 @@
+// command_deck_nav.js
+// Phase 2.3 polish — MORE ▾ overflow menu in the CD header nav.
+// Two jobs:
+//   1. Mark the MORE trigger active when we're on a route that lives
+//      inside the menu (currently /reports + /templates). Also marks
+//      the matching <a> inside the menu so it pops when revealed.
+//   2. Close any open <details.cd-nav-more> when the user clicks
+//      outside it. <details> handles toggle + ESC for free; we just
+//      add the outside-click behavior.
+
+(function () {
+	'use strict';
+
+	var path = window.location.pathname;
+	var menuRoutes = ['/command-deck/reports', '/command-deck/templates'];
+	var underMenu = menuRoutes.some(function (r) { return path.indexOf(r) === 0; });
+
+	if (underMenu) {
+		document.querySelectorAll('.cd-nav-more-trigger').forEach(function (s) {
+			s.classList.add('active');
+		});
+		document.querySelectorAll('.cd-nav-more-menu a').forEach(function (a) {
+			var href = (a.getAttribute('href') || '').replace(/\/$/, '');
+			if (href && path.indexOf(href) === 0) a.classList.add('active');
+		});
+	}
+
+	document.addEventListener('click', function (ev) {
+		document.querySelectorAll('details.cd-nav-more[open]').forEach(function (d) {
+			if (!d.contains(ev.target)) d.removeAttribute('open');
+		});
+	});
+})();

--- a/templates/command_deck_area.html
+++ b/templates/command_deck_area.html
@@ -32,6 +32,8 @@
       <span class="cd-nav-sep">·</span>
       <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
       <span class="cd-nav-sep">·</span>
+      <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+      <span class="cd-nav-sep">·</span>
       <a href="/publish" class="cd-nav-link">COCKPIT</a>
     </nav>
   </header>

--- a/templates/command_deck_area.html
+++ b/templates/command_deck_area.html
@@ -30,9 +30,13 @@
       <span class="cd-nav-sep">·</span>
       <a href="/today/" class="cd-nav-link">TODAY</a>
       <span class="cd-nav-sep">·</span>
-      <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
-      <span class="cd-nav-sep">·</span>
-      <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+      <details class="cd-nav-more">
+        <summary class="cd-nav-link cd-nav-more-trigger">MORE ▾</summary>
+        <div class="cd-nav-more-menu">
+          <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
+          <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+        </div>
+      </details>
       <span class="cd-nav-sep">·</span>
       <a href="/publish" class="cd-nav-link">COCKPIT</a>
     </nav>
@@ -348,5 +352,6 @@
 
 {% include 'includes/today_panel.html' %}
 {% include 'includes/active_timer_strip.html' %}
+<script src="/static/command_deck_nav.js"></script>
 </body>
 </html>

--- a/templates/command_deck_dashboard.html
+++ b/templates/command_deck_dashboard.html
@@ -29,6 +29,8 @@
       <span class="cd-nav-sep">·</span>
       <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
       <span class="cd-nav-sep">·</span>
+      <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+      <span class="cd-nav-sep">·</span>
       <a href="/publish" class="cd-nav-link">COCKPIT</a>
     </nav>
   </header>

--- a/templates/command_deck_dashboard.html
+++ b/templates/command_deck_dashboard.html
@@ -306,6 +306,10 @@
 <div class="cd-modal-overlay" id="newProjectModal">
   <div class="cd-modal">
     <div class="cd-modal-title">// New Project</div>
+    <label style="display:block;font-family:var(--cd-font-ui);font-size:0.55rem;letter-spacing:0.18em;color:var(--cd-text-dim);text-transform:uppercase;margin-bottom:3px;">SPAWN FROM TEMPLATE (OPTIONAL)</label>
+    <select class="cd-input cd-mb-sm" id="newProjectTemplate" style="margin-bottom:0.5rem;">
+      <option value="">— blank —</option>
+    </select>
     <label style="display:block;font-family:var(--cd-font-ui);font-size:0.55rem;letter-spacing:0.18em;color:var(--cd-text-dim);text-transform:uppercase;margin-bottom:3px;">TYPE</label>
     <select class="cd-input cd-mb-sm" id="newProjectType" style="margin-bottom:0.5rem;">
       <option value="personal">Personal project</option>
@@ -554,9 +558,47 @@ function updateBadge() {
 // NEW PROJECT MODAL
 // ============================================================
 (function() {
+  // Phase 2.3 — fetch project templates once, cache, populate the dropdown
+  // each time the modal opens. Keeps the manager and the picker in sync
+  // across modal opens without needing a full page reload.
+  let cachedProjectTemplates = null;
+  async function populateTemplateDropdown() {
+    const sel = document.getElementById('newProjectTemplate');
+    if (!sel) return;
+    if (cachedProjectTemplates === null) {
+      try {
+        const r = await fetch('/command-deck/templates/list?kind=project', {credentials: 'same-origin'});
+        const d = await r.json();
+        cachedProjectTemplates = d.templates || [];
+      } catch (e) {
+        cachedProjectTemplates = [];
+      }
+    }
+    // Re-render option list
+    const blank = '<option value="">— blank —</option>';
+    const opts = cachedProjectTemplates.map(t =>
+      `<option value="${t.id}">${escapeHtml(t.name)}</option>`
+    ).join('');
+    sel.innerHTML = blank + opts;
+  }
+
   function openNewProject() {
     document.getElementById('newProjectModal').classList.add('open');
+    populateTemplateDropdown();
     document.getElementById('newProjectTitle').focus();
+  }
+
+  // Auto-fill title when a template is picked (still editable)
+  const templateSelect = document.getElementById('newProjectTemplate');
+  if (templateSelect) {
+    templateSelect.addEventListener('change', function () {
+      if (!templateSelect.value) return;
+      const opt = templateSelect.options[templateSelect.selectedIndex];
+      const titleEl = document.getElementById('newProjectTitle');
+      if (titleEl && !titleEl.value.trim()) {
+        titleEl.value = opt.textContent;
+      }
+    });
   }
 
   document.querySelectorAll('#newProjectBtn').forEach(btn => {
@@ -608,17 +650,19 @@ function updateBadge() {
       return;
     }
 
-    // Personal project — existing form-submit flow
+    // Personal project — existing form-submit flow (extended with template_id)
     const form = document.createElement('form');
     form.method = 'POST';
     form.action = '/command-deck/projects/new';
     const isPrivate = document.getElementById('newProjectPrivate').checked ? '1' : '0';
     const trackPers = document.getElementById('newProjectTrackingPersonal').checked ? '1' : '0';
+    const templateId = (document.getElementById('newProjectTemplate') || {}).value || '';
     form.innerHTML = `
       <input name="title" value="${escapeHtml(title)}">
       <input name="description" value="${escapeHtml(desc)}">
       <input name="is_private" value="${isPrivate}">
       <input name="tracking_enabled" value="${trackPers}">
+      <input name="template_id" value="${escapeHtml(templateId)}">
     `;
     document.body.appendChild(form);
     form.submit();

--- a/templates/command_deck_dashboard.html
+++ b/templates/command_deck_dashboard.html
@@ -27,9 +27,13 @@
       <span class="cd-nav-sep">·</span>
       <a href="/today/" class="cd-nav-link">TODAY</a>
       <span class="cd-nav-sep">·</span>
-      <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
-      <span class="cd-nav-sep">·</span>
-      <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+      <details class="cd-nav-more">
+        <summary class="cd-nav-link cd-nav-more-trigger">MORE ▾</summary>
+        <div class="cd-nav-more-menu">
+          <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
+          <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+        </div>
+      </details>
       <span class="cd-nav-sep">·</span>
       <a href="/publish" class="cd-nav-link">COCKPIT</a>
     </nav>
@@ -1087,5 +1091,6 @@ function cdShowAssign(id, context) {
 
 {% include 'includes/today_panel.html' %}
 {% include 'includes/active_timer_strip.html' %}
+<script src="/static/command_deck_nav.js"></script>
 </body>
 </html>

--- a/templates/command_deck_dashboard.html
+++ b/templates/command_deck_dashboard.html
@@ -636,14 +636,19 @@ function updateBadge() {
 
     const typeVal = typeSelect.value;
     if (typeVal.indexOf('work:') === 0) {
-      // Work sub-project — POST JSON to area's subprojects endpoint
+      // Work sub-project — POST JSON to area's subprojects endpoint.
+      // Phase 2.3 fix: include template_id so picking a template + a
+      // work sub-project type both apply (was silently dropped before).
       const areaSlug = typeVal.split(':')[1];
       const tracking = document.getElementById('newProjectTracking').checked;
+      const templateId = (document.getElementById('newProjectTemplate') || {}).value || '';
+      const payload = {title, description: desc, tracking_enabled: tracking};
+      if (templateId) payload.template_id = templateId;
       const r = await fetch(`/command-deck/areas/${areaSlug}/subprojects/new`, {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         credentials: 'same-origin',
-        body: JSON.stringify({title, description: desc, tracking_enabled: tracking})
+        body: JSON.stringify(payload)
       });
       const data = await r.json();
       if (data && data.success) {

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -77,7 +77,7 @@
         </div>
         <div style="display:flex;gap:0.5rem;flex-shrink:0;align-self:flex-start;">
           <button class="cd-btn sm" id="editProjectBtn">EDIT</button>
-          <button class="cd-btn sm" id="saveAsTemplateBtn" title="Save this project's structure as a reusable template">SAVE AS TEMPLATE</button>
+          <button class="cd-btn sm" id="saveAsTemplateBtn" data-default-name="{{ project.title }}" title="Save this project's structure as a reusable template">SAVE AS TEMPLATE</button>
           <button class="cd-btn sm danger" id="deleteProjectBtn">DELETE</button>
         </div>
       </div>
@@ -1182,8 +1182,11 @@ document.addEventListener('click', function (ev) {
 
 // Phase 2.3 — SAVE AS TEMPLATE (project)
 document.getElementById('saveAsTemplateBtn').addEventListener('click',function(){
-  const projectTitle = document.querySelector('.cd-project-title, .cd-page-title');
-  const seed = projectTitle ? projectTitle.textContent.trim() : '';
+  // Read the title from the button's data-default-name (Jinja-rendered
+  // from project.title) instead of the h1.textContent — the h1 also
+  // contains the ⏱ tracking and ★ favorite glyphs as inline siblings,
+  // and textContent would flatten them into the prompt seed.
+  const seed = document.getElementById('saveAsTemplateBtn').getAttribute('data-default-name') || '';
   const name = prompt('Save this project as a template — name:', seed);
   if (name == null) return;
   const trimmed = name.trim();

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -73,6 +73,7 @@
         </div>
         <div style="display:flex;gap:0.5rem;flex-shrink:0;align-self:flex-start;">
           <button class="cd-btn sm" id="editProjectBtn">EDIT</button>
+          <button class="cd-btn sm" id="saveAsTemplateBtn" title="Save this project's structure as a reusable template">SAVE AS TEMPLATE</button>
           <button class="cd-btn sm danger" id="deleteProjectBtn">DELETE</button>
         </div>
       </div>
@@ -1047,6 +1048,31 @@ document.getElementById('deleteProjectBtn').addEventListener('click',function(){
   const form=document.createElement('form');
   form.method='POST';form.action=`/command-deck/projects/${PROJECT_SLUG}/delete`;
   document.body.appendChild(form);form.submit();
+});
+
+// Phase 2.3 — SAVE AS TEMPLATE (project)
+document.getElementById('saveAsTemplateBtn').addEventListener('click',function(){
+  const projectTitle = document.querySelector('.cd-project-title, .cd-page-title');
+  const seed = projectTitle ? projectTitle.textContent.trim() : '';
+  const name = prompt('Save this project as a template — name:', seed);
+  if (name == null) return;
+  const trimmed = name.trim();
+  if (!trimmed) return;
+  fetch(`/command-deck/projects/${PROJECT_SLUG}/save-as-template`, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({name: trimmed}),
+    credentials: 'same-origin',
+  }).then(function (r) { return r.json().then(function (d) { return {ok: r.ok, data: d}; }); })
+    .then(function (res) {
+      if (res.ok && res.data.success) {
+        alert('Template saved. Manage at /command-deck/templates/');
+      } else {
+        alert('Could not save template: ' + (res.data.error || 'unknown error'));
+      }
+    }).catch(function () {
+      alert('Network error.');
+    });
 });
 
 // ============================================================

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -31,6 +31,8 @@
       <span class="cd-nav-sep">·</span>
       <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
       <span class="cd-nav-sep">·</span>
+      <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+      <span class="cd-nav-sep">·</span>
       <a href="/publish" class="cd-nav-link">COCKPIT</a>
     </nav>
   </header>

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -29,9 +29,13 @@
       <span class="cd-nav-sep">·</span>
       <a href="/today/" class="cd-nav-link">TODAY</a>
       <span class="cd-nav-sep">·</span>
-      <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
-      <span class="cd-nav-sep">·</span>
-      <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+      <details class="cd-nav-more">
+        <summary class="cd-nav-link cd-nav-more-trigger">MORE ▾</summary>
+        <div class="cd-nav-more-menu">
+          <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
+          <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+        </div>
+      </details>
       <span class="cd-nav-sep">·</span>
       <a href="/publish" class="cd-nav-link">COCKPIT</a>
     </nav>
@@ -2124,5 +2128,6 @@ function cdEditTask(id) {
 <script src="{{ url_for('static', filename='area_easter_eggs.js') }}"></script>
 
 {% include 'includes/today_panel.html' %}
+<script src="/static/command_deck_nav.js"></script>
 </body>
 </html>

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -103,6 +103,10 @@
         <span class="cd-text-mono cd-text-dim" style="font-size:0.6rem;letter-spacing:0.15em;">ADD BLOCK</span>
         <button class="cd-btn sm" data-type="note" id="addNoteBtn">+ NOTE</button>
         <button class="cd-btn sm" data-type="checklist" id="addChecklistBtn">+ CHECKLIST</button>
+        <div class="cd-add-from-template-wrap" style="position:relative;display:inline-block;">
+          <button class="cd-btn sm" id="addFromTemplateBtn" type="button">+ FROM CHECKLIST TEMPLATE ▾</button>
+          <div class="cd-template-dropdown" id="checklistTemplateDropdown" hidden></div>
+        </div>
       </div>
 
       <!-- CONTENT BLOCKS -->
@@ -122,6 +126,7 @@
                         data-kind="block" data-id="{{ block.id }}"
                         title="{% if block.today %}Remove from Today{% else %}Add to Today{% endif %}"
                         type="button">{{ '★' if block.today else '☆' }}</button>
+                <button class="cd-btn ghost sm cd-block-save-as-template" data-block-id="{{ block.id }}" data-default-name="{{ block.title or 'Untitled Checklist' }}" title="Save this checklist as a template" type="button">TEMPLATE</button>
                 {% endif %}
                 <button class="cd-block-collapse-btn" data-block-id="{{ block.id }}" title="Collapse">▾</button>
                 <button class="cd-btn ghost sm block-delete-btn" data-id="{{ block.id }}">REMOVE</button>
@@ -600,12 +605,14 @@ fetch('/below-deck/count').then(r=>r.json()).then(data=>{
             </div>
           </div>`;
       } else {
+        const titleAttr = block.title || 'Untitled Checklist';
         div.innerHTML=`
           <div class="cd-block-header" data-block-id="${block.id}">
             <span class="cd-block-drag-handle" title="Drag to reorder">⠿</span>
-            <span class="cd-block-title-display" data-block-id="${block.id}" data-type="checklist" data-custom-title="">${placeholder}</span>
+            <span class="cd-block-title-display" data-block-id="${block.id}" data-type="checklist" data-custom-title="${escapeHtml(block.title || '')}">${escapeHtml(block.title || placeholder)}</span>
             <div class="cd-panel-actions">
               <button class="cd-today-star" data-kind="block" data-id="${block.id}" title="Add to Today" type="button">☆</button>
+              <button class="cd-btn ghost sm cd-block-save-as-template" data-block-id="${block.id}" data-default-name="${escapeHtml(titleAttr)}" title="Save this checklist as a template" type="button">TEMPLATE</button>
               <button class="cd-block-collapse-btn" data-block-id="${block.id}" title="Collapse">▾</button>
               <button class="cd-btn ghost sm block-delete-btn" data-id="${block.id}">REMOVE</button>
             </div>
@@ -1049,6 +1056,125 @@ document.getElementById('deleteProjectBtn').addEventListener('click',function(){
   form.method='POST';form.action=`/command-deck/projects/${PROJECT_SLUG}/delete`;
   document.body.appendChild(form);form.submit();
 });
+
+// Phase 2.3 — SAVE AS TEMPLATE (checklist block) — delegated click handler
+document.addEventListener('click', function (ev) {
+  const btn = ev.target.closest('.cd-block-save-as-template');
+  if (!btn) return;
+  ev.preventDefault();
+  const blockId = btn.getAttribute('data-block-id');
+  const seed = btn.getAttribute('data-default-name') || '';
+  const name = prompt('Save this checklist as a template — name:', seed);
+  if (name == null) return;
+  const trimmed = name.trim();
+  if (!trimmed) return;
+  fetch(`/command-deck/projects/${PROJECT_SLUG}/blocks/${blockId}/save-as-template`, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({name: trimmed}),
+    credentials: 'same-origin',
+  }).then(function (r) { return r.json().then(function (d) { return {ok: r.ok, data: d}; }); })
+    .then(function (res) {
+      if (res.ok && res.data.success) {
+        alert('Checklist template saved. Manage at /command-deck/templates/');
+      } else {
+        alert('Could not save template: ' + (res.data.error || 'unknown error'));
+      }
+    }).catch(function () {
+      alert('Network error.');
+    });
+});
+
+// Phase 2.3 — "+ FROM CHECKLIST TEMPLATE" dropdown
+(function () {
+  'use strict';
+  const trigger = document.getElementById('addFromTemplateBtn');
+  const dropdown = document.getElementById('checklistTemplateDropdown');
+  if (!trigger || !dropdown) return;
+
+  let cached = null;
+
+  async function loadTemplates() {
+    if (cached !== null) return cached;
+    try {
+      const r = await fetch('/command-deck/templates/list?kind=checklist', {credentials: 'same-origin'});
+      const d = await r.json();
+      cached = d.templates || [];
+    } catch (e) {
+      cached = [];
+    }
+    return cached;
+  }
+
+  async function open() {
+    const tpls = await loadTemplates();
+    if (!tpls.length) {
+      dropdown.innerHTML = '<div class="cd-template-dropdown-empty">No checklist templates yet. Save one from any checklist block.</div>';
+    } else {
+      dropdown.innerHTML = tpls.map(function (t) {
+        return `<button type="button" class="cd-template-dropdown-option" data-id="${t.id}">${escapeHtml(t.name)}</button>`;
+      }).join('');
+    }
+    dropdown.hidden = false;
+    setTimeout(function () {
+      document.addEventListener('click', closeOnOutside, true);
+      document.addEventListener('keydown', closeOnEsc, true);
+    }, 0);
+  }
+
+  function close() {
+    dropdown.hidden = true;
+    cached = null;  // invalidate so next open re-fetches
+    document.removeEventListener('click', closeOnOutside, true);
+    document.removeEventListener('keydown', closeOnEsc, true);
+  }
+
+  function closeOnOutside(ev) {
+    if (dropdown.hidden) return;
+    if (dropdown.contains(ev.target) || trigger.contains(ev.target)) return;
+    close();
+  }
+
+  function closeOnEsc(ev) {
+    if (ev.key === 'Escape') { ev.stopPropagation(); close(); }
+  }
+
+  async function spawn(templateId) {
+    const fd = new FormData();
+    fd.append('type', 'checklist');
+    fd.append('template_id', templateId);
+    try {
+      const r = await fetch(`/command-deck/projects/${PROJECT_SLUG}/blocks/add`, {
+        method: 'POST',
+        body: fd,
+        credentials: 'same-origin',
+      });
+      if (r.ok) {
+        // Simplest re-render: full reload to pick up the new block + its
+        // items. addNoteBtn / addChecklistBtn handlers do this too.
+        location.reload();
+      } else {
+        const d = await r.json().catch(function () { return {}; });
+        alert('Could not spawn from template: ' + (d.error || 'unknown error'));
+      }
+    } catch (e) {
+      alert('Network error.');
+    }
+  }
+
+  trigger.addEventListener('click', function (ev) {
+    ev.stopPropagation();
+    if (dropdown.hidden) open(); else close();
+  });
+
+  dropdown.addEventListener('click', function (ev) {
+    const opt = ev.target.closest('.cd-template-dropdown-option');
+    if (!opt) return;
+    const id = opt.getAttribute('data-id');
+    close();
+    spawn(id);
+  });
+})();
 
 // Phase 2.3 — SAVE AS TEMPLATE (project)
 document.getElementById('saveAsTemplateBtn').addEventListener('click',function(){

--- a/templates/command_deck_projects.html
+++ b/templates/command_deck_projects.html
@@ -27,9 +27,13 @@
       <span class="cd-nav-sep">·</span>
       <a href="/today/" class="cd-nav-link">TODAY</a>
       <span class="cd-nav-sep">·</span>
-      <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
-      <span class="cd-nav-sep">·</span>
-      <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+      <details class="cd-nav-more">
+        <summary class="cd-nav-link cd-nav-more-trigger">MORE ▾</summary>
+        <div class="cd-nav-more-menu">
+          <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
+          <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+        </div>
+      </details>
       <span class="cd-nav-sep">·</span>
       <a href="/publish" class="cd-nav-link">COCKPIT</a>
     </nav>
@@ -606,5 +610,6 @@ function escapeHtml(str){const d=document.createElement('div');d.appendChild(doc
 
 {% include 'includes/today_panel.html' %}
 {% include 'includes/active_timer_strip.html' %}
+<script src="/static/command_deck_nav.js"></script>
 </body>
 </html>

--- a/templates/command_deck_projects.html
+++ b/templates/command_deck_projects.html
@@ -29,6 +29,8 @@
       <span class="cd-nav-sep">·</span>
       <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
       <span class="cd-nav-sep">·</span>
+      <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+      <span class="cd-nav-sep">·</span>
       <a href="/publish" class="cd-nav-link">COCKPIT</a>
     </nav>
   </header>

--- a/templates/command_deck_projects.html
+++ b/templates/command_deck_projects.html
@@ -326,13 +326,17 @@ fetch('/below-deck/count').then(r=>r.json()).then(data=>{
     if(!title) return;
     const typeVal = typeSelect.value;
     if(typeVal.indexOf('work:') === 0){
+      // Phase 2.3 fix: sub-project flow now passes template_id when set.
       const areaSlug = typeVal.split(':')[1];
       const tracking = document.getElementById('newProjectTracking').checked;
+      const templateId = (document.getElementById('newProjectTemplate') || {}).value || '';
+      const payload = {title, description: desc, tracking_enabled: tracking};
+      if (templateId) payload.template_id = templateId;
       const r = await fetch(`/command-deck/areas/${areaSlug}/subprojects/new`, {
         method:'POST',
         headers:{'Content-Type':'application/json'},
         credentials:'same-origin',
-        body: JSON.stringify({title, description: desc, tracking_enabled: tracking})
+        body: JSON.stringify(payload)
       });
       const data = await r.json();
       if(data && data.success){

--- a/templates/command_deck_projects.html
+++ b/templates/command_deck_projects.html
@@ -171,6 +171,10 @@
 <div class="cd-modal-overlay" id="newProjectModal">
   <div class="cd-modal">
     <div class="cd-modal-title">// New Project</div>
+    <label style="display:block;font-family:var(--cd-font-ui);font-size:0.55rem;letter-spacing:0.18em;color:var(--cd-text-dim);text-transform:uppercase;margin-bottom:3px;">SPAWN FROM TEMPLATE (OPTIONAL)</label>
+    <select class="cd-input cd-mb-sm" id="newProjectTemplate" style="margin-bottom:0.5rem;">
+      <option value="">— blank —</option>
+    </select>
     <label style="display:block;font-family:var(--cd-font-ui);font-size:0.55rem;letter-spacing:0.18em;color:var(--cd-text-dim);text-transform:uppercase;margin-bottom:3px;">TYPE</label>
     <select class="cd-input cd-mb-sm" id="newProjectType" style="margin-bottom:0.5rem;">
       <option value="personal">Personal project</option>
@@ -256,8 +260,42 @@ fetch('/below-deck/count').then(r=>r.json()).then(data=>{
 
 // New project modal
 (function(){
+  // Phase 2.3 — populate template dropdown on modal open
+  let cachedProjectTemplates = null;
+  async function populateTemplateDropdown() {
+    const sel = document.getElementById('newProjectTemplate');
+    if (!sel) return;
+    if (cachedProjectTemplates === null) {
+      try {
+        const r = await fetch('/command-deck/templates/list?kind=project', {credentials: 'same-origin'});
+        const d = await r.json();
+        cachedProjectTemplates = d.templates || [];
+      } catch (e) {
+        cachedProjectTemplates = [];
+      }
+    }
+    const blank = '<option value="">— blank —</option>';
+    const opts = cachedProjectTemplates.map(t =>
+      `<option value="${t.id}">${escapeHtml(t.name)}</option>`
+    ).join('');
+    sel.innerHTML = blank + opts;
+  }
+  // Auto-fill title when a template is picked (still editable)
+  const templateSelect = document.getElementById('newProjectTemplate');
+  if (templateSelect) {
+    templateSelect.addEventListener('change', function () {
+      if (!templateSelect.value) return;
+      const opt = templateSelect.options[templateSelect.selectedIndex];
+      const titleEl = document.getElementById('newProjectTitle');
+      if (titleEl && !titleEl.value.trim()) {
+        titleEl.value = opt.textContent;
+      }
+    });
+  }
+
   document.getElementById('newProjectBtn').addEventListener('click',()=>{
     document.getElementById('newProjectModal').classList.add('open');
+    populateTemplateDropdown();
     document.getElementById('newProjectTitle').focus();
   });
   document.getElementById('cancelBtn').addEventListener('click',()=>{
@@ -304,11 +342,13 @@ fetch('/below-deck/count').then(r=>r.json()).then(data=>{
     form.method='POST'; form.action='/command-deck/projects/new';
     const isPrivate = document.getElementById('newProjectPrivate').checked ? '1' : '0';
     const trackPers = document.getElementById('newProjectTrackingPersonal').checked ? '1' : '0';
+    const templateId = (document.getElementById('newProjectTemplate') || {}).value || '';
     form.innerHTML = `
       <input name="title" value="${escapeHtml(title)}">
       <input name="description" value="${escapeHtml(desc)}">
       <input name="is_private" value="${isPrivate}">
       <input name="tracking_enabled" value="${trackPers}">
+      <input name="template_id" value="${escapeHtml(templateId)}">
     `;
     document.body.appendChild(form); form.submit();
   }

--- a/templates/command_deck_reports.html
+++ b/templates/command_deck_reports.html
@@ -27,9 +27,13 @@
       <span class="cd-nav-sep">·</span>
       <a href="/today/" class="cd-nav-link">TODAY</a>
       <span class="cd-nav-sep">·</span>
-      <a href="/command-deck/reports/" class="cd-nav-link active">REPORTS</a>
-      <span class="cd-nav-sep">·</span>
-      <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+      <details class="cd-nav-more">
+        <summary class="cd-nav-link cd-nav-more-trigger">MORE ▾</summary>
+        <div class="cd-nav-more-menu">
+          <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
+          <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+        </div>
+      </details>
       <span class="cd-nav-sep">·</span>
       <a href="/publish" class="cd-nav-link">COCKPIT</a>
     </nav>
@@ -139,5 +143,6 @@
 </div><!-- .cd-shell -->
 
 <script src="/static/command_deck_reports.js"></script>
+<script src="/static/command_deck_nav.js"></script>
 </body>
 </html>

--- a/templates/command_deck_reports.html
+++ b/templates/command_deck_reports.html
@@ -29,6 +29,8 @@
       <span class="cd-nav-sep">·</span>
       <a href="/command-deck/reports/" class="cd-nav-link active">REPORTS</a>
       <span class="cd-nav-sep">·</span>
+      <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+      <span class="cd-nav-sep">·</span>
       <a href="/publish" class="cd-nav-link">COCKPIT</a>
     </nav>
   </header>

--- a/templates/command_deck_templates.html
+++ b/templates/command_deck_templates.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <title>Templates · Command Deck</title>
+  <link rel="stylesheet" href="/static/command_deck.css">
+</head>
+<body class="command-deck">
+<div class="cd-shell">
+
+  <!-- HEADER -->
+  <header class="cd-header">
+    <div class="cd-header-left">
+      <a href="/command-deck/" class="cd-wordmark">COMMAND DECK</a>
+      <span class="cd-ident">TEMPLATES · SCAFFOLDING</span>
+    </div>
+    <nav class="cd-header-nav">
+      <a href="/command-deck/" class="cd-nav-link">BRIDGE</a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/command-deck/projects/" class="cd-nav-link">PROJECTS</a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/below-deck" class="cd-nav-link">
+        BELOW DECK
+        <span class="cd-bd-badge" id="bdBadge"></span>
+      </a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/today/" class="cd-nav-link">TODAY</a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/command-deck/templates/" class="cd-nav-link active">TEMPLATES</a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/publish" class="cd-nav-link">COCKPIT</a>
+    </nav>
+  </header>
+
+  {% include 'includes/today_panel.html' %}
+  {% include 'includes/active_timer_strip.html' %}
+
+  <!-- MAIN -->
+  <div class="cd-main full-width">
+
+    <div class="cd-templates-intro">
+      Templates capture the structure of a recurring project or checklist —
+      save a known-good shape from any project page or block header, then
+      spawn fresh copies whenever you need them. Items always start
+      unchecked; tasks always start open.
+    </div>
+
+    <div class="cd-templates-grid">
+
+      <!-- PROJECT TEMPLATES -->
+      <div class="cd-panel">
+        <div class="cd-panel-header">
+          <span class="cd-panel-title">// Project Templates</span>
+          <span class="cd-panel-count">{{ project_templates | length }}</span>
+        </div>
+        <div class="cd-panel-body">
+          {% if project_templates %}
+            <ul class="cd-templates-list">
+              {% for t in project_templates %}
+                <li class="cd-template-row" data-template-id="{{ t.id }}" data-kind="project">
+                  <div class="cd-template-row-main">
+                    <div class="cd-template-name">{{ t.name }}</div>
+                    {% if t.description %}
+                      <div class="cd-template-desc">{{ t.description }}</div>
+                    {% endif %}
+                    <div class="cd-template-meta">
+                      {{ t.block_count }} block{{ '' if t.block_count == 1 else 's' }} ·
+                      {{ t.task_count }} task{{ '' if t.task_count == 1 else 's' }} ·
+                      updated {{ t.updated[:10] }}
+                    </div>
+                  </div>
+                  <div class="cd-template-row-actions">
+                    <button class="cd-btn ghost sm cd-template-rename" type="button" data-id="{{ t.id }}" data-current="{{ t.name }}">RENAME</button>
+                    <button class="cd-btn ghost sm cd-template-delete" type="button" data-id="{{ t.id }}" data-name="{{ t.name }}">DELETE</button>
+                  </div>
+                </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <div class="cd-empty">
+              No project templates yet. Save a project as a template from any project page.
+            </div>
+          {% endif %}
+        </div>
+      </div>
+
+      <!-- CHECKLIST TEMPLATES -->
+      <div class="cd-panel">
+        <div class="cd-panel-header">
+          <span class="cd-panel-title">// Checklist Templates</span>
+          <span class="cd-panel-count">{{ checklist_templates | length }}</span>
+        </div>
+        <div class="cd-panel-body">
+          {% if checklist_templates %}
+            <ul class="cd-templates-list">
+              {% for t in checklist_templates %}
+                <li class="cd-template-row" data-template-id="{{ t.id }}" data-kind="checklist">
+                  <div class="cd-template-row-main">
+                    <div class="cd-template-name">{{ t.name }}</div>
+                    {% if t.title_in_body and t.title_in_body != t.name %}
+                      <div class="cd-template-desc">spawns block titled "{{ t.title_in_body }}"</div>
+                    {% endif %}
+                    <div class="cd-template-meta">
+                      {{ t.item_count }} item{{ '' if t.item_count == 1 else 's' }} ·
+                      updated {{ t.updated[:10] }}
+                    </div>
+                  </div>
+                  <div class="cd-template-row-actions">
+                    <button class="cd-btn ghost sm cd-template-rename" type="button" data-id="{{ t.id }}" data-current="{{ t.name }}">RENAME</button>
+                    <button class="cd-btn ghost sm cd-template-delete" type="button" data-id="{{ t.id }}" data-name="{{ t.name }}">DELETE</button>
+                  </div>
+                </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <div class="cd-empty">
+              No checklist templates yet. Save a checklist block as a template from any project page.
+            </div>
+          {% endif %}
+        </div>
+      </div>
+
+    </div><!-- /.cd-templates-grid -->
+
+  </div><!-- /.cd-main -->
+
+  <!-- FOOTER -->
+  <footer class="cd-footer">
+    <div class="cd-footer-links">
+      <a href="/command-deck/" class="cd-footer-link">Bridge</a>
+      <a href="/command-deck/projects/" class="cd-footer-link">Projects</a>
+      <a href="/publish" class="cd-footer-link">Cockpit</a>
+    </div>
+    {% include 'includes/cd_footer_status.html' %}
+    <span class="cd-footer-ident">YT-1300F · COMMAND DECK · SECURE</span>
+  </footer>
+
+</div><!-- /.cd-shell -->
+
+<script>
+(function () {
+  'use strict';
+
+  // Below Deck badge
+  fetch('/below-deck/count').then(function (r) { return r.json(); }).then(function (d) {
+    var el = document.getElementById('bdBadge');
+    if (!el || !d.count) return;
+    el.classList.add(d.count <= 3 ? 'green' : (d.count <= 6 ? 'amber' : 'red'));
+  }).catch(function () {});
+
+  // Rename
+  document.querySelectorAll('.cd-template-rename').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var id = btn.getAttribute('data-id');
+      var current = btn.getAttribute('data-current');
+      var next = prompt('Rename template:', current);
+      if (next == null) return;
+      next = next.trim();
+      if (!next || next === current) return;
+      fetch('/command-deck/templates/' + id + '/update', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({name: next}),
+        credentials: 'same-origin',
+      }).then(function (r) {
+        if (r.ok) location.reload();
+        else alert('Could not rename.');
+      });
+    });
+  });
+
+  // Delete (with confirm)
+  document.querySelectorAll('.cd-template-delete').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var id = btn.getAttribute('data-id');
+      var name = btn.getAttribute('data-name');
+      if (!confirm('Delete template "' + name + '"? This cannot be undone.')) return;
+      fetch('/command-deck/templates/' + id + '/delete', {
+        method: 'POST',
+        credentials: 'same-origin',
+      }).then(function (r) {
+        if (r.ok) {
+          var row = btn.closest('.cd-template-row');
+          if (row) row.remove();
+        } else {
+          alert('Could not delete.');
+        }
+      });
+    });
+  });
+})();
+</script>
+
+</body>
+</html>

--- a/templates/command_deck_templates.html
+++ b/templates/command_deck_templates.html
@@ -27,9 +27,13 @@
       <span class="cd-nav-sep">·</span>
       <a href="/today/" class="cd-nav-link">TODAY</a>
       <span class="cd-nav-sep">·</span>
-      <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
-      <span class="cd-nav-sep">·</span>
-      <a href="/command-deck/templates/" class="cd-nav-link active">TEMPLATES</a>
+      <details class="cd-nav-more">
+        <summary class="cd-nav-link cd-nav-more-trigger">MORE ▾</summary>
+        <div class="cd-nav-more-menu">
+          <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
+          <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+        </div>
+      </details>
       <span class="cd-nav-sep">·</span>
       <a href="/publish" class="cd-nav-link">COCKPIT</a>
     </nav>
@@ -209,5 +213,6 @@
 })();
 </script>
 
+<script src="/static/command_deck_nav.js"></script>
 </body>
 </html>

--- a/templates/command_deck_templates.html
+++ b/templates/command_deck_templates.html
@@ -48,6 +48,20 @@
       unchecked; tasks always start open.
     </div>
 
+    {% if not project_templates and not checklist_templates %}
+    <div class="cd-templates-welcome">
+      <div class="cd-templates-welcome-title">// No templates yet</div>
+      <div class="cd-templates-welcome-body">
+        Open any project page and click <strong>SAVE AS TEMPLATE</strong> to
+        snapshot its blocks, items, and tasks. Or click <strong>TEMPLATE</strong>
+        on a checklist block header to capture just that checklist for reuse.
+      </div>
+      <div class="cd-templates-welcome-actions">
+        <a href="/command-deck/projects/" class="cd-btn primary">BROWSE PROJECTS</a>
+      </div>
+    </div>
+    {% else %}
+
     <div class="cd-templates-grid">
 
       <!-- PROJECT TEMPLATES -->
@@ -124,6 +138,7 @@
       </div>
 
     </div><!-- /.cd-templates-grid -->
+    {% endif %}
 
   </div><!-- /.cd-main -->
 

--- a/templates/today.html
+++ b/templates/today.html
@@ -27,9 +27,13 @@
       <span class="cd-nav-sep">·</span>
       <a href="/today/" class="cd-nav-link active">TODAY</a>
       <span class="cd-nav-sep">·</span>
-      <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
-      <span class="cd-nav-sep">·</span>
-      <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+      <details class="cd-nav-more">
+        <summary class="cd-nav-link cd-nav-more-trigger">MORE ▾</summary>
+        <div class="cd-nav-more-menu">
+          <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
+          <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+        </div>
+      </details>
       <span class="cd-nav-sep">·</span>
       <a href="/publish" class="cd-nav-link">COCKPIT</a>
     </nav>
@@ -387,5 +391,6 @@
 })();
 </script>
 
+<script src="/static/command_deck_nav.js"></script>
 </body>
 </html>

--- a/templates/today.html
+++ b/templates/today.html
@@ -29,6 +29,8 @@
       <span class="cd-nav-sep">·</span>
       <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
       <span class="cd-nav-sep">·</span>
+      <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+      <span class="cd-nav-sep">·</span>
       <a href="/publish" class="cd-nav-link">COCKPIT</a>
     </nav>
   </header>


### PR DESCRIPTION
## Summary

Phase 2.3 ships reusable project + checklist templates plus a nav streamline that surfaced during testing. Spec: `.kt/spec-time-tracking-phase-2-3.md`. Original 6-commit plan plus 4 field-testing fixes = 10 commits.

### Original plan (6)

1. **`chore(db)`** — single `templates` table (`id, kind, name, description, body_json, created, updated`) + `idx_templates_kind`. JSON body stores blocks/items/tasks for project kind, items for checklist kind. Migration is idempotent.
2. **`feat(templates)` backend** — list (`GET /command-deck/templates/list?kind=…`), save-as (project + checklist block), update (rename), delete. `cd_project_new` extended to accept `template_id` and INSERT blocks/items/tasks via `_apply_project_template` helper. `cd_block_add` extended to accept `template_id` for checklist blocks via `_apply_checklist_template` helper. Auto-strip drops checked / completed / today flags so spawned instances start clean.
3. **`feat(templates)` manager page** at `/command-deck/templates/` — two-column grid (Project Templates / Checklist Templates), per-row rename + delete, summary counts. TEMPLATES link added to main CD nav across all CD-styled pages.
4. **`feat(templates)` project UI** — SAVE AS TEMPLATE button on project page action row + "Spawn from template (optional)" `<select>` at top of New Project modal in dashboard + projects list. Picking a template auto-fills the title input (still editable).
5. **`feat(templates)` checklist UI** — TEMPLATE button in checklist block header (next to ★ / collapse / REMOVE) + "+ FROM CHECKLIST TEMPLATE ▾" button on Add Block flow with dropdown of checklist templates.
6. **`chore(kt)`** sweep + welcome state on the manager page when both panels are empty.

### Field-testing fixes (4)

7. **`feat(nav)` MORE ▾ overflow menu** — Aaron flagged the nav as heavy after Phase 2.3 added TEMPLATES (7 links + 6 separators). Collapsed REPORTS + TEMPLATES under a `<details>` overflow menu. Cuts visible row to 5. Click outside / ESC close handled by `<details>` natively + a small shared `static/command_deck_nav.js`. Active state auto-detected from `location.pathname`.
8. **`fix(templates)` top-anchor** — manager page rendered with panels stuck in lower-middle of viewport. Root cause: `.cd-main` is a flex-stretched grid with auto rows; default `align-content` redistributes when content is short. Fixed with `align-content: start` on `.cd-main.full-width`.
9. **`fix(templates)` save-as seed** — SAVE AS TEMPLATE prompt prefilled with title + ⏱ + ★ glyphs because JS read `.textContent` from the h1, which contained icon spans as inline siblings. Switched to a `data-default-name` attribute rendered from `project.title` directly. Mirrors the block-level pattern.
10. **`fix(templates)` sub-project spawn** — picking a template + a "Sub-project under <area>" type silently dropped the template. Sub-project create JSON path didn't carry `template_id`, and `cd_area_subproject_new` didn't accept it. Both ends now wired; templates spawn cleanly into either personal projects or work sub-projects.

## Question + answer captured during testing

**"What happens if I delete the parent project after saving it as a template?"**

Templates are independent rows — `body_json` is a snapshot at save time, no FK back to the source project. Deleting the source project does NOT delete the template. The template lives on as scaffolding. Workflow "save → delete source → spawn fresh whenever" is fully supported.

## Test plan

Verified locally during build + Aaron's smoke testing:
- [x] Migration idempotent across two runs; `templates` table + `idx_templates_kind` confirmed
- [x] All 5 backend routes round-trip (list, save-as project, save-as checklist, update, delete) + reject cases (bad kind, missing name, note-block save-as, etc.)
- [x] Spawn project from template via personal path: blocks/items/tasks all copied, items unchecked, tasks open
- [x] Spawn project from template via sub-project path: same
- [x] Spawn checklist block from template: items + title adopted
- [x] Manager page renders welcome card when zero templates; per-panel empty when one kind has templates
- [x] Rename + delete flows work; delete confirms before posting
- [x] MORE ▾ menu appears on all 7 CD-styled pages; REPORTS/TEMPLATES leaks-out check passes; nav.js loaded; active state lights on /reports + /templates
- [x] Save-as prompt seeds from clean title (no icon glyphs)
- [x] Aaron eyeballed all surfaces: "boom, done"

After merge:
- [ ] On PA: `git pull origin main && python migrate_add_templates.py && reload web app`

## KT doc sweep (gitignored, local-only)

- `.kt/spec-time-tracking-phase-2-3.md` — Status: ✅ Shipped 2026-05-05; commit count updated to 10 with the 4 follow-up fixes called out
- `.kt/KT-command-deck.md` — `templates` table added to schema section; `migrate_add_templates.py` listed in setup; Deferred Features marks 2.3 ✅; nav streamline noted; Last updated bumped
- `.kt/PROJECT_KNOWLEDGE.md` — Today description rewritten to mention templates + nav streamline; Last updated bumped

## Merge strategy

Rebase-merge / fast-forward only. 10 commits in narrative order, Han Solo voice runs through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)