### PR TITLE
Phase 2.4 — block recurrence + per-cycle item instances + due dates

### DIFF
--- a/blueprints/command_deck.py
+++ b/blueprints/command_deck.py
@@ -908,6 +908,122 @@ def cd_block_update_title(slug, block_id):
 
     return jsonify({'success': True, 'title': title})
 
+# ---- Phase 2.4 — block recurrence + manual reset ----
+
+@command_deck_bp.route('/command-deck/projects/<slug>/blocks/<int:block_id>/recurrence', methods=['POST'])
+@cd_auth_required
+def cd_block_recurrence(slug, block_id):
+	"""Set or clear a checklist block's recurrence.
+
+	Body (JSON or form):
+	  recurrence:      'daily' | 'weekly' | 'monthly' | null
+	  recurrence_days: per-kind:
+	                    daily   → CSV active weekdays ('Mon,Tue,Wed,Thu,Fri'); NULL=all 7
+	                    weekly  → single weekday ('Fri') the cycle is due
+	                    monthly → day-of-month string ('1','15','last')
+
+	On enable: stamps due_date=today on existing active items + last_reset_at=now
+	so the autoclear-spawn pass waits for the next cycle boundary. The current
+	items become the cycle's "structure" for future spawns.
+
+	On disable (recurrence=null): clears the recurrence columns. Existing
+	due_date values on items are preserved (user can clear manually if wanted).
+	"""
+	from blueprints.today import _et_now_iso
+	data = request.get_json(silent=True) or request.form
+	recurrence = data.get('recurrence')
+	if recurrence in ('', 'null', 'none'):
+		recurrence = None
+	if recurrence not in (None, 'daily', 'weekly', 'monthly'):
+		return jsonify({'error': 'invalid_recurrence'}), 400
+	recurrence_days = data.get('recurrence_days')
+	if recurrence_days in ('', None):
+		recurrence_days = None
+
+	conn = get_db()
+	block = conn.execute(
+		'SELECT b.* FROM blocks b JOIN projects p ON b.project_id = p.id '
+		'WHERE b.id = ? AND p.slug = ?',
+		(block_id, slug)
+	).fetchone()
+	if not block:
+		conn.close()
+		return jsonify({'error': 'not_found'}), 404
+	if recurrence is not None and block['type'] != 'checklist':
+		conn.close()
+		return jsonify({'error': 'recurrence_only_on_checklist'}), 400
+
+	if recurrence is None:
+		conn.execute(
+			'UPDATE blocks SET recurrence = NULL, recurrence_days = NULL, last_reset_at = NULL '
+			'WHERE id = ?', (block_id,)
+		)
+	else:
+		now_iso = _et_now_iso()
+		today_iso = datetime.now(pytz.timezone('US/Eastern')).strftime('%Y-%m-%d')
+		conn.execute(
+			'UPDATE blocks SET recurrence = ?, recurrence_days = ?, last_reset_at = ? '
+			'WHERE id = ?',
+			(recurrence, recurrence_days, now_iso, block_id)
+		)
+		# Stamp current active items with today's due_date so they read as
+		# "this cycle's instance." Items with an existing due_date are left.
+		conn.execute('''
+			UPDATE checklist_items
+			SET due_date = ?
+			WHERE block_id = ? AND archived_at IS NULL AND due_date IS NULL
+		''', (today_iso, block_id))
+
+	conn.commit()
+	conn.close()
+	return jsonify({'success': True, 'recurrence': recurrence, 'recurrence_days': recurrence_days})
+
+
+@command_deck_bp.route('/command-deck/projects/<slug>/blocks/<int:block_id>/reset', methods=['POST'])
+@cd_auth_required
+def cd_block_reset(slug, block_id):
+	"""Manually trigger a cycle fire on a recurring checklist block.
+
+	Archives current active items + spawns fresh instances with a new
+	due_date. The new due_date is computed the same way as the autoclear
+	would compute it for this kind of recurrence: today for daily, next
+	target weekday for weekly, target day-of-month for monthly.
+
+	400 if block is not recurring.
+	"""
+	from blueprints.today import (
+		_spawn_cycle, _next_weekday_iso, _this_month_target_iso,
+	)
+	conn = get_db()
+	block = conn.execute(
+		'SELECT b.* FROM blocks b JOIN projects p ON b.project_id = p.id '
+		'WHERE b.id = ? AND p.slug = ?',
+		(block_id, slug)
+	).fetchone()
+	if not block:
+		conn.close()
+		return jsonify({'error': 'not_found'}), 404
+	if not block['recurrence']:
+		conn.close()
+		return jsonify({'error': 'block_not_recurring'}), 400
+
+	eastern = pytz.timezone('US/Eastern')
+	now_et = datetime.now(eastern)
+	if block['recurrence'] == 'daily':
+		due = now_et.strftime('%Y-%m-%d')
+	elif block['recurrence'] == 'weekly':
+		target = (block['recurrence_days'] or 'Fri').split(',')[0].strip() or 'Fri'
+		due = _next_weekday_iso(now_et, target)
+	else:  # monthly
+		target = (block['recurrence_days'] or '1').strip() or '1'
+		due = _this_month_target_iso(now_et, target)
+
+	count = _spawn_cycle(conn, block_id, cycle_due_date=due, et_now=now_et)
+	conn.commit()
+	conn.close()
+	return jsonify({'success': True, 'spawned_count': count, 'due_date': due})
+
+
 @command_deck_bp.route('/command-deck/projects/<slug>/blocks/<int:block_id>/delete', methods=['POST'])
 @cd_auth_required
 def cd_block_delete(slug, block_id):

--- a/blueprints/command_deck.py
+++ b/blueprints/command_deck.py
@@ -1145,6 +1145,40 @@ def cd_checklist_toggle(slug, item_id):
 	return jsonify({'error': 'not found'}), 404
 
 
+@command_deck_bp.route('/command-deck/projects/<slug>/checklist/<int:item_id>/due-date', methods=['POST'])
+@cd_auth_required
+def cd_checklist_item_due_date(slug, item_id):
+	"""Phase 2.4 — set or clear due_date on a checklist item.
+	Mirrors the task due_date route. Accepts ISO YYYY-MM-DD or empty to clear."""
+	data = request.get_json(silent=True) or request.form
+	val = data.get('due_date')
+	if val in (None, '', 'null'):
+		due = None
+	else:
+		val = val.strip()
+		import datetime as _dt
+		try:
+			_dt.date.fromisoformat(val)
+		except (ValueError, TypeError):
+			return jsonify({'error': 'invalid_due_date'}), 400
+		due = val
+	conn = get_db()
+	# Validate item exists + belongs to a block in this project
+	row = conn.execute('''
+		SELECT ci.id FROM checklist_items ci
+		JOIN blocks b ON ci.block_id = b.id
+		JOIN projects p ON b.project_id = p.id
+		WHERE ci.id = ? AND p.slug = ?
+	''', (item_id, slug)).fetchone()
+	if not row:
+		conn.close()
+		return jsonify({'error': 'not_found'}), 404
+	conn.execute('UPDATE checklist_items SET due_date = ? WHERE id = ?', (due, item_id))
+	conn.commit()
+	conn.close()
+	return jsonify({'success': True, 'due_date': due})
+
+
 @command_deck_bp.route('/command-deck/projects/<slug>/checklist/add', methods=['POST'])
 @cd_auth_required
 def cd_checklist_add(slug):

--- a/blueprints/command_deck.py
+++ b/blueprints/command_deck.py
@@ -11,7 +11,7 @@ import json
 import re
 import uuid
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 import pytz
 import anthropic
 import requests as req_lib
@@ -183,7 +183,7 @@ def cd_project_save_as_template(slug):
 			entry['content'] = b['content'] or ''
 		else:
 			items = conn.execute(
-				'SELECT text FROM checklist_items WHERE block_id = ? ORDER BY id ASC',
+				'SELECT text FROM checklist_items WHERE block_id = ? AND archived_at IS NULL ORDER BY id ASC',
 				(b['id'],)
 			).fetchall()
 			entry['items'] = [{'text': i['text']} for i in items]
@@ -230,7 +230,7 @@ def cd_block_save_as_template(slug, block_id):
 		return jsonify({'error': 'block_not_checklist'}), 400
 
 	items = conn.execute(
-		'SELECT text FROM checklist_items WHERE block_id = ? ORDER BY id ASC',
+		'SELECT text FROM checklist_items WHERE block_id = ? AND archived_at IS NULL ORDER BY id ASC',
 		(block_id,)
 	).fetchall()
 	body = {
@@ -574,7 +574,7 @@ def cd_project(slug):
 		block = dict(b)
 		if block['type'] == 'checklist':
 			items = conn.execute(
-				'SELECT * FROM checklist_items WHERE block_id = ? ORDER BY id ASC',
+				'SELECT * FROM checklist_items WHERE block_id = ? AND archived_at IS NULL ORDER BY id ASC',
 				(block['id'],)
 			).fetchall()
 			items_with_lifetime = []
@@ -852,7 +852,7 @@ def cd_block_add(slug):
 	block = dict(conn.execute('SELECT * FROM blocks WHERE id = ?', (block_id,)).fetchone())
 	if block_type == 'checklist':
 		items = conn.execute(
-			'SELECT * FROM checklist_items WHERE block_id = ? ORDER BY id ASC',
+			'SELECT * FROM checklist_items WHERE block_id = ? AND archived_at IS NULL ORDER BY id ASC',
 			(block_id,)
 		).fetchall()
 		block['items'] = [dict(i) for i in items]
@@ -977,6 +977,55 @@ def cd_block_recurrence(slug, block_id):
 	conn.commit()
 	conn.close()
 	return jsonify({'success': True, 'recurrence': recurrence, 'recurrence_days': recurrence_days})
+
+
+@command_deck_bp.route('/command-deck/projects/<slug>/blocks/<int:block_id>/history', methods=['GET'])
+@cd_auth_required
+def cd_block_history(slug, block_id):
+	"""Return archived past-cycle items grouped by due_date desc.
+
+	Limited to last 90 days for v1 — older history is reachable via reports.
+	Read-only: no toggle / edit / delete on archived items in this view.
+	"""
+	conn = get_db()
+	# Validate block belongs to project
+	block = conn.execute(
+		'SELECT b.id FROM blocks b JOIN projects p ON b.project_id = p.id '
+		'WHERE b.id = ? AND p.slug = ?',
+		(block_id, slug)
+	).fetchone()
+	if not block:
+		conn.close()
+		return jsonify({'error': 'not_found'}), 404
+
+	cutoff = (datetime.now(pytz.timezone('US/Eastern')) - timedelta(days=90)).strftime('%Y-%m-%d')
+	rows = conn.execute('''
+		SELECT id, text, checked, due_date, archived_at
+		FROM checklist_items
+		WHERE block_id = ?
+		  AND archived_at IS NOT NULL
+		  AND (due_date IS NULL OR due_date >= ?)
+		ORDER BY due_date DESC, id ASC
+	''', (block_id, cutoff)).fetchall()
+	conn.close()
+
+	# Group by due_date
+	groups = []
+	current_date = object()  # sentinel
+	current_items = None
+	for r in rows:
+		d = r['due_date'] or '(no due date)'
+		if d != current_date:
+			current_date = d
+			current_items = []
+			groups.append({'due_date': d, 'items': current_items})
+		current_items.append({
+			'id': r['id'],
+			'text': r['text'],
+			'checked': bool(r['checked']),
+			'archived_at': r['archived_at'],
+		})
+	return jsonify({'history': groups})
 
 
 @command_deck_bp.route('/command-deck/projects/<slug>/blocks/<int:block_id>/reset', methods=['POST'])
@@ -1419,7 +1468,7 @@ def _huyang_load_project_content(conn, project_id):
 		block = dict(b)
 		if block['type'] == 'checklist':
 			items = conn.execute(
-				'SELECT * FROM checklist_items WHERE block_id = ? ORDER BY id ASC',
+				'SELECT * FROM checklist_items WHERE block_id = ? AND archived_at IS NULL ORDER BY id ASC',
 				(block['id'],)
 			).fetchall()
 			block['items'] = [dict(i) for i in items]
@@ -1456,7 +1505,7 @@ def _huyang_load_area_content(conn, area_id):
 		bd = dict(b)
 		if bd['type'] == 'checklist':
 			items = conn.execute(
-				'SELECT * FROM checklist_items WHERE block_id = ? ORDER BY id ASC',
+				'SELECT * FROM checklist_items WHERE block_id = ? AND archived_at IS NULL ORDER BY id ASC',
 				(bd['id'],)
 			).fetchall()
 			bd['items'] = [dict(i) for i in items]

--- a/blueprints/tasks.py
+++ b/blueprints/tasks.py
@@ -120,6 +120,36 @@ def task_edit(task_id):
 	return jsonify({'success': True, 'task': dict(task)})
 
 
+@tasks_bp.route('/tasks/<int:task_id>/due-date', methods=['POST'])
+def task_due_date(task_id):
+	"""Phase 2.4 — set or clear due_date on a task. Accepts ISO YYYY-MM-DD
+	or null/empty to clear."""
+	if not is_authenticated():
+		return jsonify({'error': 'unauthorized'}), 403
+	data = request.get_json(silent=True) or request.form
+	val = data.get('due_date')
+	if val in (None, '', 'null'):
+		due = None
+	else:
+		val = val.strip()
+		# Light validation — accepts YYYY-MM-DD via fromisoformat
+		import datetime
+		try:
+			datetime.date.fromisoformat(val)
+		except (ValueError, TypeError):
+			return jsonify({'error': 'invalid_due_date'}), 400
+		due = val
+	conn = get_db()
+	row = conn.execute('SELECT id FROM tasks WHERE id = ?', (task_id,)).fetchone()
+	if not row:
+		conn.close()
+		return jsonify({'error': 'not_found'}), 404
+	conn.execute('UPDATE tasks SET due_date = ? WHERE id = ?', (due, task_id))
+	conn.commit()
+	conn.close()
+	return jsonify({'success': True, 'due_date': due})
+
+
 @tasks_bp.route('/tasks/<int:task_id>/assign', methods=['POST'])
 def task_assign(task_id):
 	"""Assign a Below Deck task to a project."""

--- a/blueprints/time_tracking.py
+++ b/blueprints/time_tracking.py
@@ -223,7 +223,7 @@ def time_start():
 			SELECT ci.id, b.project_id
 			FROM checklist_items ci
 			JOIN blocks b ON ci.block_id = b.id
-			WHERE ci.id = ?
+			WHERE ci.id = ? AND ci.archived_at IS NULL
 		''', (checklist_item_id,)).fetchone()
 		if not item:
 			conn.close()
@@ -396,7 +396,7 @@ def time_update(entry_id):
 			SELECT ci.id, b.project_id
 			FROM checklist_items ci
 			JOIN blocks b ON ci.block_id = b.id
-			WHERE ci.id = ?
+			WHERE ci.id = ? AND ci.archived_at IS NULL
 		''', (new_item_id,)).fetchone()
 		if not item:
 			conn.close()

--- a/blueprints/today.py
+++ b/blueprints/today.py
@@ -4,6 +4,9 @@ Phase 2.1 (.kt/spec-time-tracking-phase-2-1.md): checklist items as Today
 citizens. Phase 2.2 (.kt/spec-time-tracking-phase-2-2.md): blocks join the
 party as their own peer rows; checklist_items.checked_at stamped on every
 toggle drives a precise (vs sloppy) 4am autoclear cutoff.
+Phase 2.4 (.kt/spec-time-tracking-phase-2-4.md): block recurrence + per-cycle
+item instances + due dates. Autoclear gains a cycle-fire pass that archives
+old items and spawns fresh instances on cycle boundary.
 """
 from datetime import datetime, timedelta
 import pytz
@@ -14,10 +17,127 @@ from helpers.db import get_db, et_now
 
 
 _UTC_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
+_ET_FORMAT = '%Y-%m-%dT%H:%M:%S.%f%z'
+
+_WEEKDAY_SHORT = {0: 'Mon', 1: 'Tue', 2: 'Wed', 3: 'Thu', 4: 'Fri', 5: 'Sat', 6: 'Sun'}
+_WEEKDAY_FROM_SHORT = {v: k for k, v in _WEEKDAY_SHORT.items()}
 
 
 def _utc_now_iso():
 	return datetime.now(pytz.UTC).strftime(_UTC_FORMAT)
+
+
+def _et_now_iso():
+	"""ET-local ISO with offset — same shape as helpers.db.et_now() but full microseconds."""
+	eastern = pytz.timezone('US/Eastern')
+	return datetime.now(eastern).strftime(_ET_FORMAT)
+
+
+# ---- Phase 2.4 — recurrence helpers ----
+
+def _et_today_4am_iso(now_et):
+	"""Return today's 4am ET (or yesterday's 4am if it's before 4am right now) as an
+	ET-local ISO string suitable for lex compare against last_reset_at."""
+	if now_et.hour < 4:
+		base_date = (now_et - timedelta(days=1)).date()
+	else:
+		base_date = now_et.date()
+	eastern = pytz.timezone('US/Eastern')
+	cutoff = eastern.localize(datetime.combine(base_date, datetime.min.time()).replace(hour=4))
+	return cutoff.strftime(_ET_FORMAT)
+
+
+def _et_this_monday_4am_iso(now_et):
+	"""Most recent Monday 4am ET (inclusive of today if today is Mon and time>=4am)."""
+	# Walk back to the most recent Monday.
+	days_back = now_et.weekday()  # Mon=0
+	target_date = (now_et - timedelta(days=days_back)).date()
+	eastern = pytz.timezone('US/Eastern')
+	cutoff = eastern.localize(datetime.combine(target_date, datetime.min.time()).replace(hour=4))
+	# If we're on Monday but before 4am, the boundary just passed is the PRIOR Monday.
+	if cutoff > now_et:
+		cutoff = cutoff - timedelta(days=7)
+	return cutoff.strftime(_ET_FORMAT)
+
+
+def _et_first_of_month_4am_iso(now_et):
+	"""Most recent 1st-of-month 4am ET (inclusive of today if today=1st and time>=4am)."""
+	first_this_month = now_et.replace(day=1, hour=4, minute=0, second=0, microsecond=0)
+	if first_this_month > now_et:
+		# We're on the 1st before 4am — the boundary just passed is the prior month's 1st.
+		prior = (first_this_month - timedelta(days=1)).replace(day=1)
+		return prior.strftime(_ET_FORMAT)
+	return first_this_month.strftime(_ET_FORMAT)
+
+
+def _next_weekday_iso(now_et, target_day_short):
+	"""Next occurrence of target_day_short ('Mon'..'Sun') from now (inclusive of today),
+	within 7 days. Returns ISO YYYY-MM-DD."""
+	target = _WEEKDAY_FROM_SHORT.get(target_day_short, 4)  # default Friday
+	days_ahead = (target - now_et.weekday()) % 7
+	return (now_et + timedelta(days=days_ahead)).strftime('%Y-%m-%d')
+
+
+def _this_month_target_iso(now_et, target):
+	"""Target day-of-month in the current month. Accepts '1'..'31' or 'last'.
+	Clamps over-large values to last day of month (e.g. 31 in Feb → 28/29)."""
+	# Last day of current month
+	next_month_first = (now_et.replace(day=28) + timedelta(days=4)).replace(day=1)
+	last_day = (next_month_first - timedelta(days=1)).day
+	if target == 'last':
+		actual = last_day
+	else:
+		try:
+			actual = min(max(1, int(target)), last_day)
+		except (ValueError, TypeError):
+			actual = now_et.day
+	return now_et.replace(day=actual).strftime('%Y-%m-%d')
+
+
+def _all_items_checked(conn, block_id):
+	"""True iff the block has at least one active item AND every active item is checked."""
+	row = conn.execute('''
+		SELECT
+		  COUNT(*) AS total,
+		  SUM(CASE WHEN checked = 1 THEN 1 ELSE 0 END) AS checked
+		FROM checklist_items
+		WHERE block_id = ? AND archived_at IS NULL
+	''', (block_id,)).fetchone()
+	if not row or not row['total']:
+		return False
+	return row['checked'] == row['total']
+
+
+def _spawn_cycle(conn, block_id, cycle_due_date, et_now):
+	"""Archive current active items + spawn fresh instances with the new due_date.
+
+	Idempotent at the cycle boundary because last_reset_at is bumped after spawn —
+	subsequent autoclear passes the same day skip.
+	Returns the count of spawned items (0 if the block had no structure)."""
+	now_iso = et_now.strftime(_ET_FORMAT)
+	structure = conn.execute('''
+		SELECT text FROM checklist_items
+		WHERE block_id = ? AND archived_at IS NULL
+		ORDER BY id ASC
+	''', (block_id,)).fetchall()
+	if not structure:
+		# Empty block — bump last_reset_at so we don't loop, return 0
+		conn.execute('UPDATE blocks SET last_reset_at = ? WHERE id = ?', (now_iso, block_id))
+		return 0
+	conn.execute('''
+		UPDATE checklist_items SET archived_at = ?
+		WHERE block_id = ? AND archived_at IS NULL
+	''', (now_iso, block_id))
+	for row in structure:
+		conn.execute('''
+			INSERT INTO checklist_items (block_id, text, due_date, checked, today)
+			VALUES (?, ?, ?, 0, 0)
+		''', (block_id, row['text'], cycle_due_date))
+	conn.execute(
+		'UPDATE blocks SET today = 0, last_reset_at = ? WHERE id = ?',
+		(now_iso, block_id)
+	)
+	return len(structure)
 
 
 today_bp = Blueprint('today', __name__)
@@ -87,6 +207,62 @@ def _today_autoclear(conn):
 		      )
 		  )
 	''', (cutoff_utc,))
+
+	# Phase 2.4 — recurrence-spawn pass. For each recurring block whose cycle
+	# boundary has passed since last_reset_at, archive the current cycle and
+	# spawn fresh instances. last_reset_at is in ET-local format; cycle
+	# boundaries are computed as ET-local strings that lex-compare cleanly.
+	today_short = _WEEKDAY_SHORT[now_et.weekday()]
+
+	# DAILY — fires every day in recurrence_days (or every day if NULL).
+	daily_boundary = _et_today_4am_iso(now_et)
+	daily_blocks = conn.execute(
+		"SELECT id, recurrence_days, last_reset_at FROM blocks "
+		"WHERE recurrence = 'daily'"
+	).fetchall()
+	for b in daily_blocks:
+		days = b['recurrence_days']
+		if days:
+			allowed = {d.strip() for d in days.split(',') if d.strip()}
+			if today_short not in allowed:
+				continue
+		if b['last_reset_at'] and b['last_reset_at'] >= daily_boundary:
+			continue
+		_spawn_cycle(conn, b['id'], cycle_due_date=now_et.strftime('%Y-%m-%d'), et_now=now_et)
+
+	# WEEKLY — fires Monday 4am ET, ONLY IF all current items are checked.
+	if today_short == 'Mon' or now_et.hour >= 4:
+		# Eligible to evaluate weekly fires (we're past this Monday's 4am OR
+		# any later day in the week — the boundary check below filters).
+		weekly_boundary = _et_this_monday_4am_iso(now_et)
+		weekly_blocks = conn.execute(
+			"SELECT id, recurrence_days, last_reset_at FROM blocks "
+			"WHERE recurrence = 'weekly'"
+		).fetchall()
+		for b in weekly_blocks:
+			if b['last_reset_at'] and b['last_reset_at'] >= weekly_boundary:
+				continue
+			if not _all_items_checked(conn, b['id']):
+				continue
+			target_day = (b['recurrence_days'] or 'Fri').split(',')[0].strip() or 'Fri'
+			due = _next_weekday_iso(now_et, target_day)
+			_spawn_cycle(conn, b['id'], cycle_due_date=due, et_now=now_et)
+
+	# MONTHLY — fires 1st of month 4am ET, ONLY IF all current items are checked.
+	monthly_boundary = _et_first_of_month_4am_iso(now_et)
+	monthly_blocks = conn.execute(
+		"SELECT id, recurrence_days, last_reset_at FROM blocks "
+		"WHERE recurrence = 'monthly'"
+	).fetchall()
+	for b in monthly_blocks:
+		if b['last_reset_at'] and b['last_reset_at'] >= monthly_boundary:
+			continue
+		if not _all_items_checked(conn, b['id']):
+			continue
+		target = (b['recurrence_days'] or '1').strip() or '1'
+		due = _this_month_target_iso(now_et, target)
+		_spawn_cycle(conn, b['id'], cycle_due_date=due, et_now=now_et)
+
 	conn.commit()
 
 

--- a/blueprints/today.py
+++ b/blueprints/today.py
@@ -193,15 +193,15 @@ def _today_autoclear(conn):
 		    SELECT b.id FROM blocks b
 		    WHERE b.today = 1
 		      AND EXISTS (
-		        SELECT 1 FROM checklist_items ci WHERE ci.block_id = b.id
+		        SELECT 1 FROM checklist_items ci WHERE ci.block_id = b.id AND ci.archived_at IS NULL
 		      )
 		      AND NOT EXISTS (
 		        SELECT 1 FROM checklist_items ci
-		        WHERE ci.block_id = b.id AND ci.checked = 0
+		        WHERE ci.block_id = b.id AND ci.archived_at IS NULL AND ci.checked = 0
 		      )
 		      AND NOT EXISTS (
 		        SELECT 1 FROM checklist_items ci
-		        WHERE ci.block_id = b.id
+		        WHERE ci.block_id = b.id AND ci.archived_at IS NULL
 		          AND ci.checked = 1
 		          AND (ci.checked_at IS NULL OR ci.checked_at >= ?)
 		      )
@@ -286,7 +286,7 @@ def today_count():
 		"SELECT COUNT(*) as cnt FROM tasks WHERE today = 1 AND status = 'open'"
 	).fetchone()['cnt']
 	item_count = conn.execute(
-		"SELECT COUNT(*) as cnt FROM checklist_items WHERE today = 1 AND checked = 0"
+		"SELECT COUNT(*) as cnt FROM checklist_items WHERE today = 1 AND checked = 0 AND archived_at IS NULL"
 	).fetchone()['cnt']
 	block_count = conn.execute(
 		"SELECT COUNT(*) as cnt FROM blocks WHERE today = 1"
@@ -327,7 +327,7 @@ def today_data():
 		JOIN blocks b             ON ci.block_id = b.id
 		JOIN projects p           ON b.project_id = p.id
 		LEFT JOIN projects parent ON p.parent_project_id = parent.id
-		WHERE ci.today = 1 AND ci.checked = 0
+		WHERE ci.today = 1 AND ci.checked = 0 AND ci.archived_at IS NULL
 		ORDER BY ci.id ASC
 	''').fetchall()
 
@@ -353,7 +353,7 @@ def today_data():
 		JOIN blocks b             ON ci.block_id = b.id
 		JOIN projects p           ON b.project_id = p.id
 		LEFT JOIN projects parent ON p.parent_project_id = parent.id
-		WHERE ci.today = 1 AND ci.checked = 1
+		WHERE ci.today = 1 AND ci.checked = 1 AND ci.archived_at IS NULL
 		ORDER BY ci.id DESC
 	''').fetchall()
 
@@ -367,8 +367,8 @@ def today_data():
 		       p.title AS project_title, p.slug AS project_slug,
 		       parent.id AS area_id, parent.title AS area_title,
 		       parent.area_color AS area_color,
-		       (SELECT COUNT(*) FROM checklist_items ci WHERE ci.block_id = b.id) AS total_count,
-		       (SELECT COUNT(*) FROM checklist_items ci WHERE ci.block_id = b.id AND ci.checked = 1) AS checked_count
+		       (SELECT COUNT(*) FROM checklist_items ci WHERE ci.block_id = b.id AND ci.archived_at IS NULL) AS total_count,
+		       (SELECT COUNT(*) FROM checklist_items ci WHERE ci.block_id = b.id AND ci.archived_at IS NULL AND ci.checked = 1) AS checked_count
 		FROM blocks b
 		JOIN projects p           ON b.project_id = p.id
 		LEFT JOIN projects parent ON p.parent_project_id = parent.id
@@ -415,8 +415,8 @@ def today_data():
 		''', (proj['id'],)).fetchall()
 		blocks_raw = conn.execute('''
 			SELECT b.id, b.title, b.today,
-			       (SELECT COUNT(*) FROM checklist_items ci WHERE ci.block_id = b.id) AS total_count,
-			       (SELECT COUNT(*) FROM checklist_items ci WHERE ci.block_id = b.id AND ci.checked = 1) AS checked_count
+			       (SELECT COUNT(*) FROM checklist_items ci WHERE ci.block_id = b.id AND ci.archived_at IS NULL) AS total_count,
+			       (SELECT COUNT(*) FROM checklist_items ci WHERE ci.block_id = b.id AND ci.archived_at IS NULL AND ci.checked = 1) AS checked_count
 			FROM blocks b
 			WHERE b.project_id = ? AND b.type = 'checklist'
 			ORDER BY b.id ASC
@@ -426,9 +426,9 @@ def today_data():
 			b_dict = dict(b)
 			b_dict['open_count'] = b_dict['total_count'] - b_dict['checked_count']
 			open_items = conn.execute('''
-				SELECT id, text, checked, today, block_id
+				SELECT id, text, checked, today, block_id, due_date
 				FROM checklist_items
-				WHERE block_id = ? AND checked = 0
+				WHERE block_id = ? AND checked = 0 AND archived_at IS NULL
 				ORDER BY id ASC
 			''', (b_dict['id'],)).fetchall()
 			b_dict['open_items'] = [dict(i) for i in open_items]
@@ -571,7 +571,7 @@ def today_star():
 	# Combined open count for the badge — tasks + items + blocks
 	count = conn.execute(
 		"SELECT (SELECT COUNT(*) FROM tasks WHERE today = 1 AND status = 'open') + "
-		"       (SELECT COUNT(*) FROM checklist_items WHERE today = 1 AND checked = 0) + "
+		"       (SELECT COUNT(*) FROM checklist_items WHERE today = 1 AND checked = 0 AND archived_at IS NULL) + "
 		"       (SELECT COUNT(*) FROM blocks WHERE today = 1) "
 		"AS cnt"
 	).fetchone()['cnt']

--- a/migrate_add_recurrence_and_due_dates.py
+++ b/migrate_add_recurrence_and_due_dates.py
@@ -1,0 +1,142 @@
+"""
+migrate_add_recurrence_and_due_dates.py
+Phase 2.4 of the time-tracking spec — see .kt/spec-time-tracking-phase-2-4.md.
+
+What it does (idempotent — safe to run multiple times):
+
+  blocks:
+    + recurrence       TEXT     -- NULL | 'daily' | 'weekly' | 'monthly'
+    + recurrence_days  TEXT     -- per-kind:
+                                 --   'daily'   → comma-separated active weekdays
+                                 --              (e.g. 'Mon,Tue,Wed,Thu,Fri'); NULL = all 7
+                                 --   'weekly'  → single weekday this cycle is due
+                                 --              (e.g. 'Fri')
+                                 --   'monthly' → day-of-month string ('1','15','last')
+    + last_reset_at    TEXT     -- ISO 8601 ET-local; NULL = never reset
+
+  checklist_items:
+    + due_date     TEXT          -- ISO YYYY-MM-DD; NULL = no due date
+    + archived_at  TEXT          -- ISO 8601 ET-local; NULL = active
+
+  tasks:
+    + due_date     TEXT          -- ISO YYYY-MM-DD; NULL = no due date
+
+  + 4 partial indexes:
+    idx_blocks_recurrence            blocks(recurrence) WHERE recurrence IS NOT NULL
+    idx_checklist_items_archived     checklist_items(archived_at) WHERE archived_at IS NOT NULL
+    idx_checklist_items_due_date     checklist_items(due_date) WHERE due_date IS NOT NULL
+    idx_tasks_due_date               tasks(due_date) WHERE due_date IS NOT NULL
+
+The archive index also supports the future retention-cleanup query
+(per Aaron's "keep ~1 year, then report-out + delete; lighter data
+persists longer" policy — implementation deferred to a later phase).
+
+Prints a summary. Running it again prints "no changes."
+
+Run from PythonAnywhere bash:
+    cd /home/aaronaiken/status_update
+    python migrate_add_recurrence_and_due_dates.py
+"""
+
+import os
+import sqlite3
+
+DB_FILE = os.path.join(
+	os.environ.get('COCKPIT_REPO_ROOT', '/home/aaronaiken/status_update'),
+	'assets/data/command_deck.db'
+)
+
+
+def column_exists(cur, table, col):
+	cols = [row[1] for row in cur.execute(f"PRAGMA table_info({table})").fetchall()]
+	return col in cols
+
+
+def index_exists(cur, name):
+	row = cur.execute(
+		"SELECT name FROM sqlite_master WHERE type='index' AND name=?", (name,)
+	).fetchone()
+	return row is not None
+
+
+COLUMNS = [
+	('blocks',          'recurrence',      'TEXT'),
+	('blocks',          'recurrence_days', 'TEXT'),
+	('blocks',          'last_reset_at',   'TEXT'),
+	('checklist_items', 'due_date',        'TEXT'),
+	('checklist_items', 'archived_at',     'TEXT'),
+	('tasks',           'due_date',        'TEXT'),
+]
+
+INDEXES = [
+	(
+		'idx_blocks_recurrence',
+		'CREATE INDEX IF NOT EXISTS idx_blocks_recurrence '
+		'ON blocks(recurrence) WHERE recurrence IS NOT NULL',
+	),
+	(
+		'idx_checklist_items_archived',
+		'CREATE INDEX IF NOT EXISTS idx_checklist_items_archived '
+		'ON checklist_items(archived_at) WHERE archived_at IS NOT NULL',
+	),
+	(
+		'idx_checklist_items_due_date',
+		'CREATE INDEX IF NOT EXISTS idx_checklist_items_due_date '
+		'ON checklist_items(due_date) WHERE due_date IS NOT NULL',
+	),
+	(
+		'idx_tasks_due_date',
+		'CREATE INDEX IF NOT EXISTS idx_tasks_due_date '
+		'ON tasks(due_date) WHERE due_date IS NOT NULL',
+	),
+]
+
+
+def run():
+	if not os.path.exists(DB_FILE):
+		print(f"× DB not found at {DB_FILE}")
+		print("  Run migrate_to_sqlite.py first.")
+		return
+
+	conn = sqlite3.connect(DB_FILE)
+	cur = conn.cursor()
+
+	added = []
+	skipped = []
+
+	for table, col, sql_type in COLUMNS:
+		if column_exists(cur, table, col):
+			skipped.append(f'{table}.{col}')
+		else:
+			cur.execute(f'ALTER TABLE {table} ADD COLUMN {col} {sql_type}')
+			added.append(f'{table}.{col}')
+
+	for name, sql in INDEXES:
+		if index_exists(cur, name):
+			skipped.append(name)
+		else:
+			cur.execute(sql)
+			added.append(name)
+
+	conn.commit()
+	conn.close()
+
+	print()
+	print("Migration: migrate_add_recurrence_and_due_dates.py")
+	print(f"DB:        {DB_FILE}")
+	print()
+	if added:
+		print(f"✓ Added ({len(added)}):")
+		for item in added:
+			print(f"    + {item}")
+	if skipped:
+		print(f"— Already in place ({len(skipped)}):")
+		for item in skipped:
+			print(f"    · {item}")
+	if not added:
+		print("No changes — schema already up to date.")
+	print()
+
+
+if __name__ == '__main__':
+	run()

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -2335,6 +2335,38 @@ body.cd-strip-visible .cd-shell { padding-top: 32px; }
   max-width: 60ch;
 }
 
+/* Phase 2.4 — recurrence pill in checklist block header.
+   Sits between the title and the action buttons; reads as
+   "this is a recurring routine, here's its cadence." Same dim
+   amber as the body, brighter glyph for the ↻. */
+.cd-block-recurrence-pill {
+  background: rgba(212, 136, 10, 0.06);
+  border: 1px solid var(--cd-amber-lo);
+  color: var(--cd-text-dim);
+  font-family: var(--cd-font-ui);
+  font-size: 0.55rem;
+  letter-spacing: 0.12em;
+  padding: 2px 7px;
+  border-radius: 2px;
+  cursor: pointer;
+  text-transform: uppercase;
+  white-space: nowrap;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  margin-left: 0.5rem;
+  flex-shrink: 0;
+}
+.cd-block-recurrence-pill:hover,
+.cd-block-recurrence-pill:focus-visible {
+  background: rgba(245, 179, 50, 0.10);
+  border-color: var(--cd-amber-hi);
+  color: var(--cd-amber-hi);
+  outline: none;
+}
+.cd-block-recurrence-pill .cd-block-recurrence-label {
+  color: var(--cd-text);
+  font-weight: 500;
+}
+
 /* Phase 2.3 polish — MORE ▾ overflow menu in the CD header nav */
 .cd-nav-more {
   position: relative;

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -2335,6 +2335,69 @@ body.cd-strip-visible .cd-shell { padding-top: 32px; }
   max-width: 60ch;
 }
 
+/* Phase 2.4 — due-date badges on tasks + checklist items.
+   Always-visible on tasks; hover-only on checklist items via the
+   .cd-tt-tag-item density rule (already defined elsewhere). */
+.cd-due-wrapper {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+.cd-due-badge {
+  background: rgba(212, 136, 10, 0.06);
+  border: 1px solid var(--cd-amber-lo);
+  color: var(--cd-text-dim);
+  font-family: var(--cd-font-ui);
+  font-size: 0.55rem;
+  letter-spacing: 0.08em;
+  padding: 1px 6px;
+  border-radius: 2px;
+  cursor: pointer;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  text-transform: lowercase;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+.cd-due-badge:hover,
+.cd-due-badge:focus-visible {
+  background: rgba(245, 179, 50, 0.12);
+  border-color: var(--cd-amber-hi);
+  color: var(--cd-amber-hi);
+  outline: none;
+}
+.cd-due-badge.unset {
+  border-style: dashed;
+  border-color: var(--cd-border);
+  color: var(--cd-text-dim);
+  opacity: 0.7;
+}
+.cd-due-badge.unset:hover {
+  opacity: 1;
+}
+.cd-due-badge.today {
+  border-color: var(--cd-amber-hi);
+  color: var(--cd-amber-hi);
+  background: rgba(245, 179, 50, 0.10);
+}
+.cd-due-badge.soon {
+  color: var(--cd-amber);
+}
+.cd-due-badge.overdue {
+  border-color: var(--cd-red, #cc4040);
+  color: var(--cd-red, #cc4040);
+  background: rgba(204, 64, 64, 0.08);
+  text-transform: uppercase;
+}
+.cd-due-input {
+  background: var(--cd-bg-surface);
+  border: 1px solid var(--cd-amber-hi);
+  color: var(--cd-text);
+  font: inherit;
+  padding: 1px 4px;
+  border-radius: 2px;
+  margin-left: 4px;
+}
+
 /* Phase 2.4 — recurrence pill in checklist block header.
    Sits between the title and the action buttons; reads as
    "this is a recurring routine, here's its cadence." Same dim

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -2388,14 +2388,26 @@ body.cd-strip-visible .cd-shell { padding-top: 32px; }
   background: rgba(204, 64, 64, 0.08);
   text-transform: uppercase;
 }
+/* The date input is always in the DOM at the badge's position so
+   showPicker() has a stable anchor. Visually hidden via opacity +
+   zero size, but kept laid-out (NOT display:none) — first-click
+   picker placement was wrong before this because hidden attr meant
+   no layout, so the browser anchored to (0,0). */
 .cd-due-input {
-  background: var(--cd-bg-surface);
-  border: 1px solid var(--cd-amber-hi);
-  color: var(--cd-text);
-  font: inherit;
-  padding: 1px 4px;
-  border-radius: 2px;
-  margin-left: 4px;
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  border: 0;
+  padding: 0;
+  pointer-events: none;
+  background: transparent;
+  color: transparent;
+  cursor: pointer;
+}
+.cd-due-wrapper {
+  position: relative;
 }
 
 /* Phase 2.4 — show-history toggle + panel on recurring blocks.

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -2398,6 +2398,79 @@ body.cd-strip-visible .cd-shell { padding-top: 32px; }
   margin-left: 4px;
 }
 
+/* Phase 2.4 — show-history toggle + panel on recurring blocks.
+   Sits between the items list and the add-item input. Read-only
+   browse — no interactive checkbox/edit/delete on archived items. */
+.cd-block-history-toggle-row {
+  margin: 0.4rem 0 0.5rem 1.5rem;
+}
+.cd-block-history-toggle {
+  background: none;
+  border: none;
+  color: var(--cd-text-dim);
+  font-family: var(--cd-font-ui);
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  padding: 2px 4px;
+  text-transform: uppercase;
+  transition: color 0.15s;
+}
+.cd-block-history-toggle:hover,
+.cd-block-history-toggle:focus-visible {
+  color: var(--cd-amber-hi);
+  outline: none;
+}
+.cd-block-history-panel {
+  margin: 0.2rem 0 0.7rem 1.5rem;
+  padding: 0.5rem 0.75rem;
+  background: rgba(212, 136, 10, 0.03);
+  border: 1px dashed var(--cd-border);
+  border-radius: var(--cd-radius);
+  font-family: var(--cd-font-body);
+  font-size: 0.78rem;
+  color: var(--cd-text-dim);
+  max-height: 50vh;
+  overflow-y: auto;
+}
+.cd-block-history-group {
+  margin-bottom: 0.6rem;
+}
+.cd-block-history-group:last-child {
+  margin-bottom: 0;
+}
+.cd-block-history-date {
+  font-family: var(--cd-font-ui);
+  font-size: 0.55rem;
+  letter-spacing: 0.12em;
+  color: var(--cd-text-dim);
+  text-transform: uppercase;
+  margin-bottom: 0.3rem;
+}
+.cd-block-history-item {
+  padding: 1px 0 1px 0.4rem;
+  font-family: var(--cd-font-body);
+}
+.cd-block-history-item.checked {
+  color: var(--cd-text);
+}
+.cd-block-history-empty {
+  padding: 0.6rem;
+  font-family: var(--cd-font-ui);
+  font-size: 0.62rem;
+  color: var(--cd-text-dim);
+  text-align: center;
+}
+.cd-block-history-footer {
+  margin-top: 0.5rem;
+  font-family: var(--cd-font-ui);
+  font-size: 0.55rem;
+  color: var(--cd-text-dim);
+  text-align: right;
+  font-style: italic;
+  opacity: 0.7;
+}
+
 /* Phase 2.4 — recurrence pill in checklist block header.
    Sits between the title and the action buttons; reads as
    "this is a recurring routine, here's its cadence." Same dim

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -176,7 +176,7 @@
                             data-due-date="{{ item.due_date or '' }}">
                         <button class="cd-due-badge{% if not item.due_date %} unset{% endif %}" type="button"
                                 title="Set / change due date">{% if item.due_date %}due {{ item.due_date }}{% else %}+ due{% endif %}</button>
-                        <input type="date" class="cd-due-input" value="{{ item.due_date or '' }}" hidden>
+                        <input type="date" class="cd-due-input" value="{{ item.due_date or '' }}" tabindex="-1" aria-hidden="true">
                       </span>
                       <button class="cd-today-star cd-tt-tag-item{% if item.today %} starred{% endif %}"
                               data-kind="item" data-id="{{ item.id }}"
@@ -239,7 +239,7 @@
                         data-due-date="{{ task.due_date or '' }}">
                     <button class="cd-due-badge{% if not task.due_date %} unset{% endif %}" type="button"
                             title="Set / change due date">{% if task.due_date %}due {{ task.due_date }}{% else %}+ due{% endif %}</button>
-                    <input type="date" class="cd-due-input" value="{{ task.due_date or '' }}" hidden>
+                    <input type="date" class="cd-due-input" value="{{ task.due_date or '' }}" tabindex="-1" aria-hidden="true">
                   </span>
                   <button class="cd-today-star{% if task.today %} starred{% endif %}"
                           data-kind="task" data-id="{{ task.id }}"
@@ -812,7 +812,7 @@ document.getElementById('blocksContainer').addEventListener('click', function(e)
       li.dataset.itemText=data.item.text;
       // Phase 1.5: emit the same ⏱ markup Jinja would render, so newly-added
       // items are tracker-aware without a page reload.
-      const dueMarkup = `<span class="cd-due-wrapper cd-tt-tag-item" data-due-url="/command-deck/projects/${PROJECT_SLUG}/checklist/${data.item.id}/due-date" data-due-date=""><button class="cd-due-badge unset" type="button" title="Set / change due date">+ due</button><input type="date" class="cd-due-input" hidden></span>`;
+      const dueMarkup = `<span class="cd-due-wrapper cd-tt-tag-item" data-due-url="/command-deck/projects/${PROJECT_SLUG}/checklist/${data.item.id}/due-date" data-due-date=""><button class="cd-due-badge unset" type="button" title="Set / change due date">+ due</button><input type="date" class="cd-due-input" tabindex="-1" aria-hidden="true"></span>`;
       const starMarkup = `<button class="cd-today-star cd-tt-tag-item" data-kind="item" data-id="${data.item.id}" title="Add to Today" type="button">☆</button>`;
       const ttMarkup = (typeof PROJECT_TRACKING !== 'undefined' && PROJECT_TRACKING)
         ? `<span class="cd-tt-today-tag cd-tt-tag-item" data-item-today-tag="${data.item.id}" hidden></span>
@@ -871,7 +871,7 @@ document.getElementById('blocksContainer').addEventListener('click', function(e)
       // Phase 1.5: dynamically-added rows must include the same ⏱ button +
       // today-tag markup that Jinja emits, otherwise tasks added without a
       // page reload won't be tracker-aware.
-      const dueMarkup = `<span class="cd-due-wrapper" data-due-url="/tasks/${data.task.id}/due-date" data-due-date=""><button class="cd-due-badge unset" type="button" title="Set / change due date">+ due</button><input type="date" class="cd-due-input" hidden></span>`;
+      const dueMarkup = `<span class="cd-due-wrapper" data-due-url="/tasks/${data.task.id}/due-date" data-due-date=""><button class="cd-due-badge unset" type="button" title="Set / change due date">+ due</button><input type="date" class="cd-due-input" tabindex="-1" aria-hidden="true"></span>`;
       const starMarkup = `<button class="cd-today-star" data-kind="task" data-id="${data.task.id}" title="Add to Today" type="button">☆</button>`;
       const ttMarkup = (typeof PROJECT_TRACKING !== 'undefined' && PROJECT_TRACKING)
         ? `<span class="cd-tt-today-tag" data-task-today-tag="${data.task.id}" hidden></span>
@@ -1420,7 +1420,10 @@ document.addEventListener('click', function (ev) {
     document.querySelectorAll('.cd-due-badge').forEach(formatBadge);
   }
 
-  // Click badge → reveal date input + open native picker
+  // Click badge → open native date picker. The input is always in
+  // the DOM at the badge's position (CSS opacity:0, position:absolute)
+  // so showPicker() has a stable anchor on first click — no more
+  // top-left-then-correct-on-second-click bug.
   document.addEventListener('click', function (ev) {
     const badge = ev.target.closest('.cd-due-badge');
     if (!badge) return;
@@ -1429,9 +1432,8 @@ document.addEventListener('click', function (ev) {
     if (!wrapper) return;
     const input = wrapper.querySelector('.cd-due-input');
     if (!input) return;
-    input.hidden = false;
     if (typeof input.showPicker === 'function') {
-      try { input.showPicker(); } catch (e) { /* unsupported */ input.focus(); }
+      try { input.showPicker(); } catch (e) { input.focus(); }
     } else {
       input.focus();
     }
@@ -1459,7 +1461,6 @@ document.addEventListener('click', function (ev) {
         if (badge) formatBadge(badge);
       }
     } catch (e) { /* silent */ }
-    input.hidden = true;
   });
 
   // Right-click badge → quick clear

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -192,6 +192,15 @@
                     </li>
                   {% endfor %}
                 </ul>
+                {% if block.recurrence %}
+                <div class="cd-block-history-toggle-row">
+                  <button class="cd-block-history-toggle" type="button"
+                          data-block-id="{{ block.id }}"
+                          data-slug="{{ project.slug }}"
+                          aria-expanded="false">↳ show history ▾</button>
+                </div>
+                <div class="cd-block-history-panel" data-block-id="{{ block.id }}" hidden></div>
+                {% endif %}
                 <div class="cd-checklist-add">
                   <input type="text" class="cd-input checklist-new-item"
                     data-block-id="{{ block.id }}"
@@ -1268,6 +1277,79 @@ document.addEventListener('click', function (ev) {
     const id = opt.getAttribute('data-id');
     close();
     spawn(id);
+  });
+})();
+
+// Phase 2.4 — show-history toggle on recurring blocks
+(function () {
+  'use strict';
+
+  function escHtml(s) {
+    const d = document.createElement('div');
+    d.appendChild(document.createTextNode(s == null ? '' : String(s)));
+    return d.innerHTML;
+  }
+
+  function fmtDateForHeader(iso) {
+    if (!iso || iso === '(no due date)') return '(no due date)';
+    const [y, m, d] = iso.split('-').map(Number);
+    if (!y || !m || !d) return iso;
+    const dt = new Date(y, m - 1, d);
+    const wk = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][dt.getDay()];
+    const mo = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'][m - 1];
+    return wk + ' ' + mo + ' ' + d + ', ' + y;
+  }
+
+  document.addEventListener('click', async function (ev) {
+    const btn = ev.target.closest('.cd-block-history-toggle');
+    if (!btn) return;
+    ev.preventDefault();
+    const blockId = btn.getAttribute('data-block-id');
+    const slug = btn.getAttribute('data-slug');
+    const panel = document.querySelector(
+      `.cd-block-history-panel[data-block-id="${blockId}"]`
+    );
+    if (!panel) return;
+
+    // Toggle off if already open
+    if (!panel.hidden) {
+      panel.hidden = true;
+      btn.textContent = '↳ show history ▾';
+      btn.setAttribute('aria-expanded', 'false');
+      return;
+    }
+
+    // Fetch + render
+    btn.textContent = '↳ loading…';
+    try {
+      const r = await fetch(`/command-deck/projects/${slug}/blocks/${blockId}/history`);
+      if (!r.ok) {
+        btn.textContent = '↳ history unavailable';
+        return;
+      }
+      const data = await r.json();
+      const groups = data.history || [];
+      if (groups.length === 0) {
+        panel.innerHTML = '<div class="cd-block-history-empty">No past cycles yet.</div>';
+      } else {
+        panel.innerHTML = groups.map(function (g) {
+          const items = g.items.map(function (i) {
+            const cls = i.checked ? 'cd-block-history-item checked' : 'cd-block-history-item';
+            const mark = i.checked ? '☑' : '☐';
+            return '<div class="' + cls + '">' + mark + ' ' + escHtml(i.text) + '</div>';
+          }).join('');
+          return '<div class="cd-block-history-group">' +
+                 '<div class="cd-block-history-date">─── ' + escHtml(fmtDateForHeader(g.due_date)) + ' ───</div>' +
+                 items +
+                 '</div>';
+        }).join('') + '<div class="cd-block-history-footer">(showing last 90 days)</div>';
+      }
+      panel.hidden = false;
+      btn.textContent = '↳ hide history ▴';
+      btn.setAttribute('aria-expanded', 'true');
+    } catch (e) {
+      btn.textContent = '↳ history unavailable';
+    }
   });
 })();
 

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -171,6 +171,13 @@
                         data-item-id="{{ item.id }}"
                         data-slug="{{ project.slug }}">
                       <label>{{ item.text }}</label>
+                      <span class="cd-due-wrapper cd-tt-tag-item"
+                            data-due-url="/command-deck/projects/{{ project.slug }}/checklist/{{ item.id }}/due-date"
+                            data-due-date="{{ item.due_date or '' }}">
+                        <button class="cd-due-badge{% if not item.due_date %} unset{% endif %}" type="button"
+                                title="Set / change due date">{% if item.due_date %}due {{ item.due_date }}{% else %}+ due{% endif %}</button>
+                        <input type="date" class="cd-due-input" value="{{ item.due_date or '' }}" hidden>
+                      </span>
                       <button class="cd-today-star cd-tt-tag-item{% if item.today %} starred{% endif %}"
                               data-kind="item" data-id="{{ item.id }}"
                               title="{% if item.today %}Remove from Today{% else %}Add to Today{% endif %}"
@@ -218,6 +225,13 @@
                 <li class="cd-task-item" data-id="{{ task.id }}" data-task-title="{{ task.title }}">
                   <input type="checkbox" class="cd-task-check project-task-check" data-id="{{ task.id }}" data-slug="{{ project.slug }}">
                   <span class="cd-task-title">{{ task.title }}</span>
+                  <span class="cd-due-wrapper"
+                        data-due-url="/tasks/{{ task.id }}/due-date"
+                        data-due-date="{{ task.due_date or '' }}">
+                    <button class="cd-due-badge{% if not task.due_date %} unset{% endif %}" type="button"
+                            title="Set / change due date">{% if task.due_date %}due {{ task.due_date }}{% else %}+ due{% endif %}</button>
+                    <input type="date" class="cd-due-input" value="{{ task.due_date or '' }}" hidden>
+                  </span>
                   <button class="cd-today-star{% if task.today %} starred{% endif %}"
                           data-kind="task" data-id="{{ task.id }}"
                           title="{% if task.today %}Remove from Today{% else %}Add to Today{% endif %}"
@@ -789,6 +803,7 @@ document.getElementById('blocksContainer').addEventListener('click', function(e)
       li.dataset.itemText=data.item.text;
       // Phase 1.5: emit the same ⏱ markup Jinja would render, so newly-added
       // items are tracker-aware without a page reload.
+      const dueMarkup = `<span class="cd-due-wrapper cd-tt-tag-item" data-due-url="/command-deck/projects/${PROJECT_SLUG}/checklist/${data.item.id}/due-date" data-due-date=""><button class="cd-due-badge unset" type="button" title="Set / change due date">+ due</button><input type="date" class="cd-due-input" hidden></span>`;
       const starMarkup = `<button class="cd-today-star cd-tt-tag-item" data-kind="item" data-id="${data.item.id}" title="Add to Today" type="button">☆</button>`;
       const ttMarkup = (typeof PROJECT_TRACKING !== 'undefined' && PROJECT_TRACKING)
         ? `<span class="cd-tt-today-tag cd-tt-tag-item" data-item-today-tag="${data.item.id}" hidden></span>
@@ -798,6 +813,7 @@ document.getElementById('blocksContainer').addEventListener('click', function(e)
       li.innerHTML=`
         <input type="checkbox" data-item-id="${data.item.id}" data-slug="${PROJECT_SLUG}">
         <label>${escapeHtml(data.item.text)}</label>
+        ${dueMarkup}
         ${starMarkup}
         ${ttMarkup}
         <button class="cd-btn ghost sm checklist-item-delete" data-id="${data.item.id}" data-slug="${PROJECT_SLUG}">✕</button>`;
@@ -846,6 +862,7 @@ document.getElementById('blocksContainer').addEventListener('click', function(e)
       // Phase 1.5: dynamically-added rows must include the same ⏱ button +
       // today-tag markup that Jinja emits, otherwise tasks added without a
       // page reload won't be tracker-aware.
+      const dueMarkup = `<span class="cd-due-wrapper" data-due-url="/tasks/${data.task.id}/due-date" data-due-date=""><button class="cd-due-badge unset" type="button" title="Set / change due date">+ due</button><input type="date" class="cd-due-input" hidden></span>`;
       const starMarkup = `<button class="cd-today-star" data-kind="task" data-id="${data.task.id}" title="Add to Today" type="button">☆</button>`;
       const ttMarkup = (typeof PROJECT_TRACKING !== 'undefined' && PROJECT_TRACKING)
         ? `<span class="cd-tt-today-tag" data-task-today-tag="${data.task.id}" hidden></span>
@@ -856,6 +873,7 @@ document.getElementById('blocksContainer').addEventListener('click', function(e)
         <input type="checkbox" class="cd-task-check project-task-check"
           data-id="${data.task.id}" data-slug="${PROJECT_SLUG}">
         <span class="cd-task-title">${escapeHtml(data.task.title)}</span>
+        ${dueMarkup}
         ${starMarkup}
         ${ttMarkup}
         <button class="cd-task-edit" data-id="${data.task.id}" title="Edit">✎</button>
@@ -1251,6 +1269,123 @@ document.addEventListener('click', function (ev) {
     close();
     spawn(id);
   });
+})();
+
+// Phase 2.4 — DUE DATE badges + setter on tasks/items
+(function () {
+  'use strict';
+
+  function fmtDueLabel(iso) {
+    if (!iso) return '+ due';
+    // Compute days delta in local TZ
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const [y, m, d] = iso.split('-').map(Number);
+    const due = new Date(y, m - 1, d);
+    due.setHours(0, 0, 0, 0);
+    const days = Math.round((due - today) / 86400000);
+    if (days < 0) {
+      // OVERDUE — show abbreviated weekday + month/day
+      const wk = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][due.getDay()];
+      return 'OVERDUE ' + wk + ' ' + (due.getMonth() + 1) + '/' + due.getDate();
+    }
+    if (days === 0) return 'due today';
+    if (days === 1) return 'due tomorrow';
+    if (days < 7) {
+      const wk = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][due.getDay()];
+      return 'due ' + wk + ' ' + (due.getMonth() + 1) + '/' + due.getDate();
+    }
+    // Distant future — full ISO
+    return 'due ' + iso;
+  }
+
+  function formatBadge(badgeEl) {
+    const wrapper = badgeEl.closest('.cd-due-wrapper');
+    const iso = wrapper ? wrapper.getAttribute('data-due-date') : '';
+    badgeEl.textContent = fmtDueLabel(iso);
+    badgeEl.classList.toggle('unset', !iso);
+    badgeEl.classList.toggle('overdue', iso && fmtDueLabel(iso).startsWith('OVERDUE'));
+    badgeEl.classList.toggle('today', iso && fmtDueLabel(iso) === 'due today');
+    badgeEl.classList.toggle('soon', iso && (fmtDueLabel(iso) === 'due tomorrow' || /^due (Mon|Tue|Wed|Thu|Fri|Sat|Sun) /.test(fmtDueLabel(iso))));
+  }
+
+  function refreshAllBadges() {
+    document.querySelectorAll('.cd-due-badge').forEach(formatBadge);
+  }
+
+  // Click badge → reveal date input + open native picker
+  document.addEventListener('click', function (ev) {
+    const badge = ev.target.closest('.cd-due-badge');
+    if (!badge) return;
+    ev.preventDefault();
+    const wrapper = badge.closest('.cd-due-wrapper');
+    if (!wrapper) return;
+    const input = wrapper.querySelector('.cd-due-input');
+    if (!input) return;
+    input.hidden = false;
+    if (typeof input.showPicker === 'function') {
+      try { input.showPicker(); } catch (e) { /* unsupported */ input.focus(); }
+    } else {
+      input.focus();
+    }
+  });
+
+  // Change date input → POST + update badge
+  document.addEventListener('change', async function (ev) {
+    const input = ev.target.closest('.cd-due-input');
+    if (!input) return;
+    const wrapper = input.closest('.cd-due-wrapper');
+    if (!wrapper) return;
+    const url = wrapper.getAttribute('data-due-url');
+    const newVal = input.value || '';
+    try {
+      const r = await fetch(url, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ due_date: newVal || null }),
+        credentials: 'same-origin',
+      });
+      if (r.ok) {
+        const d = await r.json();
+        wrapper.setAttribute('data-due-date', d.due_date || '');
+        const badge = wrapper.querySelector('.cd-due-badge');
+        if (badge) formatBadge(badge);
+      }
+    } catch (e) { /* silent */ }
+    input.hidden = true;
+  });
+
+  // Right-click badge → quick clear
+  document.addEventListener('contextmenu', async function (ev) {
+    const badge = ev.target.closest('.cd-due-badge');
+    if (!badge) return;
+    const wrapper = badge.closest('.cd-due-wrapper');
+    if (!wrapper) return;
+    const iso = wrapper.getAttribute('data-due-date');
+    if (!iso) return;  // already cleared
+    ev.preventDefault();
+    if (!confirm('Clear due date?')) return;
+    const url = wrapper.getAttribute('data-due-url');
+    try {
+      const r = await fetch(url, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ due_date: null }),
+        credentials: 'same-origin',
+      });
+      if (r.ok) {
+        wrapper.setAttribute('data-due-date', '');
+        const inp = wrapper.querySelector('.cd-due-input');
+        if (inp) inp.value = '';
+        formatBadge(badge);
+      }
+    } catch (e) { /* silent */ }
+  });
+
+  // On page load, format all badges based on relative dates
+  document.addEventListener('DOMContentLoaded', refreshAllBadges);
+  // Also re-run after a small delay to catch any deferred renders
+  setTimeout(refreshAllBadges, 100);
 })();
 
 // Phase 2.4 — RECURRENCE setter modal + RESET button

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -1280,6 +1280,31 @@ document.addEventListener('click', function (ev) {
   });
 })();
 
+// Phase 2.4 — small polish: compact "MON,TUE,WED,THU,FRI" → "MON–FRI"
+// on recurrence pill labels. Server renders the raw CSV; we prettify
+// well-known ranges client-side after load.
+(function () {
+  'use strict';
+  const COMPACT = {
+    'MON,TUE,WED,THU,FRI': 'MON–FRI',
+    'SAT,SUN': 'WEEKEND',
+    'MON,WED,FRI': 'MWF',
+    'TUE,THU': 'TTh',
+  };
+  function prettify() {
+    document.querySelectorAll('.cd-block-recurrence-label').forEach(function (el) {
+      const text = el.textContent || '';
+      Object.keys(COMPACT).forEach(function (raw) {
+        if (text.indexOf(raw) !== -1) {
+          el.textContent = text.replace(raw, COMPACT[raw]);
+        }
+      });
+    });
+  }
+  document.addEventListener('DOMContentLoaded', prettify);
+  setTimeout(prettify, 50);
+})();
+
 // Phase 2.4 — show-history toggle on recurring blocks
 (function () {
   'use strict';

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -124,6 +124,15 @@
                 data-block-id="{{ block.id }}"
                 data-type="{{ block.type }}"
                 data-custom-title="{{ block.title | default('', true) }}">{% if block.title %}{{ block.title }}{% elif block.type == 'note' %}Untitled Note{% else %}Untitled Checklist{% endif %}</span>
+              {% if block.type == 'checklist' and block.recurrence %}
+                <button class="cd-block-recurrence-pill cd-block-recurrence-trigger"
+                        data-block-id="{{ block.id }}"
+                        data-recurrence="{{ block.recurrence }}"
+                        data-recurrence-days="{{ block.recurrence_days or '' }}"
+                        title="Change recurrence" type="button">
+                  ↻ <span class="cd-block-recurrence-label">{{ block.recurrence | upper }}{% if block.recurrence_days %} · {{ block.recurrence_days | upper }}{% endif %}</span>
+                </button>
+              {% endif %}
               <div class="cd-panel-actions">
                 {% if block.type == 'checklist' %}
                 <button class="cd-today-star{% if block.today %} starred{% endif %}"
@@ -131,6 +140,11 @@
                         title="{% if block.today %}Remove from Today{% else %}Add to Today{% endif %}"
                         type="button">{{ '★' if block.today else '☆' }}</button>
                 <button class="cd-btn ghost sm cd-block-save-as-template" data-block-id="{{ block.id }}" data-default-name="{{ block.title or 'Untitled Checklist' }}" title="Save this checklist as a template" type="button">TEMPLATE</button>
+                {% if block.recurrence %}
+                <button class="cd-btn ghost sm cd-block-reset" data-block-id="{{ block.id }}" data-block-title="{{ block.title or 'this checklist' }}" title="Reset cycle now — archive current items, spawn fresh" type="button">RESET</button>
+                {% else %}
+                <button class="cd-btn ghost sm cd-block-recurrence-trigger" data-block-id="{{ block.id }}" data-recurrence="" data-recurrence-days="" title="Set up recurrence" type="button">↻</button>
+                {% endif %}
                 {% endif %}
                 <button class="cd-block-collapse-btn" data-block-id="{{ block.id }}" title="Collapse">▾</button>
                 <button class="cd-btn ghost sm block-delete-btn" data-id="{{ block.id }}">REMOVE</button>
@@ -336,6 +350,64 @@
   </footer>
 
 </div><!-- .cd-shell -->
+
+<!-- RECURRENCE SETTER MODAL (Phase 2.4) -->
+<div class="cd-modal-overlay" id="recurrenceModal">
+  <div class="cd-modal">
+    <div class="cd-modal-title">// Recurrence</div>
+    <p style="font-family:var(--cd-font-body);font-size:0.78rem;color:var(--cd-text-dim);margin:0 0 0.75rem;line-height:1.45;">
+      A recurring checklist archives its items at the cycle boundary and spawns fresh copies — each cycle is its own set with its own due date and time-tracking lineage.
+    </p>
+
+    <div id="recurrenceKindGroup" style="display:flex;flex-direction:column;gap:0.4rem;font-family:var(--cd-font-ui);font-size:0.72rem;color:var(--cd-text);">
+      <label style="display:flex;align-items:center;gap:0.5rem;cursor:pointer;">
+        <input type="radio" name="recurrenceKind" value="" style="accent-color:var(--cd-amber);"> none — one-shot
+      </label>
+      <label style="display:flex;align-items:center;gap:0.5rem;cursor:pointer;">
+        <input type="radio" name="recurrenceKind" value="daily" style="accent-color:var(--cd-amber);"> daily
+      </label>
+      <label style="display:flex;align-items:center;gap:0.5rem;cursor:pointer;">
+        <input type="radio" name="recurrenceKind" value="weekly" style="accent-color:var(--cd-amber);"> weekly (only fires Mon if all items checked)
+      </label>
+      <label style="display:flex;align-items:center;gap:0.5rem;cursor:pointer;">
+        <input type="radio" name="recurrenceKind" value="monthly" style="accent-color:var(--cd-amber);"> monthly (only fires 1st if all items checked)
+      </label>
+    </div>
+
+    <div id="recurrenceDailyDays" style="margin-top:0.7rem;display:none;">
+      <div style="font-family:var(--cd-font-ui);font-size:0.55rem;letter-spacing:0.18em;color:var(--cd-text-dim);text-transform:uppercase;margin-bottom:5px;">ACTIVE DAYS</div>
+      <div style="display:flex;gap:0.4rem;flex-wrap:wrap;font-family:var(--cd-font-ui);font-size:0.7rem;">
+        <label><input type="checkbox" name="recDaily" value="Mon" checked> Mon</label>
+        <label><input type="checkbox" name="recDaily" value="Tue" checked> Tue</label>
+        <label><input type="checkbox" name="recDaily" value="Wed" checked> Wed</label>
+        <label><input type="checkbox" name="recDaily" value="Thu" checked> Thu</label>
+        <label><input type="checkbox" name="recDaily" value="Fri" checked> Fri</label>
+        <label><input type="checkbox" name="recDaily" value="Sat"> Sat</label>
+        <label><input type="checkbox" name="recDaily" value="Sun"> Sun</label>
+      </div>
+    </div>
+
+    <div id="recurrenceWeeklyDay" style="margin-top:0.7rem;display:none;">
+      <div style="font-family:var(--cd-font-ui);font-size:0.55rem;letter-spacing:0.18em;color:var(--cd-text-dim);text-transform:uppercase;margin-bottom:5px;">DUE DAY OF WEEK</div>
+      <select class="cd-input" id="recurrenceWeeklySelect" style="width:auto;">
+        <option value="Mon">Mon</option><option value="Tue">Tue</option>
+        <option value="Wed">Wed</option><option value="Thu">Thu</option>
+        <option value="Fri" selected>Fri</option>
+        <option value="Sat">Sat</option><option value="Sun">Sun</option>
+      </select>
+    </div>
+
+    <div id="recurrenceMonthlyDay" style="margin-top:0.7rem;display:none;">
+      <div style="font-family:var(--cd-font-ui);font-size:0.55rem;letter-spacing:0.18em;color:var(--cd-text-dim);text-transform:uppercase;margin-bottom:5px;">DUE DAY OF MONTH</div>
+      <input type="text" class="cd-input" id="recurrenceMonthlyInput" placeholder="1–31 or 'last'" value="1" style="width:8em;">
+    </div>
+
+    <div class="cd-modal-actions">
+      <button class="cd-btn ghost" id="recurrenceCancelBtn">CANCEL</button>
+      <button class="cd-btn primary" id="recurrenceSaveBtn">SAVE</button>
+    </div>
+  </div>
+</div>
 
 <!-- EDIT PROJECT MODAL -->
 <div class="cd-modal-overlay" id="editModal">
@@ -617,6 +689,7 @@ fetch('/below-deck/count').then(r=>r.json()).then(data=>{
             <div class="cd-panel-actions">
               <button class="cd-today-star" data-kind="block" data-id="${block.id}" title="Add to Today" type="button">☆</button>
               <button class="cd-btn ghost sm cd-block-save-as-template" data-block-id="${block.id}" data-default-name="${escapeHtml(titleAttr)}" title="Save this checklist as a template" type="button">TEMPLATE</button>
+              <button class="cd-btn ghost sm cd-block-recurrence-trigger" data-block-id="${block.id}" data-recurrence="" data-recurrence-days="" title="Set up recurrence" type="button">↻</button>
               <button class="cd-block-collapse-btn" data-block-id="${block.id}" title="Collapse">▾</button>
               <button class="cd-btn ghost sm block-delete-btn" data-id="${block.id}">REMOVE</button>
             </div>
@@ -1177,6 +1250,143 @@ document.addEventListener('click', function (ev) {
     const id = opt.getAttribute('data-id');
     close();
     spawn(id);
+  });
+})();
+
+// Phase 2.4 — RECURRENCE setter modal + RESET button
+(function () {
+  'use strict';
+  const modal = document.getElementById('recurrenceModal');
+  if (!modal) return;
+  let activeBlockId = null;
+
+  function syncDailyDaysFromCsv(csv) {
+    const set = new Set((csv || '').split(',').map(s => s.trim()).filter(Boolean));
+    document.querySelectorAll('input[name="recDaily"]').forEach(cb => {
+      // Default = Mon-Fri checked when nothing supplied
+      cb.checked = csv ? set.has(cb.value) : ['Mon','Tue','Wed','Thu','Fri'].includes(cb.value);
+    });
+  }
+
+  function showSection(kind) {
+    document.getElementById('recurrenceDailyDays').style.display   = (kind === 'daily')   ? '' : 'none';
+    document.getElementById('recurrenceWeeklyDay').style.display   = (kind === 'weekly')  ? '' : 'none';
+    document.getElementById('recurrenceMonthlyDay').style.display  = (kind === 'monthly') ? '' : 'none';
+  }
+
+  function openModal(blockId, currentKind, currentDays) {
+    activeBlockId = blockId;
+    const kind = currentKind || '';
+    document.querySelectorAll('input[name="recurrenceKind"]').forEach(r => {
+      r.checked = (r.value === kind);
+    });
+    showSection(kind);
+    if (kind === 'daily') syncDailyDaysFromCsv(currentDays);
+    if (kind === 'weekly') {
+      document.getElementById('recurrenceWeeklySelect').value = (currentDays || 'Fri').split(',')[0].trim() || 'Fri';
+    }
+    if (kind === 'monthly') {
+      document.getElementById('recurrenceMonthlyInput').value = (currentDays || '1').trim() || '1';
+    }
+    modal.classList.add('open');
+  }
+
+  function closeModal() {
+    activeBlockId = null;
+    modal.classList.remove('open');
+  }
+
+  // Open from delegated click (recurrence pill OR ↻ button)
+  document.addEventListener('click', function (ev) {
+    const trigger = ev.target.closest('.cd-block-recurrence-trigger');
+    if (!trigger) return;
+    ev.preventDefault();
+    openModal(
+      trigger.getAttribute('data-block-id'),
+      trigger.getAttribute('data-recurrence') || '',
+      trigger.getAttribute('data-recurrence-days') || ''
+    );
+  });
+
+  // Kind radio toggles which sub-section is visible
+  document.querySelectorAll('input[name="recurrenceKind"]').forEach(r => {
+    r.addEventListener('change', function () { showSection(r.value); });
+  });
+
+  // Cancel + click-outside
+  document.getElementById('recurrenceCancelBtn').addEventListener('click', closeModal);
+  modal.addEventListener('click', function (ev) {
+    if (ev.target === modal) closeModal();
+  });
+
+  // Save
+  document.getElementById('recurrenceSaveBtn').addEventListener('click', async function () {
+    if (!activeBlockId) return;
+    const kindEl = document.querySelector('input[name="recurrenceKind"]:checked');
+    const kind = kindEl ? kindEl.value : '';
+    let days = null;
+    if (kind === 'daily') {
+      const checked = Array.from(document.querySelectorAll('input[name="recDaily"]:checked')).map(c => c.value);
+      // 7 of 7 → NULL (means "every day"); fewer → CSV
+      days = (checked.length === 7) ? null : checked.join(',');
+      if (checked.length === 0) {
+        alert('Pick at least one active day, or switch to none.');
+        return;
+      }
+    } else if (kind === 'weekly') {
+      days = document.getElementById('recurrenceWeeklySelect').value;
+    } else if (kind === 'monthly') {
+      days = (document.getElementById('recurrenceMonthlyInput').value || '1').trim();
+    }
+    const payload = { recurrence: kind || null, recurrence_days: days };
+    try {
+      const r = await fetch(`/command-deck/projects/${PROJECT_SLUG}/blocks/${activeBlockId}/recurrence`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(payload),
+        credentials: 'same-origin',
+      });
+      if (r.ok) {
+        location.reload();
+      } else {
+        const d = await r.json().catch(() => ({}));
+        alert('Could not save recurrence: ' + (d.error || 'unknown error'));
+      }
+    } catch (e) {
+      alert('Network error.');
+    }
+  });
+
+  // RESET button — delegated; confirm + fire
+  document.addEventListener('click', async function (ev) {
+    const btn = ev.target.closest('.cd-block-reset');
+    if (!btn) return;
+    ev.preventDefault();
+    const blockId = btn.getAttribute('data-block-id');
+    const title = btn.getAttribute('data-block-title') || 'this checklist';
+    if (!confirm(`Reset ${title}? Archives current items and spawns a fresh cycle.`)) return;
+    try {
+      const r = await fetch(`/command-deck/projects/${PROJECT_SLUG}/blocks/${blockId}/reset`, {
+        method: 'POST',
+        credentials: 'same-origin',
+      });
+      if (r.ok) {
+        location.reload();
+      } else {
+        const d = await r.json().catch(() => ({}));
+        alert('Could not reset: ' + (d.error || 'unknown error'));
+      }
+    } catch (e) {
+      alert('Network error.');
+    }
+  });
+
+  // ESC closes modal
+  document.addEventListener('keydown', function (ev) {
+    if (ev.key === 'Escape' && modal.classList.contains('open')) {
+      ev.stopPropagation();
+      closeModal();
+    }
   });
 })();
 


### PR DESCRIPTION
## Summary

Phase 2.4 of the time-tracking roadmap — block recurrence (daily / weekly / monthly with weekday subset), per-cycle item instances at cycle boundary, due dates as a general concept on tasks AND items, archive-on-cycle preserving time-entry lineage, plus a per-block show-history toggle for browsing past cycles. Spec: `.kt/spec-time-tracking-phase-2-4.md`. Eight commits — 7-commit plan plus 1 small bugfix caught during testing.

### What this solves

Aaron's recurring routines (daily PD, weekly portfolio, etc) ran into two real problems after Phase 2.3:

1. **Clutter** — completed cycles left fully-checked blocks lingering until manually deleted or unchecked.
2. **Lifetime weirdness** — a recurring item accumulated "lifetime: 78:00" across 90 cycles. Technically correct, mostly unhelpful; the user wants per-cycle hours, not cumulative.

Phase 2.4 reframes recurring blocks as **definitions that spawn fresh item instances per cycle**, each with its own identity, due date, and time-tracking lineage. Old instances archive (preserve link to time entries) and are browsable via a per-block history toggle.

## Eight commits

| # | Commit | What |
|---|---|---|
| 1 | `chore(db)` | Migration adds 6 columns + 4 partial indexes |
| 2 | `feat(recurrence)` | Cycle-fire pass in `_today_autoclear` (daily/weekly/monthly with proper boundary math) + new `/blocks/<id>/recurrence` and `/blocks/<id>/reset` routes |
| 3 | `feat(recurrence)` | Archive filter (`archived_at IS NULL`) on every checklist_items query that drives a live UI surface; new `/blocks/<id>/history` endpoint (last 90 days) |
| 4 | `feat(recurrence)` | Block-header recurrence pill + setter modal + RESET button + JS-spawned-block parity |
| 5 | `feat(due-dates)` | `+ due` badges on tasks AND checklist items; native date picker; OVERDUE/today/tomorrow/soon/distant relative formatting; right-click to clear; new `/tasks/<id>/due-date` and `/checklist/<id>/due-date` routes |
| 6 | `feat(recurrence)` | "↳ show history ▾" toggle on recurring blocks reveals archived items grouped by due_date |
| 7 | `chore(kt)` | KT sweep + compact weekday labels (`MON–FRI` / `WEEKEND` / `MWF` / `TTh` instead of full CSV) |
| 8 | `fix(due-dates)` | Native date picker anchors correctly on first click (was opening top-left because `hidden` attr meant no layout for `showPicker()` to anchor against) |

## Cycle-fire semantics

- **Daily**: 4am ET on every active weekday in `recurrence_days` (or all 7 if NULL). Always resets — fresh slate every active day.
- **Weekly**: Monday 4am ET. ONLY fires if all current items are checked (otherwise items persist with overdue due_date). New items get `due_date = next occurrence of recurrence_days[0]`.
- **Monthly**: 1st of month 4am ET. Same only-if-complete rule. Day-of-month accepts `'1'..'31'` or `'last'` (clamps to last day if over-large for Feb etc).

Manual RESET button on every recurring block — escape hatch for ad-hoc cycle triggers (with confirm dialog).

## Test plan

- [x] Migration idempotent across two runs; 6 columns + 4 indexes confirmed
- [x] Backend cycle-fire: backdated `last_reset_at` triggers spawn on `/today/data` fetch; archived current cycle, fresh items inserted with new due_date
- [x] Recurrence routes: enable / clear / change kind; rejects on note blocks (400 recurrence_only_on_checklist)
- [x] RESET route: archives + spawns; rejects on non-recurring (400 block_not_recurring)
- [x] Archive filter applied across project page, today panel, master browse, count queries, time-tracking validation
- [x] History endpoint groups by due_date desc with 90-day cutoff
- [x] Due-date routes: valid date set, invalid date 400, empty clears, item route validates project slug
- [x] Project page renders recurrence pill / RESET / due-date badges / show-history toggle for both Jinja AND JS-spawned rows
- [x] Date picker anchors below the field on FIRST click (post-fix)
- [x] Aaron eyeballed everything: "a thing of beauty"

After merge:
- [ ] On PA: `git pull origin main && python migrate_add_recurrence_and_due_dates.py && reload web app`

## KT doc sweep (gitignored, local-only)

- `.kt/spec-time-tracking-phase-2-4.md` — Status: ✅ Shipped 2026-05-06
- `.kt/KT-command-deck.md` — schema additions documented; Phase 2.4 row marked ✅ in Deferred Features; Last updated bumped
- `.kt/PROJECT_KNOWLEDGE.md` — Last updated bumped; Phase 2.4 summary in headline slot

## Merge strategy

Rebase-merge / fast-forward only. Eight commits in narrative order, Han Solo voice runs through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)