### PR TITLE
Phase 5: meeting tracker

### DIFF
--- a/app.py
+++ b/app.py
@@ -142,6 +142,7 @@ from blueprints.mozzie import mozzie_bp
 from blueprints.time_tracking import time_tracking_bp
 from blueprints.healthz import healthz_bp
 from blueprints.reports import reports_bp
+from blueprints.meetings import meetings_bp
 app.register_blueprint(tasks_bp)
 app.register_blueprint(today_bp)
 app.register_blueprint(below_deck_bp)
@@ -152,6 +153,7 @@ app.register_blueprint(mozzie_bp)
 app.register_blueprint(time_tracking_bp)
 app.register_blueprint(healthz_bp)
 app.register_blueprint(reports_bp)
+app.register_blueprint(meetings_bp)
 
 
 if __name__ == "__main__": app.run(debug=True)

--- a/blueprints/command_deck.py
+++ b/blueprints/command_deck.py
@@ -1475,7 +1475,7 @@ def _huyang_build_context(project=None):
 	return '\n'.join(lines)
 
 
-def _huyang_build_system_with_content(project, blocks, project_tasks, files):
+def _huyang_build_system_with_content(project, blocks, project_tasks, files, meetings=None):
 	"""Full system prompt with all project content injected."""
 	system = _huyang_build_context(project)
 
@@ -1506,11 +1506,30 @@ def _huyang_build_system_with_content(project, blocks, project_tasks, files):
 		file_lines = '\n'.join(f"  - {f['filename']}" for f in files)
 		system += f'\n\nATTACHED FILES:\n{file_lines}'
 
+	if meetings:
+		# Phase 5 — meeting notes for the linked project. Format: date + title +
+		# the body of the notes, separated by horizontal rules so Huyang can
+		# treat each meeting as its own block.
+		mtg_sections = []
+		for m in meetings:
+			when = (m.get('meeting_date') or '')[:16]
+			head = f"[{when}] {m.get('title', '')}".strip()
+			body = (m.get('notes') or '').strip()
+			if body:
+				mtg_sections.append(f"{head}\n{body}")
+			else:
+				mtg_sections.append(head)
+		if mtg_sections:
+			system += '\n\nMEETINGS:\n' + '\n\n---\n\n'.join(mtg_sections)
+
 	return system
 
 
 def _huyang_load_project_content(conn, project_id):
-	"""Blocks (with checklist items), open tasks, files for a single project."""
+	"""Blocks (with checklist items), open tasks, files, and meetings for a
+	single project. Phase 5 adds meetings — title + date + notes for the 20
+	most recent meetings linked to this project, so Huyang can answer
+	"what did we decide last sync" without needing a separate tool."""
 	blocks_raw = conn.execute(
 		'SELECT * FROM blocks WHERE project_id = ? ORDER BY "order" ASC', (project_id,)
 	).fetchall()
@@ -1530,7 +1549,12 @@ def _huyang_load_project_content(conn, project_id):
 	files = [dict(f) for f in conn.execute(
 		'SELECT * FROM files WHERE project_id = ?', (project_id,)
 	).fetchall()]
-	return blocks, project_tasks, files
+	meetings = [dict(m) for m in conn.execute(
+		'SELECT id, title, meeting_date, notes FROM meetings '
+		'WHERE project_id = ? ORDER BY meeting_date DESC, id DESC LIMIT 20',
+		(project_id,)
+	).fetchall()]
+	return blocks, project_tasks, files, meetings
 
 
 def _huyang_load_area_content(conn, area_id):
@@ -1774,9 +1798,10 @@ def cd_chat():
 			project = dict(project)
 			if project.get('project_type') == 'work_area':
 				blocks, project_tasks, files = _huyang_load_area_content(conn, project['id'])
+				meetings = []  # area-mode meetings could be aggregated; defer to 5.x
 			else:
-				blocks, project_tasks, files = _huyang_load_project_content(conn, project['id'])
-			system = _huyang_build_system_with_content(project, blocks, project_tasks, files)
+				blocks, project_tasks, files, meetings = _huyang_load_project_content(conn, project['id'])
+			system = _huyang_build_system_with_content(project, blocks, project_tasks, files, meetings)
 		else:
 			system = _huyang_build_context()
 	else:

--- a/blueprints/command_deck.py
+++ b/blueprints/command_deck.py
@@ -603,6 +603,21 @@ def cd_project(slug):
 		(project['id'],)
 	).fetchall()
 
+	# Phase 5 — recent meetings on this project (most recent 10). The full
+	# list lives at /command-deck/meetings/?project=<slug>; the project page
+	# just summarizes.
+	meetings_recent = conn.execute('''
+		SELECT m.id, m.title, m.meeting_date,
+		       (SELECT COUNT(*) FROM tasks WHERE meeting_id = m.id) AS action_count
+		FROM meetings m
+		WHERE m.project_id = ?
+		ORDER BY m.meeting_date DESC, m.id DESC
+		LIMIT 10
+	''', (project['id'],)).fetchall()
+	meetings_total = conn.execute(
+		'SELECT COUNT(*) AS n FROM meetings WHERE project_id = ?', (project['id'],)
+	).fetchone()['n']
+
 	# Huyang chat — last 50 messages for this project
 	chat_history = conn.execute('''
 		SELECT * FROM chat_messages
@@ -620,6 +635,8 @@ def cd_project(slug):
 		blocks=blocks,
 		project_tasks=project_tasks,
 		files=[dict(f) for f in files],
+		meetings_recent=[dict(m) for m in meetings_recent],
+		meetings_total=meetings_total,
 		chat_history=[dict(m) for m in chat_history]
 	)
 

--- a/blueprints/meetings.py
+++ b/blueprints/meetings.py
@@ -1,0 +1,338 @@
+"""
+Meetings blueprint — Phase 5 of the Command Deck spec.
+
+Routes (all under /command-deck/meetings/*, all PIN-gated when the linked
+project is private — privacy inherits from the project per spec §1 #10):
+
+  GET   /command-deck/meetings/                  -- index page (chronological)
+  GET   /command-deck/meetings/<id>/             -- detail page
+  POST  /command-deck/meetings/new               -- create
+  POST  /command-deck/meetings/<id>/update       -- per-field patch
+  POST  /command-deck/meetings/<id>/delete       -- hard delete (cascades NULL)
+  POST  /command-deck/meetings/<id>/action-items/add  -- creates a tasks row
+
+Cascade rules are baked into the schema (migrate_add_meetings.py):
+  - project delete  → meetings.project_id          = NULL
+  - meeting delete  → tasks.meeting_id             = NULL
+  - meeting delete  → time_entries.meeting_id      = NULL
+
+Notes are markdown source; rendering happens client-side via marked.js
+(same pipeline as note blocks).
+"""
+import datetime as _dt
+
+from flask import (
+	Blueprint, jsonify, redirect, render_template, request, url_for,
+)
+
+from helpers.auth import cd_auth_required, is_authenticated
+from helpers.db import et_now, get_db
+
+
+meetings_bp = Blueprint('meetings', __name__)
+
+
+# ---- Helpers ----
+
+
+def _serialize_meeting(row, action_count=None):
+	d = dict(row)
+	if action_count is not None:
+		d['action_count'] = action_count
+	return d
+
+
+def _parse_meeting_date(val):
+	"""Validate an ET-local datetime string. Accepts:
+	- ISO 8601 with offset (what et_now() emits) — used as-is
+	- 'YYYY-MM-DDTHH:MM' from a <input type="datetime-local"> — localized to ET via et_now's tz
+	- empty / None → falls back to et_now()
+	"""
+	if not val:
+		return et_now()
+	val = val.strip()
+	if not val:
+		return et_now()
+	try:
+		_dt.datetime.fromisoformat(val)
+		return val
+	except (ValueError, TypeError):
+		return None
+
+
+# ---- Index page ----
+
+
+@meetings_bp.route('/command-deck/meetings/', methods=['GET'])
+@meetings_bp.route('/command-deck/meetings', methods=['GET'])
+@cd_auth_required
+def meetings_index():
+	conn = get_db()
+	project_filter = request.args.get('project')
+	args = []
+	where = ''
+	if project_filter:
+		project_row = conn.execute(
+			'SELECT id, title, slug FROM projects WHERE slug = ?', (project_filter,)
+		).fetchone()
+		if project_row:
+			where = 'WHERE m.project_id = ?'
+			args.append(project_row['id'])
+			project_filter_obj = dict(project_row)
+		else:
+			project_filter_obj = None
+	else:
+		project_filter_obj = None
+
+	rows = conn.execute(f'''
+		SELECT m.*,
+		       p.title AS project_title,
+		       p.slug  AS project_slug,
+		       p.is_private AS project_is_private,
+		       (SELECT COUNT(*) FROM tasks WHERE meeting_id = m.id) AS action_count
+		FROM meetings m
+		LEFT JOIN projects p ON m.project_id = p.id
+		{where}
+		ORDER BY m.meeting_date DESC, m.id DESC
+	''', args).fetchall()
+
+	# Drop private-project meetings unless the user has unlocked. The lock is
+	# advisory (over-the-shoulder); auth guarantees it's Aaron, the lock just
+	# hides them from passers-by. Mirror the dashboard convention: if the
+	# unlock cookie/localStorage is set, the client passes ?include_private=1.
+	include_private = request.args.get('include_private') == '1'
+	if not include_private:
+		rows = [r for r in rows if not (r['project_is_private'] or 0)]
+
+	conn.close()
+	return render_template(
+		'command_deck_meetings.html',
+		meetings=[dict(r) for r in rows],
+		project_filter=project_filter_obj,
+		include_private=include_private,
+	)
+
+
+# ---- Detail page ----
+
+
+@meetings_bp.route('/command-deck/meetings/<int:meeting_id>/', methods=['GET'])
+@meetings_bp.route('/command-deck/meetings/<int:meeting_id>', methods=['GET'])
+@cd_auth_required
+def meeting_detail(meeting_id):
+	conn = get_db()
+	meeting = conn.execute('''
+		SELECT m.*,
+		       p.title AS project_title,
+		       p.slug  AS project_slug,
+		       p.tracking_enabled AS project_tracking_enabled,
+		       p.is_private AS project_is_private
+		FROM meetings m
+		LEFT JOIN projects p ON m.project_id = p.id
+		WHERE m.id = ?
+	''', (meeting_id,)).fetchone()
+	if not meeting:
+		conn.close()
+		return "Meeting not found", 404
+
+	action_items = conn.execute('''
+		SELECT * FROM tasks
+		WHERE meeting_id = ? AND status = 'open'
+		ORDER BY "order" ASC, id ASC
+	''', (meeting_id,)).fetchall()
+
+	# Lifetime time tracked on this meeting — sum of all duration_seconds where
+	# meeting_id = ?. Mirrors the per-task lifetime tag pattern from cd_project.
+	lifetime_row = conn.execute('''
+		SELECT COALESCE(SUM(duration_seconds), 0) AS secs
+		FROM time_entries
+		WHERE meeting_id = ? AND duration_seconds IS NOT NULL
+	''', (meeting_id,)).fetchone()
+	lifetime_seconds = int(lifetime_row['secs'] or 0)
+
+	# Project picker for the reassign dropdown (work sub-projects + personals)
+	projects = conn.execute('''
+		SELECT id, title, slug, project_type, parent_project_id, is_private
+		FROM projects
+		WHERE project_type IN ('work_subproject', 'personal')
+		  AND is_private = 0
+		ORDER BY title ASC
+	''').fetchall()
+
+	conn.close()
+	return render_template(
+		'command_deck_meeting.html',
+		meeting=dict(meeting),
+		action_items=[dict(t) for t in action_items],
+		projects=[dict(p) for p in projects],
+		lifetime_seconds=lifetime_seconds,
+	)
+
+
+# ---- Create ----
+
+
+@meetings_bp.route('/command-deck/meetings/new', methods=['POST'])
+@cd_auth_required
+def meeting_new():
+	title = (request.form.get('title') or '').strip()
+	if not title:
+		# Inline modal sends application/x-www-form-urlencoded; either redirect
+		# back to the referrer or land the user on the index.
+		return redirect(request.referrer or url_for('meetings.meetings_index'))
+
+	meeting_date = _parse_meeting_date(request.form.get('meeting_date'))
+	if meeting_date is None:
+		return redirect(request.referrer or url_for('meetings.meetings_index'))
+
+	project_id = request.form.get('project_id')
+	try:
+		project_id = int(project_id) if project_id else None
+	except (ValueError, TypeError):
+		project_id = None
+
+	notes = request.form.get('notes')
+	now = et_now()
+
+	conn = get_db()
+	cur = conn.execute('''
+		INSERT INTO meetings (project_id, title, meeting_date, notes, created, updated)
+		VALUES (?, ?, ?, ?, ?, ?)
+	''', (project_id, title, meeting_date, notes, now, now))
+	new_id = cur.lastrowid
+	conn.commit()
+	conn.close()
+	return redirect(url_for('meetings.meeting_detail', meeting_id=new_id))
+
+
+# ---- Per-field update ----
+
+
+@meetings_bp.route('/command-deck/meetings/<int:meeting_id>/update', methods=['POST'])
+@cd_auth_required
+def meeting_update(meeting_id):
+	data = request.get_json(silent=True) or request.form
+	conn = get_db()
+	row = conn.execute('SELECT * FROM meetings WHERE id = ?', (meeting_id,)).fetchone()
+	if not row:
+		conn.close()
+		return jsonify({'error': 'not_found'}), 404
+
+	updates = {}
+	if 'title' in data:
+		title = (data.get('title') or '').strip()
+		if not title:
+			conn.close()
+			return jsonify({'error': 'title_required'}), 400
+		updates['title'] = title
+
+	if 'meeting_date' in data:
+		val = _parse_meeting_date(data.get('meeting_date'))
+		if val is None:
+			conn.close()
+			return jsonify({'error': 'invalid_meeting_date'}), 400
+		updates['meeting_date'] = val
+
+	if 'project_id' in data:
+		val = data.get('project_id')
+		if val in (None, '', 'null', 'standalone'):
+			updates['project_id'] = None
+		else:
+			try:
+				updates['project_id'] = int(val)
+			except (ValueError, TypeError):
+				conn.close()
+				return jsonify({'error': 'invalid_project_id'}), 400
+
+	if 'notes' in data:
+		updates['notes'] = data.get('notes') or ''
+
+	if not updates:
+		conn.close()
+		return jsonify({'error': 'no_fields'}), 400
+
+	updates['updated'] = et_now()
+	set_sql = ', '.join(f'{k} = ?' for k in updates)
+	vals = list(updates.values()) + [meeting_id]
+	conn.execute(f'UPDATE meetings SET {set_sql} WHERE id = ?', vals)
+	conn.commit()
+	row = conn.execute('SELECT * FROM meetings WHERE id = ?', (meeting_id,)).fetchone()
+	conn.close()
+	return jsonify({'success': True, 'meeting': dict(row)})
+
+
+# ---- Delete ----
+
+
+@meetings_bp.route('/command-deck/meetings/<int:meeting_id>/delete', methods=['POST'])
+@cd_auth_required
+def meeting_delete(meeting_id):
+	conn = get_db()
+	row = conn.execute('SELECT id FROM meetings WHERE id = ?', (meeting_id,)).fetchone()
+	if not row:
+		conn.close()
+		return jsonify({'error': 'not_found'}), 404
+	# Cascade is SET NULL on tasks.meeting_id and time_entries.meeting_id —
+	# tasks survive as orphan action items, time entries keep their project
+	# attribution. The DB does this automatically given the FK declaration,
+	# but SQLite doesn't enforce FKs by default; do it explicitly so we don't
+	# rely on PRAGMA foreign_keys=ON being set somewhere upstream.
+	conn.execute('UPDATE tasks SET meeting_id = NULL WHERE meeting_id = ?', (meeting_id,))
+	conn.execute('UPDATE time_entries SET meeting_id = NULL WHERE meeting_id = ?', (meeting_id,))
+	conn.execute('DELETE FROM meetings WHERE id = ?', (meeting_id,))
+	conn.commit()
+	conn.close()
+	return jsonify({'success': True, 'deleted_id': meeting_id})
+
+
+# ---- Action items ----
+
+
+@meetings_bp.route('/command-deck/meetings/<int:meeting_id>/action-items/add', methods=['POST'])
+def meeting_action_item_add(meeting_id):
+	# This route is also POSTed to from inline JS on the meeting detail page,
+	# which uses XHR; cd_auth_required redirects to /login on auth failure
+	# (HTML), which would break JSON consumers. Match the pattern from
+	# tasks_bp routes and return JSON 403.
+	if not is_authenticated():
+		return jsonify({'error': 'unauthorized'}), 403
+
+	title = (request.form.get('title') or '').strip()
+	if not title:
+		return jsonify({'error': 'title_required'}), 400
+
+	conn = get_db()
+	meeting = conn.execute(
+		'SELECT id, project_id FROM meetings WHERE id = ?', (meeting_id,)
+	).fetchone()
+	if not meeting:
+		conn.close()
+		return jsonify({'error': 'not_found'}), 404
+
+	# Pull the next "order" within this meeting's project bucket so the action
+	# item lands at the bottom of the project task list (not jammed in random)
+	# — mirroring the cd_project_task_add convention.
+	if meeting['project_id'] is not None:
+		row = conn.execute(
+			'SELECT COALESCE(MAX("order"), -1) + 1 AS next_order '
+			'FROM tasks WHERE project_id = ?',
+			(meeting['project_id'],)
+		).fetchone()
+	else:
+		row = conn.execute(
+			'SELECT COALESCE(MAX("order"), -1) + 1 AS next_order '
+			'FROM tasks WHERE project_id IS NULL'
+		).fetchone()
+	next_order = row['next_order'] if row else 0
+
+	now = et_now()
+	cur = conn.execute('''
+		INSERT INTO tasks
+			(title, status, created, project_id, "order", today, meeting_id)
+		VALUES (?, 'open', ?, ?, ?, 0, ?)
+	''', (title, now, meeting['project_id'], next_order, meeting_id))
+	new_id = cur.lastrowid
+	conn.commit()
+	task = conn.execute('SELECT * FROM tasks WHERE id = ?', (new_id,)).fetchone()
+	conn.close()
+	return jsonify({'success': True, 'task': dict(task)})

--- a/blueprints/reports.py
+++ b/blueprints/reports.py
@@ -238,6 +238,7 @@ def reports_data():
 	conn = get_db()
 	rows = conn.execute(f'''
 		SELECT te.id, te.project_id, te.task_id, te.checklist_item_id,
+		       te.meeting_id,
 		       te.description, te.started_at, te.ended_at,
 		       te.duration_seconds,
 		       p.title           AS project_title,
@@ -248,13 +249,15 @@ def reports_data():
 		       t.title           AS task_title,
 		       ci.text           AS checklist_item_text,
 		       b.id              AS block_id,
-		       b.title           AS block_title
+		       b.title           AS block_title,
+		       m.title           AS meeting_title
 		FROM time_entries te
 		JOIN projects p              ON te.project_id = p.id
 		LEFT JOIN projects parent    ON p.parent_project_id = parent.id
 		LEFT JOIN tasks t            ON te.task_id = t.id
 		LEFT JOIN checklist_items ci ON te.checklist_item_id = ci.id
 		LEFT JOIN blocks b           ON ci.block_id = b.id
+		LEFT JOIN meetings m         ON te.meeting_id = m.id
 		WHERE {where_sql}
 		ORDER BY te.started_at ASC
 	''', args).fetchall()
@@ -302,6 +305,8 @@ def reports_data():
 			'checklist_item_text': r['checklist_item_text'],
 			'block_id': r['block_id'],
 			'block_title': r['block_title'],
+			'meeting_id': r['meeting_id'],
+			'meeting_title': r['meeting_title'],
 			'description': r['description'],
 			'started_at': r['started_at'],
 			'ended_at': ended,

--- a/blueprints/time_tracking.py
+++ b/blueprints/time_tracking.py
@@ -77,26 +77,30 @@ def _row_get(row, key, default=None):
 
 def _fetch_entry_with_context(conn, entry_id):
 	"""Re-fetch a time_entries row with task + checklist_item + parent-block
-	context joined. Phase 2.1 added the blocks JOIN so client renderers can
-	display [Checklist: <block.title>] for item-scoped entries instead of
-	the raw item text."""
+	+ meeting context joined. Phase 2.1 added the blocks JOIN so client
+	renderers can display [Checklist: <block.title>] for item-scoped entries;
+	Phase 5 added the meetings JOIN so the active strip / panel / reports
+	can show [meeting: <title>] for meeting-scoped entries."""
 	return conn.execute('''
 		SELECT te.*,
 		       t.title  AS task_title,
 		       ci.text  AS checklist_item_text,
 		       b.id     AS block_id,
-		       b.title  AS block_title
+		       b.title  AS block_title,
+		       m.title  AS meeting_title
 		FROM time_entries te
 		LEFT JOIN tasks t            ON te.task_id = t.id
 		LEFT JOIN checklist_items ci ON te.checklist_item_id = ci.id
 		LEFT JOIN blocks b           ON ci.block_id = b.id
+		LEFT JOIN meetings m         ON te.meeting_id = m.id
 		WHERE te.id = ?
 	''', (entry_id,)).fetchone()
 
 
 def _serialize_active_entry(row):
 	"""Active-entry shape — Phase 1 §3.1 + Phase 1.5 task/item context +
-	Phase 2.1 block context for item-scoped entries."""
+	Phase 2.1 block context for item-scoped entries + Phase 5 meeting
+	context for meeting-scoped entries."""
 	started = _parse_iso_utc(row['started_at'])
 	elapsed = int((datetime.now(pytz.UTC) - started).total_seconds()) if started else 0
 	return {
@@ -115,6 +119,8 @@ def _serialize_active_entry(row):
 		'checklist_item_text': _row_get(row, 'checklist_item_text'),
 		'block_id': _row_get(row, 'block_id'),
 		'block_title': _row_get(row, 'block_title'),
+		'meeting_id': _row_get(row, 'meeting_id'),
+		'meeting_title': _row_get(row, 'meeting_title'),
 	}
 
 
@@ -129,6 +135,8 @@ def _serialize_entry(row):
 		'checklist_item_text': _row_get(row, 'checklist_item_text'),
 		'block_id': _row_get(row, 'block_id'),
 		'block_title': _row_get(row, 'block_title'),
+		'meeting_id': _row_get(row, 'meeting_id'),
+		'meeting_title': _row_get(row, 'meeting_title'),
 		'description': row['description'],
 		'started_at': row['started_at'],
 		'ended_at': row['ended_at'],
@@ -148,7 +156,7 @@ def time_active():
 	conn = get_db()
 	rows = conn.execute('''
 		SELECT te.id, te.project_id, te.description, te.started_at,
-		       te.task_id, te.checklist_item_id,
+		       te.task_id, te.checklist_item_id, te.meeting_id,
 		       p.title             AS project_title,
 		       p.parent_project_id,
 		       parent.id           AS area_id,
@@ -157,13 +165,15 @@ def time_active():
 		       t.title             AS task_title,
 		       ci.text             AS checklist_item_text,
 		       b.id                AS block_id,
-		       b.title             AS block_title
+		       b.title             AS block_title,
+		       m.title             AS meeting_title
 		FROM time_entries te
 		JOIN projects p ON te.project_id = p.id
 		LEFT JOIN projects parent    ON p.parent_project_id = parent.id
 		LEFT JOIN tasks t            ON te.task_id = t.id
 		LEFT JOIN checklist_items ci ON te.checklist_item_id = ci.id
 		LEFT JOIN blocks b           ON ci.block_id = b.id
+		LEFT JOIN meetings m         ON te.meeting_id = m.id
 		WHERE te.ended_at IS NULL
 		ORDER BY te.started_at ASC
 	''').fetchall()
@@ -180,13 +190,15 @@ def time_start():
 	description = (data.get('description') or '').strip()
 	task_id = data.get('task_id')
 	checklist_item_id = data.get('checklist_item_id')
+	meeting_id = data.get('meeting_id')
 
 	if not project_id:
 		return jsonify({'error': 'project_id required'}), 400
 
-	# Phase 1.5 — mutual exclusion of task vs checklist item
-	if task_id and checklist_item_id:
-		return jsonify({'error': 'task_or_item_not_both'}), 400
+	# Phase 1.5 + Phase 5 — at most one of task / item / meeting may scope an entry
+	scopes_set = sum(1 for x in (task_id, checklist_item_id, meeting_id) if x)
+	if scopes_set > 1:
+		return jsonify({'error': 'task_item_or_meeting_not_multiple'}), 400
 
 	conn = get_db()
 	project = conn.execute(
@@ -235,6 +247,21 @@ def time_start():
 				'item_project_id': item['project_id'],
 			}), 400
 
+	# Phase 5 — meeting_id must point to a meeting on this project
+	if meeting_id:
+		meeting = conn.execute(
+			'SELECT id, project_id FROM meetings WHERE id = ?', (meeting_id,)
+		).fetchone()
+		if not meeting:
+			conn.close()
+			return jsonify({'error': 'meeting_not_found'}), 404
+		if meeting['project_id'] != int(project_id):
+			conn.close()
+			return jsonify({
+				'error': 'meeting_project_mismatch',
+				'meeting_project_id': meeting['project_id'],
+			}), 400
+
 	# §0a.2 #3 — 409 on concurrent same-project timer
 	existing = conn.execute(
 		'SELECT id FROM time_entries WHERE project_id = ? AND ended_at IS NULL',
@@ -250,13 +277,14 @@ def time_start():
 	now = _utc_now_iso()
 	cur = conn.execute('''
 		INSERT INTO time_entries
-			(project_id, task_id, checklist_item_id, description,
-			 started_at, created, updated)
-		VALUES (?, ?, ?, ?, ?, ?, ?)
+			(project_id, task_id, checklist_item_id, meeting_id,
+			 description, started_at, created, updated)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 	''', (
 		project_id,
 		int(task_id) if task_id else None,
 		int(checklist_item_id) if checklist_item_id else None,
+		int(meeting_id) if meeting_id else None,
 		description, now, now, now,
 	))
 	new_id = cur.lastrowid
@@ -323,6 +351,7 @@ def time_update(entry_id):
 	new_ended = row['ended_at']
 	new_task_id = row['task_id']
 	new_item_id = row['checklist_item_id']
+	new_meeting_id = _row_get(row, 'meeting_id')
 
 	if 'description' in data:
 		new_description = (data.get('description') or '').strip()
@@ -371,9 +400,21 @@ def time_update(entry_id):
 				conn.close()
 				return jsonify({'error': 'invalid_checklist_item_id'}), 400
 
-	if new_task_id is not None and new_item_id is not None:
+	if 'meeting_id' in data:
+		val = data.get('meeting_id')
+		if val in (None, '', 'null'):
+			new_meeting_id = None
+		else:
+			try:
+				new_meeting_id = int(val)
+			except (ValueError, TypeError):
+				conn.close()
+				return jsonify({'error': 'invalid_meeting_id'}), 400
+
+	scopes_set = sum(1 for x in (new_task_id, new_item_id, new_meeting_id) if x is not None)
+	if scopes_set > 1:
 		conn.close()
-		return jsonify({'error': 'task_or_item_not_both'}), 400
+		return jsonify({'error': 'task_item_or_meeting_not_multiple'}), 400
 
 	entry_project_id = row['project_id']
 
@@ -408,6 +449,20 @@ def time_update(entry_id):
 				'item_project_id': item['project_id'],
 			}), 400
 
+	if 'meeting_id' in data and new_meeting_id is not None:
+		meeting = conn.execute(
+			'SELECT id, project_id FROM meetings WHERE id = ?', (new_meeting_id,)
+		).fetchone()
+		if not meeting:
+			conn.close()
+			return jsonify({'error': 'meeting_not_found'}), 404
+		if meeting['project_id'] != entry_project_id:
+			conn.close()
+			return jsonify({
+				'error': 'meeting_project_mismatch',
+				'meeting_project_id': meeting['project_id'],
+			}), 400
+
 	if new_ended:
 		try:
 			s = _parse_iso_utc(new_started)
@@ -424,11 +479,11 @@ def time_update(entry_id):
 		UPDATE time_entries
 		SET description = ?, started_at = ?, ended_at = ?,
 		    duration_seconds = ?, task_id = ?, checklist_item_id = ?,
-		    updated = ?
+		    meeting_id = ?, updated = ?
 		WHERE id = ?
 	''', (
 		new_description, new_started, new_ended, new_duration,
-		new_task_id, new_item_id, now_iso, entry_id,
+		new_task_id, new_item_id, new_meeting_id, now_iso, entry_id,
 	))
 	conn.commit()
 	row = _fetch_entry_with_context(conn, entry_id)
@@ -554,11 +609,13 @@ def time_today(project_id):
 		       t.title  AS task_title,
 		       ci.text  AS checklist_item_text,
 		       b.id     AS block_id,
-		       b.title  AS block_title
+		       b.title  AS block_title,
+		       m.title  AS meeting_title
 		FROM time_entries te
 		LEFT JOIN tasks t            ON te.task_id = t.id
 		LEFT JOIN checklist_items ci ON te.checklist_item_id = ci.id
 		LEFT JOIN blocks b           ON ci.block_id = b.id
+		LEFT JOIN meetings m         ON te.meeting_id = m.id
 		WHERE te.project_id = ?
 		  AND te.started_at >= ?
 		  AND te.started_at <  ?

--- a/migrate_add_meetings.py
+++ b/migrate_add_meetings.py
@@ -1,0 +1,164 @@
+"""
+migrate_add_meetings.py
+Phase 5 of the Command Deck spec — see .kt/spec-phase-5-meetings.md.
+
+What it does (idempotent — safe to run multiple times):
+
+  + meetings table:
+        id            INTEGER PRIMARY KEY AUTOINCREMENT
+        project_id    INTEGER REFERENCES projects(id) ON DELETE SET NULL
+        title         TEXT NOT NULL
+        meeting_date  TEXT NOT NULL          -- ISO 8601 ET-local with offset
+        notes         TEXT                   -- markdown source
+        created       TEXT NOT NULL
+        updated       TEXT NOT NULL
+
+  + tasks.meeting_id          INTEGER  -- FK meetings(id), ON DELETE SET NULL
+  + time_entries.meeting_id   INTEGER  -- FK meetings(id), ON DELETE SET NULL
+                                       -- mutually exclusive with task_id /
+                                       -- checklist_item_id; project_id of
+                                       -- the entry must equal meeting.project_id
+
+  + indexes:
+    idx_meetings_project       meetings(project_id)
+    idx_meetings_date          meetings(meeting_date)
+    idx_tasks_meeting          tasks(meeting_id)
+                                  WHERE meeting_id IS NOT NULL
+    idx_time_entries_meeting   time_entries(meeting_id)
+                                  WHERE meeting_id IS NOT NULL
+
+Cascade rules:
+  - project delete  → meetings.project_id          = NULL  (meetings go standalone)
+  - meeting delete  → tasks.meeting_id             = NULL  (tasks survive)
+  - meeting delete  → time_entries.meeting_id      = NULL  (entries survive,
+                                                            keep their project_id
+                                                            + duration)
+
+Prints a summary. Running it again prints "no changes."
+
+Run from PythonAnywhere bash:
+    cd /home/aaronaiken/status_update
+    python migrate_add_meetings.py
+"""
+
+import os
+import sqlite3
+
+DB_FILE = os.path.join(
+	os.environ.get('COCKPIT_REPO_ROOT', '/home/aaronaiken/status_update'),
+	'assets/data/command_deck.db'
+)
+
+
+def table_exists(cur, name):
+	row = cur.execute(
+		"SELECT name FROM sqlite_master WHERE type='table' AND name=?", (name,)
+	).fetchone()
+	return row is not None
+
+
+def column_exists(cur, table, col):
+	cols = [row[1] for row in cur.execute(f"PRAGMA table_info({table})").fetchall()]
+	return col in cols
+
+
+def index_exists(cur, name):
+	row = cur.execute(
+		"SELECT name FROM sqlite_master WHERE type='index' AND name=?", (name,)
+	).fetchone()
+	return row is not None
+
+
+CREATE_MEETINGS_SQL = """
+CREATE TABLE meetings (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id   INTEGER REFERENCES projects(id) ON DELETE SET NULL,
+    title        TEXT NOT NULL,
+    meeting_date TEXT NOT NULL,
+    notes        TEXT,
+    created      TEXT NOT NULL,
+    updated      TEXT NOT NULL
+)
+"""
+
+COLUMNS = [
+	('tasks',        'meeting_id', 'INTEGER REFERENCES meetings(id) ON DELETE SET NULL'),
+	('time_entries', 'meeting_id', 'INTEGER REFERENCES meetings(id) ON DELETE SET NULL'),
+]
+
+INDEXES = [
+	(
+		'idx_meetings_project',
+		'CREATE INDEX IF NOT EXISTS idx_meetings_project ON meetings(project_id)',
+	),
+	(
+		'idx_meetings_date',
+		'CREATE INDEX IF NOT EXISTS idx_meetings_date ON meetings(meeting_date)',
+	),
+	(
+		'idx_tasks_meeting',
+		'CREATE INDEX IF NOT EXISTS idx_tasks_meeting '
+		'ON tasks(meeting_id) WHERE meeting_id IS NOT NULL',
+	),
+	(
+		'idx_time_entries_meeting',
+		'CREATE INDEX IF NOT EXISTS idx_time_entries_meeting '
+		'ON time_entries(meeting_id) WHERE meeting_id IS NOT NULL',
+	),
+]
+
+
+def run():
+	if not os.path.exists(DB_FILE):
+		print(f"× DB not found at {DB_FILE}")
+		print("  Run migrate_to_sqlite.py first.")
+		return
+
+	conn = sqlite3.connect(DB_FILE)
+	cur = conn.cursor()
+
+	added = []
+	skipped = []
+
+	if table_exists(cur, 'meetings'):
+		skipped.append('meetings (table)')
+	else:
+		cur.execute(CREATE_MEETINGS_SQL)
+		added.append('meetings (table)')
+
+	for table, col, sql_type in COLUMNS:
+		if column_exists(cur, table, col):
+			skipped.append(f'{table}.{col}')
+		else:
+			cur.execute(f'ALTER TABLE {table} ADD COLUMN {col} {sql_type}')
+			added.append(f'{table}.{col}')
+
+	for name, sql in INDEXES:
+		if index_exists(cur, name):
+			skipped.append(name)
+		else:
+			cur.execute(sql)
+			added.append(name)
+
+	conn.commit()
+	conn.close()
+
+	print()
+	print("Migration: migrate_add_meetings.py")
+	print(f"DB:        {DB_FILE}")
+	print()
+	if added:
+		print(f"✓ Added ({len(added)}):")
+		for item in added:
+			print(f"    + {item}")
+	if skipped:
+		print(f"— Already in place ({len(skipped)}):")
+		for item in skipped:
+			print(f"    · {item}")
+	if not added:
+		print("No changes — schema already up to date.")
+	print()
+
+
+if __name__ == '__main__':
+	run()

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -3772,3 +3772,293 @@ body[data-cd-tab="personal"] .cd-huyang-search-row { display: none; }
   }
 }
 
+
+/* ============================================================
+ * MEETINGS — Phase 5
+ * Index page chrome, detail page meta + notes, action items.
+ * ============================================================ */
+
+.cd-meetings-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.cd-meetings-title-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.cd-meetings-filter-pill {
+  font-family: var(--cd-font-ui);
+  font-size: 0.62rem;
+  letter-spacing: 0.1em;
+  color: var(--cd-text-dim);
+  border: 1px solid var(--cd-border);
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.cd-meetings-filter-pill a { color: var(--cd-amber); text-decoration: none; }
+.cd-meetings-filter-clear {
+  color: var(--cd-text-dim) !important;
+  text-decoration: none;
+  padding: 0 0.2rem;
+}
+.cd-meetings-filter-clear:hover { color: var(--cd-amber-hi) !important; }
+
+.cd-meetings-month {
+  font-family: var(--cd-font-ui);
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  color: var(--cd-text-dim);
+  margin: 1.5rem 0 0.4rem;
+  text-transform: uppercase;
+}
+
+.cd-meetings-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--cd-border);
+}
+
+.cd-meeting-row {
+  border-bottom: 1px solid var(--cd-border);
+}
+.cd-meeting-row-link {
+  display: grid;
+  grid-template-columns: 14em 1fr 12em 7em;
+  gap: 1rem;
+  padding: 0.55rem 0.4rem;
+  align-items: baseline;
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.12s;
+}
+.cd-meeting-row-link:hover { background: rgba(212, 136, 10, 0.05); }
+
+.cd-meeting-row-date {
+  font-family: var(--cd-font-ui);
+  font-size: 0.62rem;
+  letter-spacing: 0.1em;
+  color: var(--cd-text-dim);
+  white-space: nowrap;
+}
+.cd-meeting-row-title {
+  font-size: 0.95rem;
+  color: var(--cd-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cd-meeting-row-project {
+  font-family: var(--cd-font-ui);
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  color: var(--cd-amber);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cd-meeting-row-project em {
+  color: var(--cd-text-dim);
+  font-style: normal;
+}
+.cd-meeting-row-actions {
+  font-family: var(--cd-font-ui);
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  color: var(--cd-text-dim);
+  text-align: right;
+  white-space: nowrap;
+}
+
+.cd-meetings-empty {
+  font-family: var(--cd-font-ui);
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  color: var(--cd-text-dim);
+  padding: 2rem 0;
+  text-align: center;
+}
+
+@media (max-width: 720px) {
+  .cd-meeting-row-link {
+    grid-template-columns: 1fr 6em;
+    grid-template-areas:
+      "date    actions"
+      "title   title"
+      "project project";
+    row-gap: 0.2rem;
+  }
+  .cd-meeting-row-date    { grid-area: date; }
+  .cd-meeting-row-title   { grid-area: title; }
+  .cd-meeting-row-project { grid-area: project; }
+  .cd-meeting-row-actions { grid-area: actions; }
+}
+
+/* --- Detail page --- */
+
+.cd-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--cd-font-ui);
+  font-size: 0.62rem;
+  letter-spacing: 0.12em;
+  color: var(--cd-text-dim);
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+}
+.cd-breadcrumb a {
+  color: var(--cd-amber);
+  text-decoration: none;
+}
+.cd-breadcrumb a:hover { color: var(--cd-amber-hi); }
+.cd-breadcrumb-sep { color: var(--cd-text-dim); }
+.cd-breadcrumb-tail {
+  color: var(--cd-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+.cd-breadcrumb-actions { margin-left: auto; }
+
+.cd-meeting-header {
+  margin-bottom: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--cd-border);
+}
+
+.cd-meeting-title-edit {
+  outline: none;
+  border-radius: 2px;
+  padding: 0 0.2rem;
+  margin-left: -0.2rem;
+}
+.cd-meeting-title-edit:focus,
+.cd-meeting-title-edit:hover {
+  background: rgba(212, 136, 10, 0.06);
+}
+
+.cd-meeting-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  margin-top: 0.75rem;
+}
+
+.cd-meeting-meta-row {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+  font-family: var(--cd-font-ui);
+  font-size: 0.7rem;
+}
+
+.cd-meeting-meta-label {
+  display: inline-block;
+  min-width: 5em;
+  letter-spacing: 0.14em;
+  color: var(--cd-text-dim);
+  text-transform: uppercase;
+  font-size: 0.6rem;
+}
+
+.cd-meeting-date-input {
+  background: transparent;
+  border: 1px solid var(--cd-border);
+  color: var(--cd-text);
+  font: inherit;
+  font-size: 0.7rem;
+  padding: 0.25rem 0.4rem;
+  border-radius: 2px;
+  display: none;
+}
+
+.cd-meeting-date-display {
+  cursor: pointer;
+  color: var(--cd-text);
+  border-bottom: 1px dashed transparent;
+  padding: 0.1rem 0;
+}
+.cd-meeting-date-display:hover {
+  border-bottom-color: var(--cd-amber);
+}
+
+.cd-meeting-project-select {
+  background: transparent;
+  border: 1px solid var(--cd-border);
+  color: var(--cd-text);
+  font: inherit;
+  font-size: 0.7rem;
+  padding: 0.2rem 0.35rem;
+  border-radius: 2px;
+}
+
+.cd-meeting-project-link {
+  font-size: 0.6rem;
+  color: var(--cd-amber);
+  text-decoration: none;
+  letter-spacing: 0.1em;
+}
+.cd-meeting-project-link:hover { color: var(--cd-amber-hi); }
+
+.cd-meeting-tt-row .cd-tt-row-btn {
+  margin-right: 0.4rem;
+}
+
+.cd-meeting-meta-hint .cd-meeting-meta-note {
+  color: var(--cd-text-dim);
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+}
+
+.cd-meeting-notes-rendered {
+  min-height: 4em;
+  cursor: text;
+  padding: 0.4rem;
+  border-radius: 2px;
+}
+.cd-meeting-notes-rendered:hover { background: rgba(212, 136, 10, 0.04); }
+.cd-meeting-notes-rendered .cd-note-placeholder {
+  color: var(--cd-text-dim);
+  font-style: italic;
+}
+.cd-meeting-notes-editor textarea {
+  width: 100%;
+  background: transparent;
+  border: 1px solid var(--cd-border);
+  color: var(--cd-text);
+  font-family: inherit;
+  font-size: 0.85rem;
+  padding: 0.5rem;
+  border-radius: 2px;
+  resize: vertical;
+}
+
+/* --- New-meeting modal labels --- */
+.cd-modal .cd-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-bottom: 0.75rem;
+}
+.cd-modal .cd-label > span {
+  font-family: var(--cd-font-ui);
+  font-size: 0.6rem;
+  letter-spacing: 0.12em;
+  color: var(--cd-text-dim);
+  text-transform: uppercase;
+}

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -4062,3 +4062,57 @@ body[data-cd-tab="personal"] .cd-huyang-search-row { display: none; }
   color: var(--cd-text-dim);
   text-transform: uppercase;
 }
+
+/* Project page // Meetings panel — Phase 5 */
+.cd-project-meetings-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.cd-project-meeting-row {
+  border-bottom: 1px solid var(--cd-border);
+}
+.cd-project-meeting-row:last-child { border-bottom: none; }
+.cd-project-meeting-link {
+  display: grid;
+  grid-template-columns: 13em 1fr 7em;
+  gap: 0.75rem;
+  padding: 0.4rem 0.2rem;
+  align-items: baseline;
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.12s;
+}
+.cd-project-meeting-link:hover { background: rgba(212, 136, 10, 0.05); }
+.cd-project-meeting-date {
+  font-family: var(--cd-font-ui);
+  font-size: 0.6rem;
+  letter-spacing: 0.1em;
+  color: var(--cd-text-dim);
+  white-space: nowrap;
+}
+.cd-project-meeting-title {
+  font-size: 0.85rem;
+  color: var(--cd-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cd-project-meeting-actions {
+  font-family: var(--cd-font-ui);
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  color: var(--cd-text-dim);
+  text-align: right;
+  white-space: nowrap;
+}
+@media (max-width: 720px) {
+  .cd-project-meeting-link {
+    grid-template-columns: 1fr 5em;
+    grid-template-areas: "date actions" "title title";
+    row-gap: 0.15rem;
+  }
+  .cd-project-meeting-date    { grid-area: date; }
+  .cd-project-meeting-title   { grid-area: title; }
+  .cd-project-meeting-actions { grid-area: actions; }
+}

--- a/static/command_deck_nav.js
+++ b/static/command_deck_nav.js
@@ -12,7 +12,11 @@
 	'use strict';
 
 	var path = window.location.pathname;
-	var menuRoutes = ['/command-deck/reports', '/command-deck/templates'];
+	var menuRoutes = [
+		'/command-deck/reports',
+		'/command-deck/templates',
+		'/command-deck/meetings',
+	];
 	var underMenu = menuRoutes.some(function (r) { return path.indexOf(r) === 0; });
 
 	if (underMenu) {

--- a/static/command_deck_reports.js
+++ b/static/command_deck_reports.js
@@ -343,6 +343,12 @@
 					? `Checklist: ${escapeHtml(e.block_title)}`
 					: 'Checklist';
 			}
+			else if (e.meeting_id) {
+				// Phase 5: meeting-scoped entry.
+				context = e.meeting_title
+					? `meeting: ${escapeHtml(e.meeting_title)}`
+					: 'meeting';
+			}
 			const runningCls = e.running ? ' is-running' : '';
 			const runningGlyph = e.running ? ' <span class="cd-reports-running-dot" title="still running"></span>' : '';
 			// Click-to-edit on stopped entries; running entries stay static.

--- a/static/time_tracker_panel.js
+++ b/static/time_tracker_panel.js
@@ -157,6 +157,13 @@
 								: 'Checklist';
 							ctxLine = '<span class="ttp-row-ctx">' + blockLabel + '</span>';
 						}
+						else if (e.meeting_id) {
+							// Phase 5: meeting-scoped entry.
+							var mLabel = e.meeting_title
+								? 'meeting · ' + escHtml(e.meeting_title)
+								: 'meeting';
+							ctxLine = '<span class="ttp-row-ctx">' + mLabel + '</span>';
+						}
 						var descNode = isEditing
 							? '<input class="ttp-row-desc-input" data-id="' + e.id + '" value="' + escHtml(desc) + '">'
 							: '<span class="ttp-row-desc" data-id="' + e.id + '">' + escHtml(desc) + '</span>';

--- a/templates/command_deck_area.html
+++ b/templates/command_deck_area.html
@@ -35,6 +35,7 @@
         <div class="cd-nav-more-menu">
           <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
           <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+          <a href="/command-deck/meetings/" class="cd-nav-link">MEETINGS</a>
         </div>
       </details>
       <span class="cd-nav-sep">·</span>

--- a/templates/command_deck_dashboard.html
+++ b/templates/command_deck_dashboard.html
@@ -32,6 +32,7 @@
         <div class="cd-nav-more-menu">
           <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
           <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+          <a href="/command-deck/meetings/" class="cd-nav-link">MEETINGS</a>
         </div>
       </details>
       <span class="cd-nav-sep">·</span>

--- a/templates/command_deck_meeting.html
+++ b/templates/command_deck_meeting.html
@@ -1,0 +1,615 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <title>{{ meeting.title }} · Meeting · Command Deck</title>
+  <link rel="stylesheet" href="/static/command_deck.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/9.1.6/marked.min.js"></script>
+</head>
+<body class="command-deck">
+<div class="cd-shell">
+
+  <!-- HEADER -->
+  <header class="cd-header">
+    <div class="cd-header-left">
+      <a href="/command-deck/" class="cd-wordmark">COMMAND DECK</a>
+      <span class="cd-ident">MEETING · LOG</span>
+    </div>
+    <nav class="cd-header-nav">
+      <a href="/command-deck/" class="cd-nav-link">BRIDGE</a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/command-deck/projects/" class="cd-nav-link">PROJECTS</a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/below-deck" class="cd-nav-link">
+        BELOW DECK
+        <span class="cd-bd-badge" id="bdBadge"></span>
+      </a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/today/" class="cd-nav-link">TODAY</a>
+      <span class="cd-nav-sep">·</span>
+      <details class="cd-nav-more">
+        <summary class="cd-nav-link cd-nav-more-trigger">MORE ▾</summary>
+        <div class="cd-nav-more-menu">
+          <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
+          <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+          <a href="/command-deck/meetings/" class="cd-nav-link">MEETINGS</a>
+        </div>
+      </details>
+      <span class="cd-nav-sep">·</span>
+      <a href="/publish" class="cd-nav-link">COCKPIT</a>
+    </nav>
+  </header>
+
+  {% include 'includes/today_panel.html' %}
+  {% include 'includes/active_timer_strip.html' %}
+
+  <!-- MAIN -->
+  <div class="cd-main full-width">
+
+    <!-- BREADCRUMB -->
+    <div class="cd-breadcrumb">
+      <a href="/command-deck/meetings/">Meetings</a>
+      <span class="cd-breadcrumb-sep">›</span>
+      <span class="cd-breadcrumb-tail">{{ meeting.title }}</span>
+      <span class="cd-breadcrumb-actions">
+        <button class="cd-btn ghost sm" id="meetingDeleteBtn" type="button">DELETE</button>
+      </span>
+    </div>
+
+    <!-- HEADER PANEL -->
+    <section class="cd-meeting-header">
+      <h1 class="cd-page-title cd-meeting-title-edit"
+          contenteditable="true"
+          data-original="{{ meeting.title }}">{{ meeting.title }}</h1>
+
+      <div class="cd-meeting-meta">
+        <div class="cd-meeting-meta-row">
+          <span class="cd-meeting-meta-label">When</span>
+          <input type="datetime-local"
+                 class="cd-meeting-date-input"
+                 id="meetingDateInput"
+                 data-iso="{{ meeting.meeting_date }}">
+          <span class="cd-meeting-date-display" id="meetingDateDisplay" data-iso="{{ meeting.meeting_date }}"></span>
+        </div>
+        <div class="cd-meeting-meta-row">
+          <span class="cd-meeting-meta-label">Project</span>
+          <select class="cd-meeting-project-select" id="meetingProjectSelect">
+            <option value="">— standalone —</option>
+            {% for p in projects %}
+              <option value="{{ p.id }}" {% if meeting.project_id == p.id %}selected{% endif %}>{{ p.title }}</option>
+            {% endfor %}
+          </select>
+          {% if meeting.project_slug %}
+            <a class="cd-meeting-project-link" href="/command-deck/projects/{{ meeting.project_slug }}/">open project →</a>
+          {% endif %}
+        </div>
+
+        {% if meeting.project_id and meeting.project_tracking_enabled %}
+          <div class="cd-meeting-meta-row cd-meeting-tt-row">
+            <span class="cd-meeting-meta-label">Time</span>
+            <button class="cd-tt-row-btn cd-tt-meeting-btn"
+                    id="meetingTimerBtn"
+                    data-tt-meeting-id="{{ meeting.id }}"
+                    data-tt-text="{{ meeting.title }}"
+                    data-tt-project-id="{{ meeting.project_id }}"
+                    title="Start timer on this meeting"
+                    type="button">⏱</button>
+            <span class="cd-tt-today-tag" id="meetingTodayTag" hidden></span>
+            <span class="cd-tt-lifetime-tag" id="meetingLifetimeTag"
+                  {% if not lifetime_seconds %}hidden{% endif %}
+                  data-seconds="{{ lifetime_seconds }}">
+              {% if lifetime_seconds %}lifetime: <span id="meetingLifetimeText"></span>{% endif %}
+            </span>
+          </div>
+        {% elif not meeting.project_id %}
+          <div class="cd-meeting-meta-row cd-meeting-meta-hint">
+            <span class="cd-meeting-meta-label"></span>
+            <span class="cd-meeting-meta-note">Standalone meetings can't be timed — assign a project to enable ⏱.</span>
+          </div>
+        {% endif %}
+      </div>
+    </section>
+
+    <!-- NOTES -->
+    <section class="cd-panel cd-mb">
+      <div class="cd-panel-header">
+        <span class="cd-panel-title">// Notes</span>
+        <span class="cd-panel-hint">click to edit · markdown</span>
+      </div>
+      <div class="cd-panel-body cd-meeting-notes-wrapper">
+        <div class="cd-note-rendered cd-meeting-notes-rendered" id="meetingNotesRendered"></div>
+        <div class="cd-note-editor cd-meeting-notes-editor" id="meetingNotesEditor" style="display:none;">
+          <textarea class="cd-note-textarea" id="meetingNotesTextarea" rows="8" placeholder="Notes (markdown)…">{{ meeting.notes or '' }}</textarea>
+        </div>
+      </div>
+    </section>
+
+    <!-- ACTION ITEMS -->
+    <section class="cd-panel cd-mb">
+      <div class="cd-panel-header">
+        <span class="cd-panel-title">// Action items</span>
+        <span class="cd-panel-count" id="actionItemCount">{{ action_items | length }}</span>
+      </div>
+      <div class="cd-panel-body">
+        <div class="cd-input-row cd-mb-sm">
+          <input type="text" class="cd-input" id="actionItemInput" placeholder="add an action item…">
+          <button class="cd-btn primary sm" id="actionItemAddBtn" type="button">ADD</button>
+        </div>
+        {% if action_items %}
+          <ul class="cd-task-list" id="actionItemList">
+            {% for task in action_items %}
+              <li class="cd-task-item" data-id="{{ task.id }}" data-task-title="{{ task.title }}">
+                <input type="checkbox" class="cd-task-check action-item-check" data-id="{{ task.id }}">
+                <span class="cd-task-title">{{ task.title }}</span>
+                <button class="cd-today-star{% if task.today %} starred{% endif %}"
+                        data-kind="task" data-id="{{ task.id }}"
+                        title="{% if task.today %}Remove from Today{% else %}Add to Today{% endif %}"
+                        type="button">{{ '★' if task.today else '☆' }}</button>
+                <button class="cd-task-edit" data-id="{{ task.id }}" title="Edit">✎</button>
+                <button class="cd-btn ghost sm action-item-delete" data-id="{{ task.id }}" type="button">✕</button>
+              </li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <div class="cd-empty" id="actionItemEmpty">No action items yet.</div>
+        {% endif %}
+      </div>
+    </section>
+
+  </div><!-- .cd-main -->
+
+  <!-- FOOTER -->
+  <footer class="cd-footer">
+    <div class="cd-footer-links">
+      <a href="/command-deck/" class="cd-footer-link">Bridge</a>
+      <a href="/command-deck/projects/" class="cd-footer-link">Projects</a>
+      <a href="/command-deck/meetings/" class="cd-footer-link">Meetings</a>
+    </div>
+    {% include 'includes/cd_footer_status.html' %}
+    <span class="cd-footer-ident">YT-1300F · COMMAND DECK · SECURE</span>
+  </footer>
+
+</div><!-- .cd-shell -->
+
+<script>
+const MEETING_ID = {{ meeting.id }};
+const MEETING_PROJECT_ID = {{ (meeting.project_id or 0) | tojson }};
+const MEETING_TRACKING = {{ ((meeting.project_tracking_enabled or 0)) | tojson }};
+const MEETING_LIFETIME_SECONDS = {{ lifetime_seconds | tojson }};
+
+(function () {
+  // Below-Deck badge
+  fetch('/below-deck/count').then(r=>r.json()).then(d=>{
+    var b=document.getElementById('bdBadge');
+    if(!b||d.count===0)return;
+    b.classList.add(d.count<=3?'green':d.count<=6?'amber':'red');
+  });
+
+  function escHtml(s) {
+    var d = document.createElement('div');
+    d.appendChild(document.createTextNode(s == null ? '' : String(s)));
+    return d.innerHTML;
+  }
+
+  function fmtElapsed(secs) {
+    if (window.TimeTrackerCore) return window.TimeTrackerCore.formatElapsed(secs);
+    secs = Math.max(0, Math.floor(secs || 0));
+    var h = Math.floor(secs / 3600), m = Math.floor((secs % 3600) / 60), s = secs % 60;
+    var pad = function (n) { return n < 10 ? '0' + n : '' + n; };
+    if (h > 0) return h + ':' + pad(m) + ':' + pad(s);
+    return m + ':' + pad(s);
+  }
+  function fmtHmm(secs) {
+    secs = Math.max(0, Math.floor(secs || 0));
+    if (!secs) return '';
+    var h = Math.floor(secs / 3600), m = Math.floor((secs % 3600) / 60);
+    if (h === 0 && m === 0) return '<1m';
+    return h + ':' + (m < 10 ? '0' + m : m);
+  }
+
+  // ---- TITLE inline edit ----
+  var titleEl = document.querySelector('.cd-meeting-title-edit');
+  function saveTitle() {
+    var v = (titleEl.textContent || '').trim();
+    if (!v) {
+      titleEl.textContent = titleEl.dataset.original;
+      return;
+    }
+    if (v === titleEl.dataset.original) return;
+    fetch('/command-deck/meetings/' + MEETING_ID + '/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify({ title: v })
+    }).then(r => r.json()).then(d => {
+      if (d.success) titleEl.dataset.original = v;
+    });
+  }
+  titleEl.addEventListener('blur', saveTitle);
+  titleEl.addEventListener('keydown', function (e) {
+    if (e.key === 'Enter') { e.preventDefault(); titleEl.blur(); }
+    if (e.key === 'Escape') {
+      titleEl.textContent = titleEl.dataset.original;
+      titleEl.blur();
+    }
+  });
+
+  // ---- DATE inline edit ----
+  var dateInput = document.getElementById('meetingDateInput');
+  var dateDisplay = document.getElementById('meetingDateDisplay');
+
+  function renderDateDisplay() {
+    var iso = dateDisplay.getAttribute('data-iso') || '';
+    if (!iso) { dateDisplay.textContent = '—'; return; }
+    var d = new Date(iso);
+    if (isNaN(d.getTime())) { dateDisplay.textContent = iso; return; }
+    var opts = { weekday: 'short', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' };
+    dateDisplay.textContent = d.toLocaleString(undefined, opts);
+  }
+  function isoToDatetimeLocal(iso) {
+    if (!iso) return '';
+    var d = new Date(iso);
+    if (isNaN(d.getTime())) return '';
+    var pad = function (n) { return n < 10 ? '0' + n : '' + n; };
+    return d.getFullYear() + '-' + pad(d.getMonth()+1) + '-' + pad(d.getDate())
+      + 'T' + pad(d.getHours()) + ':' + pad(d.getMinutes());
+  }
+  function datetimeLocalToIso(v) {
+    if (!v) return '';
+    var d = new Date(v);
+    if (isNaN(d.getTime())) return '';
+    var off = -d.getTimezoneOffset();
+    var sign = off >= 0 ? '+' : '-';
+    var abs = Math.abs(off);
+    var hh = String(Math.floor(abs / 60)).padStart(2, '0');
+    var mm = String(abs % 60).padStart(2, '0');
+    var pad = function (n) { return n < 10 ? '0' + n : '' + n; };
+    return d.getFullYear() + '-' + pad(d.getMonth()+1) + '-' + pad(d.getDate())
+      + 'T' + pad(d.getHours()) + ':' + pad(d.getMinutes()) + ':00'
+      + sign + hh + ':' + mm;
+  }
+  dateInput.value = isoToDatetimeLocal(dateInput.getAttribute('data-iso'));
+  renderDateDisplay();
+
+  dateDisplay.addEventListener('click', function () {
+    dateDisplay.style.display = 'none';
+    dateInput.style.display = 'inline-block';
+    dateInput.focus();
+    if (dateInput.showPicker) try { dateInput.showPicker(); } catch (_) {}
+  });
+  dateInput.addEventListener('change', function () {
+    var iso = datetimeLocalToIso(dateInput.value);
+    if (!iso) return;
+    fetch('/command-deck/meetings/' + MEETING_ID + '/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify({ meeting_date: iso })
+    }).then(r => r.json()).then(d => {
+      if (d.success) {
+        dateDisplay.setAttribute('data-iso', iso);
+        renderDateDisplay();
+        dateInput.style.display = 'none';
+        dateDisplay.style.display = 'inline-block';
+      }
+    });
+  });
+  dateInput.addEventListener('blur', function () {
+    dateInput.style.display = 'none';
+    dateDisplay.style.display = 'inline-block';
+  });
+
+  // ---- PROJECT reassign ----
+  var projectSelect = document.getElementById('meetingProjectSelect');
+  projectSelect.addEventListener('change', function () {
+    var v = projectSelect.value || '';
+    fetch('/command-deck/meetings/' + MEETING_ID + '/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify({ project_id: v || null })
+    }).then(function (r) { return r.json(); }).then(function (d) {
+      if (d.success) {
+        // Reload so the ⏱ row + breadcrumb chrome reflect the new project state.
+        window.location.reload();
+      }
+    });
+  });
+
+  // ---- NOTES click-to-edit (markdown) ----
+  var rendered = document.getElementById('meetingNotesRendered');
+  var editor = document.getElementById('meetingNotesEditor');
+  var textarea = document.getElementById('meetingNotesTextarea');
+
+  function renderNotes() {
+    var raw = textarea.value || '';
+    if (raw.trim()) rendered.innerHTML = marked.parse(raw);
+    else rendered.innerHTML = '<span class="cd-note-placeholder">Click to add notes (markdown supported)…</span>';
+    rendered.dataset.rawContent = raw;
+  }
+  renderNotes();
+
+  rendered.addEventListener('click', function () {
+    rendered.style.display = 'none';
+    editor.style.display = 'block';
+    textarea.focus();
+    textarea.selectionStart = textarea.selectionEnd = textarea.value.length;
+  });
+  var notesSaveTimer;
+  function saveNotes() {
+    fetch('/command-deck/meetings/' + MEETING_ID + '/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify({ notes: textarea.value })
+    });
+  }
+  textarea.addEventListener('input', function () {
+    clearTimeout(notesSaveTimer);
+    notesSaveTimer = setTimeout(saveNotes, 1500);
+  });
+  textarea.addEventListener('blur', function () {
+    clearTimeout(notesSaveTimer);
+    saveNotes();
+    renderNotes();
+    rendered.style.display = 'block';
+    editor.style.display = 'none';
+  });
+
+  // ---- DELETE ----
+  document.getElementById('meetingDeleteBtn').addEventListener('click', function () {
+    if (!confirm('Delete this meeting? Action items and time entries survive (orphaned).')) return;
+    fetch('/command-deck/meetings/' + MEETING_ID + '/delete', {
+      method: 'POST',
+      credentials: 'same-origin',
+    }).then(r => r.json()).then(d => {
+      if (d.success) window.location.href = '/command-deck/meetings/';
+    });
+  });
+
+  // ---- ACTION ITEMS ----
+  var input = document.getElementById('actionItemInput');
+  var addBtn = document.getElementById('actionItemAddBtn');
+  var list = document.getElementById('actionItemList');
+  var empty = document.getElementById('actionItemEmpty');
+  var countEl = document.getElementById('actionItemCount');
+
+  function setCount(n) { if (countEl) countEl.textContent = n; }
+  function actionRowHtml(task) {
+    return ''
+      + '<input type="checkbox" class="cd-task-check action-item-check" data-id="' + task.id + '">'
+      + '<span class="cd-task-title">' + escHtml(task.title) + '</span>'
+      + '<button class="cd-today-star" data-kind="task" data-id="' + task.id + '" type="button" title="Add to Today">☆</button>'
+      + '<button class="cd-task-edit" data-id="' + task.id + '" title="Edit">✎</button>'
+      + '<button class="cd-btn ghost sm action-item-delete" data-id="' + task.id + '" type="button">✕</button>';
+  }
+
+  function appendRow(task) {
+    if (!list) {
+      // First row — promote the empty placeholder into a list
+      var section = empty ? empty.parentElement : null;
+      if (empty) empty.remove();
+      list = document.createElement('ul');
+      list.className = 'cd-task-list';
+      list.id = 'actionItemList';
+      (section || document.querySelector('.cd-panel-body')).appendChild(list);
+    }
+    var li = document.createElement('li');
+    li.className = 'cd-task-item';
+    li.dataset.id = task.id;
+    li.dataset.taskTitle = task.title;
+    li.innerHTML = actionRowHtml(task);
+    list.appendChild(li);
+  }
+
+  function addItem() {
+    var v = (input.value || '').trim();
+    if (!v) return;
+    addBtn.disabled = true;
+    var fd = new FormData();
+    fd.append('title', v);
+    fetch('/command-deck/meetings/' + MEETING_ID + '/action-items/add', {
+      method: 'POST',
+      credentials: 'same-origin',
+      body: fd,
+    }).then(r => r.json()).then(d => {
+      if (d.success) {
+        appendRow(d.task);
+        input.value = '';
+        setCount((list ? list.children.length : 0));
+      }
+    }).finally(function () { addBtn.disabled = false; input.focus(); });
+  }
+
+  if (addBtn) addBtn.addEventListener('click', addItem);
+  if (input) input.addEventListener('keydown', function (e) {
+    if (e.key === 'Enter') { e.preventDefault(); addItem(); }
+  });
+
+  // Inline complete + delete + ★ Today + ✎ edit
+  document.addEventListener('click', function (ev) {
+    var t = ev.target;
+    if (t.classList.contains('action-item-delete')) {
+      var id = t.getAttribute('data-id');
+      if (!confirm('Delete this action item?')) return;
+      fetch('/tasks/delete', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: 'id=' + encodeURIComponent(id),
+      }).then(r => r.json()).then(d => {
+        if (d.ok) {
+          var li = t.closest('.cd-task-item');
+          if (li) li.remove();
+          if (list && !list.children.length) {
+            list.remove(); list = null;
+            empty = document.createElement('div');
+            empty.id = 'actionItemEmpty';
+            empty.className = 'cd-empty';
+            empty.textContent = 'No action items yet.';
+            document.querySelector('.cd-panel-body').appendChild(empty);
+          }
+          setCount(list ? list.children.length : 0);
+        }
+      });
+      return;
+    }
+    if (t.classList.contains('cd-today-star') && t.dataset.kind === 'task') {
+      var id = t.getAttribute('data-id');
+      var starred = t.classList.contains('starred');
+      fetch('/today/toggle', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: 'kind=task&id=' + encodeURIComponent(id) + '&value=' + (starred ? '0' : '1'),
+      }).then(r => r.json()).then(d => {
+        if (d.success) {
+          t.classList.toggle('starred');
+          t.textContent = t.classList.contains('starred') ? '★' : '☆';
+        }
+      });
+      return;
+    }
+    if (t.classList.contains('cd-task-edit')) {
+      var id = t.getAttribute('data-id');
+      var li = t.closest('.cd-task-item');
+      var span = li ? li.querySelector('.cd-task-title') : null;
+      if (!span) return;
+      var current = span.textContent;
+      var next = prompt('Edit action item:', current);
+      if (next === null) return;
+      next = next.trim();
+      if (!next || next === current) return;
+      var fd = new FormData();
+      fd.append('title', next);
+      fetch('/tasks/' + id + '/edit', {
+        method: 'POST', credentials: 'same-origin', body: fd,
+      }).then(r => r.json()).then(d => {
+        if (d.success) span.textContent = next;
+      });
+      return;
+    }
+  });
+
+  document.addEventListener('change', function (ev) {
+    var t = ev.target;
+    if (t.classList.contains('action-item-check')) {
+      var id = t.getAttribute('data-id');
+      if (!t.checked) return;
+      fetch('/tasks/complete', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: 'id=' + encodeURIComponent(id),
+      }).then(r => r.json()).then(d => {
+        if (d.ok) {
+          var li = t.closest('.cd-task-item');
+          if (li) li.remove();
+          if (list && !list.children.length) {
+            list.remove(); list = null;
+            empty = document.createElement('div');
+            empty.id = 'actionItemEmpty';
+            empty.className = 'cd-empty';
+            empty.textContent = 'No action items yet.';
+            document.querySelector('.cd-panel-body').appendChild(empty);
+          }
+          setCount(list ? list.children.length : 0);
+        }
+      });
+    }
+  });
+
+  // ---- ⏱ TIMER button + lifetime ----
+  function fmtLifetime() {
+    var el = document.getElementById('meetingLifetimeText');
+    if (el) el.textContent = fmtHmm(MEETING_LIFETIME_SECONDS);
+  }
+  fmtLifetime();
+
+  var timerBtn = document.getElementById('meetingTimerBtn');
+  if (timerBtn) {
+    function startMeetingTimer() {
+      var body = {
+        project_id: parseInt(timerBtn.getAttribute('data-tt-project-id'), 10),
+        meeting_id: MEETING_ID,
+        description: timerBtn.getAttribute('data-tt-text') || '',
+      };
+      return fetch('/time/start', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify(body),
+      }).then(function (r) {
+        return r.json().then(function (d) {
+          if (r.ok && window.TimeTrackerCore) window.TimeTrackerCore.refresh();
+          else if (r.status === 409) alert('Already tracking this project.');
+          else if (!r.ok) alert(d.error || 'Could not start timer.');
+        });
+      });
+    }
+    timerBtn.addEventListener('click', function () {
+      if (timerBtn.dataset.running === '1' && timerBtn.dataset.entryId) {
+        if (window.TimeTrackerCore) window.TimeTrackerCore.stopTimer(timerBtn.dataset.entryId);
+        return;
+      }
+      startMeetingTimer();
+    });
+
+    // Keep the button label in sync with the active timer state.
+    function syncMeetingButton(entries) {
+      timerBtn.dataset.running = '0';
+      timerBtn.dataset.entryId = '';
+      timerBtn.textContent = '⏱';
+      timerBtn.title = 'Start timer on this meeting';
+      (entries || []).forEach(function (e) {
+        if (String(e.meeting_id || '') === String(MEETING_ID)) {
+          timerBtn.dataset.running = '1';
+          timerBtn.dataset.entryId = e.id;
+          timerBtn.textContent = '■ ' + fmtElapsed(window.TimeTrackerCore ? window.TimeTrackerCore.elapsedSeconds(e) : 0);
+          timerBtn.title = 'Stop timer';
+        }
+      });
+    }
+    if (window.TimeTrackerCore) {
+      window.TimeTrackerCore.subscribe(syncMeetingButton);
+      // Re-render button text every second while running so the elapsed counter ticks.
+      setInterval(function () {
+        if (window.TimeTrackerCore) syncMeetingButton(window.TimeTrackerCore.current());
+      }, 1000);
+    }
+
+    // Today-tag totals on the meeting row — sum entries on this project today
+    // that target this meeting_id.
+    function syncTodayTag() {
+      if (!MEETING_PROJECT_ID) return;
+      fetch('/time/today/' + MEETING_PROJECT_ID, { credentials: 'same-origin' })
+        .then(function (r) { return r.ok ? r.json() : { entries: [] }; })
+        .then(function (data) {
+          var sum = 0;
+          (data.entries || []).forEach(function (e) {
+            if (String(e.meeting_id || '') !== String(MEETING_ID)) return;
+            var dur = e.duration_seconds != null
+              ? e.duration_seconds
+              : Math.floor((Date.now() - new Date(e.started_at).getTime()) / 1000);
+            sum += Math.max(0, dur);
+          });
+          var tag = document.getElementById('meetingTodayTag');
+          if (!tag) return;
+          if (sum > 0) {
+            tag.hidden = false;
+            tag.textContent = 'today: ' + fmtHmm(sum);
+          } else {
+            tag.hidden = true;
+            tag.textContent = '';
+          }
+        });
+    }
+    syncTodayTag();
+    setInterval(syncTodayTag, 30000);
+  }
+})();
+</script>
+<script src="/static/command_deck_nav.js"></script>
+</body>
+</html>

--- a/templates/command_deck_meetings.html
+++ b/templates/command_deck_meetings.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <title>Meetings · Command Deck</title>
+  <link rel="stylesheet" href="/static/command_deck.css">
+</head>
+<body class="command-deck">
+<div class="cd-shell">
+
+  <!-- HEADER -->
+  <header class="cd-header">
+    <div class="cd-header-left">
+      <a href="/command-deck/" class="cd-wordmark">COMMAND DECK</a>
+      <span class="cd-ident">MEETINGS · ARCHIVE</span>
+    </div>
+    <nav class="cd-header-nav">
+      <a href="/command-deck/" class="cd-nav-link">BRIDGE</a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/command-deck/projects/" class="cd-nav-link">PROJECTS</a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/below-deck" class="cd-nav-link">
+        BELOW DECK
+        <span class="cd-bd-badge" id="bdBadge"></span>
+      </a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/today/" class="cd-nav-link">TODAY</a>
+      <span class="cd-nav-sep">·</span>
+      <details class="cd-nav-more">
+        <summary class="cd-nav-link cd-nav-more-trigger">MORE ▾</summary>
+        <div class="cd-nav-more-menu">
+          <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
+          <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+          <a href="/command-deck/meetings/" class="cd-nav-link">MEETINGS</a>
+        </div>
+      </details>
+      <span class="cd-nav-sep">·</span>
+      <a href="/publish" class="cd-nav-link">COCKPIT</a>
+    </nav>
+  </header>
+
+  {% include 'includes/today_panel.html' %}
+  {% include 'includes/active_timer_strip.html' %}
+
+  <!-- MAIN -->
+  <div class="cd-main full-width">
+
+    <section class="cd-meetings-controls">
+      <div class="cd-meetings-title-row">
+        <h1 class="cd-page-title">// Meetings</h1>
+        {% if project_filter %}
+          <span class="cd-meetings-filter-pill">
+            scoped to <a href="/command-deck/projects/{{ project_filter.slug }}/">{{ project_filter.title }}</a>
+            <a class="cd-meetings-filter-clear" href="/command-deck/meetings/" title="Clear filter">×</a>
+          </span>
+        {% endif %}
+      </div>
+      <div class="cd-meetings-actions">
+        <button class="cd-btn primary" id="newMeetingBtn">+ NEW MEETING</button>
+      </div>
+    </section>
+
+    {% if meetings %}
+      {% set ns = namespace(current_month='') %}
+      <section class="cd-meetings-list">
+        {% for m in meetings %}
+          {% set month_label = m.meeting_date[:7] %}
+          {% if month_label != ns.current_month %}
+            {% if not loop.first %}</ul>{% endif %}
+            <h2 class="cd-meetings-month">// {{ month_label }}</h2>
+            <ul class="cd-meetings-rows">
+            {% set ns.current_month = month_label %}
+          {% endif %}
+          <li class="cd-meeting-row">
+            <a class="cd-meeting-row-link" href="/command-deck/meetings/{{ m.id }}/">
+              <span class="cd-meeting-row-date" data-iso="{{ m.meeting_date }}">{{ m.meeting_date[:16] }}</span>
+              <span class="cd-meeting-row-title">{{ m.title }}</span>
+              <span class="cd-meeting-row-project">
+                {% if m.project_title %}{{ m.project_title }}{% else %}<em>standalone</em>{% endif %}
+              </span>
+              <span class="cd-meeting-row-actions">
+                {{ m.action_count }} action{{ '' if m.action_count == 1 else 's' }}
+              </span>
+            </a>
+          </li>
+          {% if loop.last %}</ul>{% endif %}
+        {% endfor %}
+      </section>
+    {% else %}
+      <div class="cd-meetings-empty">
+        {% if project_filter %}
+          No meetings yet for {{ project_filter.title }}. Start one with + NEW MEETING.
+        {% else %}
+          No meetings yet. Start one with + NEW MEETING.
+        {% endif %}
+      </div>
+    {% endif %}
+
+  </div><!-- .cd-main -->
+
+  <!-- NEW MEETING MODAL -->
+  <div class="cd-modal-overlay" id="newMeetingModal">
+    <div class="cd-modal">
+      <div class="cd-modal-title">// New Meeting</div>
+      <form method="POST" action="/command-deck/meetings/new" id="newMeetingForm">
+        <label class="cd-label">
+          <span>Title</span>
+          <input type="text" class="cd-input" name="title" required>
+        </label>
+        <label class="cd-label">
+          <span>When</span>
+          <input type="datetime-local" class="cd-input" name="meeting_date" id="newMeetingDate">
+        </label>
+        <label class="cd-label">
+          <span>Project (optional)</span>
+          <select class="cd-input" name="project_id" id="newMeetingProject">
+            <option value="">— standalone —</option>
+            {# Project options injected by JS once /time/projects loads #}
+          </select>
+        </label>
+        <label class="cd-label">
+          <span>Notes (optional, markdown)</span>
+          <textarea class="cd-input" name="notes" rows="4"></textarea>
+        </label>
+        <div class="cd-modal-actions">
+          <button type="button" class="cd-btn ghost" id="newMeetingCancelBtn">CANCEL</button>
+          <button type="submit" class="cd-btn primary">CREATE</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <!-- FOOTER -->
+  <footer class="cd-footer">
+    <div class="cd-footer-links">
+      <a href="/command-deck/" class="cd-footer-link">Bridge</a>
+      <a href="/command-deck/projects/" class="cd-footer-link">Projects</a>
+      <a href="/publish" class="cd-footer-link">Cockpit</a>
+    </div>
+    {% include 'includes/cd_footer_status.html' %}
+    <span class="cd-footer-ident">YT-1300F · COMMAND DECK · SECURE</span>
+  </footer>
+
+</div><!-- .cd-shell -->
+
+<script>
+(function () {
+  // Below-Deck badge
+  fetch('/below-deck/count').then(r=>r.json()).then(d=>{
+    var b=document.getElementById('bdBadge');
+    if(!b||d.count===0)return;
+    b.classList.add(d.count<=3?'green':d.count<=6?'amber':'red');
+  });
+
+  // Pretty-print row dates from raw ET-local ISO into "Tue May 5, 2:00 PM"
+  document.querySelectorAll('.cd-meeting-row-date').forEach(function (el) {
+    var iso = el.getAttribute('data-iso');
+    if (!iso) return;
+    var d = new Date(iso);
+    if (isNaN(d.getTime())) return;
+    var opts = { weekday: 'short', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' };
+    el.textContent = d.toLocaleString(undefined, opts);
+  });
+
+  // ---- NEW MEETING MODAL ----
+  var modal = document.getElementById('newMeetingModal');
+  var openBtn = document.getElementById('newMeetingBtn');
+  var cancelBtn = document.getElementById('newMeetingCancelBtn');
+  var dateInput = document.getElementById('newMeetingDate');
+  var projectSelect = document.getElementById('newMeetingProject');
+
+  function openModal() {
+    modal.classList.add('open');
+    if (!dateInput.value) {
+      var now = new Date();
+      var pad = function (n) { return n < 10 ? '0' + n : '' + n; };
+      dateInput.value = now.getFullYear() + '-' + pad(now.getMonth()+1) + '-' + pad(now.getDate())
+        + 'T' + pad(now.getHours()) + ':' + pad(now.getMinutes());
+    }
+    var input = modal.querySelector('input[name="title"]');
+    if (input) input.focus();
+  }
+  function closeModal() { modal.classList.remove('open'); }
+
+  openBtn.addEventListener('click', openModal);
+  cancelBtn.addEventListener('click', closeModal);
+  modal.addEventListener('click', function (e) {
+    if (e.target === modal) closeModal();
+  });
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && modal.classList.contains('open')) closeModal();
+  });
+
+  // Pre-select project_id from query string (?project=<slug> doesn't carry id;
+  // but the index also accepts ?project=<id> as a hint for the modal default.)
+  var qs = new URLSearchParams(window.location.search);
+  var defaultProjectId = qs.get('default_project_id');
+
+  // Lazy-fill the project dropdown from /time/projects (same source as the
+  // floating timer picker — keeps the UX consistent and avoids server-side
+  // scope/privacy gymnastics here).
+  fetch('/time/projects', { credentials: 'same-origin' })
+    .then(function (r) { return r.ok ? r.json() : null; })
+    .then(function (data) {
+      if (!data) return;
+      var frag = document.createDocumentFragment();
+      (data.areas || []).forEach(function (a) {
+        var grp = document.createElement('optgroup');
+        grp.label = a.title;
+        (a.subprojects || []).forEach(function (s) {
+          var opt = document.createElement('option');
+          opt.value = s.id;
+          opt.textContent = s.title;
+          if (defaultProjectId && String(s.id) === defaultProjectId) opt.selected = true;
+          grp.appendChild(opt);
+        });
+        if (grp.children.length) frag.appendChild(grp);
+      });
+      if ((data.personal || []).length) {
+        var grp = document.createElement('optgroup');
+        grp.label = 'Personal';
+        data.personal.forEach(function (p) {
+          var opt = document.createElement('option');
+          opt.value = p.id;
+          opt.textContent = p.title;
+          if (defaultProjectId && String(p.id) === defaultProjectId) opt.selected = true;
+          grp.appendChild(opt);
+        });
+        frag.appendChild(grp);
+      }
+      projectSelect.appendChild(frag);
+    });
+
+  // Convert datetime-local (no offset) → ISO with the user's UTC offset
+  // so the server sees a real ET-local-with-offset string. Browsers send
+  // datetime-local as 'YYYY-MM-DDTHH:MM' with no tz; pad it to ISO.
+  document.getElementById('newMeetingForm').addEventListener('submit', function (ev) {
+    var v = dateInput.value;
+    if (v && v.length >= 16 && !v.includes('+') && !v.endsWith('Z')) {
+      var d = new Date(v);
+      if (!isNaN(d.getTime())) {
+        var off = -d.getTimezoneOffset();
+        var sign = off >= 0 ? '+' : '-';
+        var abs = Math.abs(off);
+        var hh = String(Math.floor(abs / 60)).padStart(2, '0');
+        var mm = String(abs % 60).padStart(2, '0');
+        var pad = function (n) { return n < 10 ? '0' + n : '' + n; };
+        var iso = d.getFullYear() + '-' + pad(d.getMonth()+1) + '-' + pad(d.getDate())
+          + 'T' + pad(d.getHours()) + ':' + pad(d.getMinutes()) + ':00'
+          + sign + hh + ':' + mm;
+        dateInput.value = iso;
+      }
+    }
+  });
+})();
+</script>
+<script src="/static/command_deck_nav.js"></script>
+</body>
+</html>

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -2133,6 +2133,14 @@ function cdEditTask(id) {
             ? 'Checklist: ' + escHtml(e.block_title)
             : 'Checklist';
           contextBadge = '<' + triggerTag + ' class="' + triggerCls + ' item"' + triggerAttrs + '>[' + blockLabel + ']' + (isRunning ? '' : ' ▾') + '</' + triggerTag + '>';
+        } else if (e.meeting_id) {
+          // Phase 5: meeting-scoped entry. Static badge — re-assigning a meeting-
+          // scoped entry to a different meeting/task/item is out of v1 scope
+          // (delete + recreate as needed).
+          const mLabel = e.meeting_title
+            ? 'meeting: ' + escHtml(e.meeting_title)
+            : 'meeting';
+          contextBadge = '<span class="cd-tt-entry-context meeting">[' + mLabel + ']</span>';
         } else if (!isRunning) {
           contextBadge = '<button type="button" class="cd-tt-entry-context cd-tt-assign-trigger unassigned" data-entry-id="' + e.id + '">[+ assign ▾]</button>';
         } else {

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -263,6 +263,36 @@
         </div>
       </div>
 
+      <!-- MEETINGS -->
+      <div class="cd-panel cd-mb">
+        <div class="cd-panel-header">
+          <span class="cd-panel-title">// Meetings</span>
+          <div class="cd-panel-actions">
+            {% if meetings_total and meetings_total > (meetings_recent | length) %}
+              <a href="/command-deck/meetings/?project={{ project.slug }}" class="cd-btn ghost sm">VIEW ALL ({{ meetings_total }})</a>
+            {% endif %}
+            <button class="cd-btn primary sm" id="newMeetingBtn" type="button">+ NEW</button>
+          </div>
+        </div>
+        <div class="cd-panel-body">
+          {% if meetings_recent %}
+            <ul class="cd-project-meetings-list" id="projectMeetingsList">
+              {% for m in meetings_recent %}
+                <li class="cd-project-meeting-row" data-meeting-id="{{ m.id }}">
+                  <a class="cd-project-meeting-link" href="/command-deck/meetings/{{ m.id }}/">
+                    <span class="cd-project-meeting-date" data-iso="{{ m.meeting_date }}">{{ m.meeting_date[:16] }}</span>
+                    <span class="cd-project-meeting-title">{{ m.title }}</span>
+                    <span class="cd-project-meeting-actions">{{ m.action_count }} action{{ '' if m.action_count == 1 else 's' }}</span>
+                  </a>
+                </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <div class="cd-empty" id="projectMeetingsEmpty">No meetings yet for this project.</div>
+          {% endif %}
+        </div>
+      </div>
+
       <!-- FILES -->
       <div class="cd-panel cd-mb">
         <div class="cd-panel-header">
@@ -461,6 +491,32 @@
       <button class="cd-btn ghost" id="editCancelBtn">CANCEL</button>
       <button class="cd-btn primary" id="editConfirmBtn">SAVE</button>
     </div>
+  </div>
+</div>
+
+<!-- NEW MEETING MODAL (Phase 5) -->
+<div class="cd-modal-overlay" id="projectNewMeetingModal">
+  <div class="cd-modal">
+    <div class="cd-modal-title">// New Meeting</div>
+    <form method="POST" action="/command-deck/meetings/new" id="projectNewMeetingForm">
+      <input type="hidden" name="project_id" value="{{ project.id }}">
+      <label class="cd-label">
+        <span>Title</span>
+        <input type="text" class="cd-input" name="title" required>
+      </label>
+      <label class="cd-label">
+        <span>When</span>
+        <input type="datetime-local" class="cd-input" name="meeting_date" id="projectNewMeetingDate">
+      </label>
+      <label class="cd-label">
+        <span>Notes (optional, markdown)</span>
+        <textarea class="cd-input" name="notes" rows="4"></textarea>
+      </label>
+      <div class="cd-modal-actions">
+        <button type="button" class="cd-btn ghost" id="projectNewMeetingCancelBtn">CANCEL</button>
+        <button type="submit" class="cd-btn primary">CREATE</button>
+      </div>
+    </form>
   </div>
 </div>
 
@@ -2577,6 +2633,66 @@ function cdEditTask(id) {
         btn.textContent = wasStarred ? '★' : '☆';
         btn.title = wasStarred ? 'Remove from Today' : 'Add to Today';
       });
+  });
+})();
+
+// ============================================================
+// MEETINGS — pretty-print row dates + new-meeting modal (Phase 5)
+// ============================================================
+(function () {
+  document.querySelectorAll('.cd-project-meeting-date').forEach(function (el) {
+    var iso = el.getAttribute('data-iso');
+    if (!iso) return;
+    var d = new Date(iso);
+    if (isNaN(d.getTime())) return;
+    el.textContent = d.toLocaleString(undefined, {
+      weekday: 'short', month: 'short', day: 'numeric',
+      hour: 'numeric', minute: '2-digit',
+    });
+  });
+
+  var modal = document.getElementById('projectNewMeetingModal');
+  var openBtn = document.getElementById('newMeetingBtn');
+  var cancelBtn = document.getElementById('projectNewMeetingCancelBtn');
+  var dateInput = document.getElementById('projectNewMeetingDate');
+  var form = document.getElementById('projectNewMeetingForm');
+  if (!modal || !openBtn) return;
+
+  function openModal() {
+    modal.classList.add('open');
+    if (!dateInput.value) {
+      var now = new Date();
+      var pad = function (n) { return n < 10 ? '0' + n : '' + n; };
+      dateInput.value = now.getFullYear() + '-' + pad(now.getMonth()+1) + '-' + pad(now.getDate())
+        + 'T' + pad(now.getHours()) + ':' + pad(now.getMinutes());
+    }
+    var input = modal.querySelector('input[name="title"]');
+    if (input) input.focus();
+  }
+  function closeModal() { modal.classList.remove('open'); }
+  openBtn.addEventListener('click', openModal);
+  cancelBtn.addEventListener('click', closeModal);
+  modal.addEventListener('click', function (e) { if (e.target === modal) closeModal(); });
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && modal.classList.contains('open')) closeModal();
+  });
+
+  form.addEventListener('submit', function () {
+    var v = dateInput.value;
+    if (v && v.length >= 16 && !v.includes('+') && !v.endsWith('Z')) {
+      var d = new Date(v);
+      if (!isNaN(d.getTime())) {
+        var off = -d.getTimezoneOffset();
+        var sign = off >= 0 ? '+' : '-';
+        var abs = Math.abs(off);
+        var hh = String(Math.floor(abs / 60)).padStart(2, '0');
+        var mm = String(abs % 60).padStart(2, '0');
+        var pad = function (n) { return n < 10 ? '0' + n : '' + n; };
+        dateInput.value = d.getFullYear() + '-' + pad(d.getMonth()+1) + '-' + pad(d.getDate())
+          + 'T' + pad(d.getHours()) + ':' + pad(d.getMinutes()) + ':00'
+          + sign + hh + ':' + mm;
+      }
+    }
   });
 })();
 </script>

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -34,6 +34,7 @@
         <div class="cd-nav-more-menu">
           <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
           <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+          <a href="/command-deck/meetings/" class="cd-nav-link">MEETINGS</a>
         </div>
       </details>
       <span class="cd-nav-sep">·</span>

--- a/templates/command_deck_projects.html
+++ b/templates/command_deck_projects.html
@@ -32,6 +32,7 @@
         <div class="cd-nav-more-menu">
           <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
           <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+          <a href="/command-deck/meetings/" class="cd-nav-link">MEETINGS</a>
         </div>
       </details>
       <span class="cd-nav-sep">·</span>

--- a/templates/command_deck_reports.html
+++ b/templates/command_deck_reports.html
@@ -32,6 +32,7 @@
         <div class="cd-nav-more-menu">
           <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
           <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+          <a href="/command-deck/meetings/" class="cd-nav-link">MEETINGS</a>
         </div>
       </details>
       <span class="cd-nav-sep">·</span>

--- a/templates/command_deck_templates.html
+++ b/templates/command_deck_templates.html
@@ -32,6 +32,7 @@
         <div class="cd-nav-more-menu">
           <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
           <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+          <a href="/command-deck/meetings/" class="cd-nav-link">MEETINGS</a>
         </div>
       </details>
       <span class="cd-nav-sep">·</span>

--- a/templates/includes/active_timer_strip.html
+++ b/templates/includes/active_timer_strip.html
@@ -260,6 +260,13 @@
           : 'Checklist';
         ctx = '<span class="tt-row-ctx">[' + blockLabel + ']</span>';
       }
+      else if (e.meeting_id) {
+        // Phase 5: meeting-scoped entry.
+        var mLabel = e.meeting_title
+          ? 'meeting: ' + escHtml(e.meeting_title)
+          : 'meeting';
+        ctx = '<span class="tt-row-ctx">[' + mLabel + ']</span>';
+      }
       return '<div class="tt-row" data-id="' + e.id + '">' +
         '<span class="tt-row-dot" style="background:' + color + ';"></span>' +
         '<span class="tt-row-area">' + escHtml(areaName) + '</span>' +

--- a/templates/today.html
+++ b/templates/today.html
@@ -32,6 +32,7 @@
         <div class="cd-nav-more-menu">
           <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
           <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+          <a href="/command-deck/meetings/" class="cd-nav-link">MEETINGS</a>
         </div>
       </details>
       <span class="cd-nav-sep">·</span>


### PR DESCRIPTION
## Summary

Six commits, ~2k lines. Meeting tracker as a first-class Command Deck domain — meetings link to projects (or stand alone), action items spawn as real `tasks` rows with provenance, and timers can be scoped to a meeting via the new `time_entries.meeting_id` column.

- **Schema** — new `meetings` table (id / project_id / title / meeting_date / notes / created / updated). Additive `tasks.meeting_id` and `time_entries.meeting_id`, both ON DELETE SET NULL. Four new partial indexes. Migration is idempotent.
- **Backend** — `blueprints/meetings.py` with CRUD + action-items add. `time_tracking` learns `meeting_id` with the same mutex + project-validation pattern that task_id and checklist_item_id already use. Serializers + reports query JOIN meetings(title).
- **Frontend** — index page (chronological, grouped by month, + NEW MEETING modal), detail page (contenteditable title, click-to-reveal datetime, project reassign, marked.js notes, action items, ⏱ button on tracking-enabled projects, lifetime tag), MEETINGS in MORE ▾ across all 7 CD-styled pages, "// Meetings" section on project pages.
- **Surfaces** — `[meeting: <title>]` ctx renders in the active timer strip, floating panel, project today's-time list, and the reports entries table.
- **Huyang** — project mode loads the 20 most recent meetings (title + date + notes) into the system prompt. Search-work + area mode unchanged for v1.

Time-tracking-on-meeting was added pre-implementation per Aaron's call; the spec was originally going to defer it. Standalone meetings can't be timed (no project to scope to); UI hides the ⏱ button.

## Test plan

- [ ] Run `python migrate_add_meetings.py` on PA — expect 7 added (table + 2 columns + 4 indexes); re-run shows "no changes."
- [ ] Open `/command-deck/meetings/` — empty state renders; + NEW MEETING modal opens with project picker hydrated from /time/projects.
- [ ] Create a meeting on a tracking-enabled project; detail page renders with ⏱ button.
- [ ] Add an action item — confirm it shows up on the project page's task list AND on the meeting detail page.
- [ ] Start a timer from the meeting page — active strip shows `[meeting: <title>]`; floating panel shows `meeting · <title>`; reports entries table column shows `meeting: <title>`; project page today list shows the meeting badge.
- [ ] Reassign the meeting to a different project — page reloads; ⏱ row updates; action-item tasks stay where they were (per spec decision #6).
- [ ] Delete a meeting — confirm tasks + time entries survive with `meeting_id` NULL.
- [ ] Open Huyang on a project that has meetings; ask "what did we discuss last meeting" — answer references the notes.
- [ ] Standalone meeting — confirm ⏱ row doesn't render and the "assign a project to enable ⏱" hint shows instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)