### PR TITLE
Phase 3: mileage tracker

### DIFF
--- a/app.py
+++ b/app.py
@@ -143,6 +143,7 @@ from blueprints.time_tracking import time_tracking_bp
 from blueprints.healthz import healthz_bp
 from blueprints.reports import reports_bp
 from blueprints.meetings import meetings_bp
+from blueprints.mileage import mileage_bp
 app.register_blueprint(tasks_bp)
 app.register_blueprint(today_bp)
 app.register_blueprint(below_deck_bp)
@@ -154,6 +155,7 @@ app.register_blueprint(time_tracking_bp)
 app.register_blueprint(healthz_bp)
 app.register_blueprint(reports_bp)
 app.register_blueprint(meetings_bp)
+app.register_blueprint(mileage_bp)
 
 
 if __name__ == "__main__": app.run(debug=True)

--- a/app.py
+++ b/app.py
@@ -144,6 +144,7 @@ from blueprints.healthz import healthz_bp
 from blueprints.reports import reports_bp
 from blueprints.meetings import meetings_bp
 from blueprints.mileage import mileage_bp
+from blueprints.settings import settings_bp
 app.register_blueprint(tasks_bp)
 app.register_blueprint(today_bp)
 app.register_blueprint(below_deck_bp)
@@ -156,6 +157,7 @@ app.register_blueprint(healthz_bp)
 app.register_blueprint(reports_bp)
 app.register_blueprint(meetings_bp)
 app.register_blueprint(mileage_bp)
+app.register_blueprint(settings_bp)
 
 
 if __name__ == "__main__": app.run(debug=True)

--- a/blueprints/command_deck.py
+++ b/blueprints/command_deck.py
@@ -618,6 +618,28 @@ def cd_project(slug):
 		'SELECT COUNT(*) AS n FROM meetings WHERE project_id = ?', (project['id'],)
 	).fetchone()['n']
 
+	# Phase 3 — mileage rollup for this project. Last 5 trips + totals so the
+	# project page can show a compact strip without paging through the full
+	# mileage index.
+	mileage_recent = conn.execute('''
+		SELECT id, date, description, from_location, to_location,
+		       round_trip, miles, rate_cents, submitted_at
+		FROM mileage_entries
+		WHERE project_id = ?
+		ORDER BY date DESC, id DESC
+		LIMIT 5
+	''', (project['id'],)).fetchall()
+	mileage_totals = conn.execute('''
+		SELECT
+		    COUNT(*)                                                                   AS count,
+		    COALESCE(SUM(miles), 0)                                                    AS miles,
+		    COALESCE(SUM(miles * rate_cents), 0)                                       AS cents,
+		    COALESCE(SUM(CASE WHEN submitted_at IS NULL THEN miles ELSE 0 END), 0)     AS unsubmitted_miles,
+		    COALESCE(SUM(CASE WHEN submitted_at IS NULL THEN miles * rate_cents ELSE 0 END), 0) AS unsubmitted_cents
+		FROM mileage_entries
+		WHERE project_id = ?
+	''', (project['id'],)).fetchone()
+
 	# Huyang chat — last 50 messages for this project
 	chat_history = conn.execute('''
 		SELECT * FROM chat_messages
@@ -637,6 +659,8 @@ def cd_project(slug):
 		files=[dict(f) for f in files],
 		meetings_recent=[dict(m) for m in meetings_recent],
 		meetings_total=meetings_total,
+		mileage_recent=[dict(m) for m in mileage_recent],
+		mileage_totals=dict(mileage_totals),
 		chat_history=[dict(m) for m in chat_history]
 	)
 

--- a/blueprints/mileage.py
+++ b/blueprints/mileage.py
@@ -225,7 +225,38 @@ def mileage_data():
 	})
 
 
-# ---- Edit page ----
+# ---- Form pages (new + edit share a template) ----
+
+
+def _form_context(conn, entry=None):
+	"""Common context for new + edit form pages."""
+	projects = conn.execute('''
+		SELECT id, title, slug, is_private
+		FROM projects
+		WHERE project_type IN ('work_subproject', 'personal')
+		  AND is_private = 0
+		ORDER BY title ASC
+	''').fetchall()
+	settings_row = conn.execute('SELECT * FROM settings WHERE id = 1').fetchone()
+	# Phase 3 — preselect the form's project from query string (?project_id=…)
+	# so the project-page LOG MILES button can deep-link with the project
+	# already chosen.
+	query_project = _to_int(request.args.get('project_id'))
+	return {
+		'entry': entry,
+		'projects': [dict(p) for p in projects],
+		'settings': dict(settings_row) if settings_row else {},
+		'query_project_id': query_project,
+	}
+
+
+@mileage_bp.route('/command-deck/mileage/new', methods=['GET'])
+@cd_auth_required
+def mileage_new_form():
+	conn = get_db()
+	ctx = _form_context(conn, entry=None)
+	conn.close()
+	return render_template('command_deck_mileage_form.html', mode='new', **ctx)
 
 
 @mileage_bp.route('/command-deck/mileage/<int:entry_id>/edit', methods=['GET'])
@@ -242,22 +273,9 @@ def mileage_edit(entry_id):
 		conn.close()
 		return "Mileage entry not found", 404
 
-	projects = conn.execute('''
-		SELECT id, title, slug, is_private
-		FROM projects
-		WHERE project_type IN ('work_subproject', 'personal')
-		  AND is_private = 0
-		ORDER BY title ASC
-	''').fetchall()
-	settings_row = conn.execute('SELECT * FROM settings WHERE id = 1').fetchone()
-
+	ctx = _form_context(conn, entry=_serialize_entry(row))
 	conn.close()
-	return render_template(
-		'command_deck_mileage_edit.html',
-		entry=_serialize_entry(row),
-		projects=[dict(p) for p in projects],
-		settings=dict(settings_row) if settings_row else {},
-	)
+	return render_template('command_deck_mileage_form.html', mode='edit', **ctx)
 
 
 # ---- Create ----

--- a/blueprints/mileage.py
+++ b/blueprints/mileage.py
@@ -1,0 +1,608 @@
+"""
+Mileage blueprint — Phase 3 of the time-tracking spec.
+
+Routes:
+
+  GET   /command-deck/mileage/                  -- index page (filterable)
+  GET   /command-deck/mileage/<id>/edit         -- edit form page
+  GET   /command-deck/mileage/data              -- JSON for index page (filtered)
+  POST  /command-deck/mileage/new               -- create
+  POST  /command-deck/mileage/<id>/update       -- per-field patch
+  POST  /command-deck/mileage/<id>/delete       -- hard delete
+  POST  /command-deck/mileage/<id>/submit       -- toggle submitted_at
+  POST  /command-deck/mileage/bulk-submit       -- mark many as submitted
+  GET   /command-deck/mileage/export.xlsx       -- xlsx download (filtered)
+
+Storage:
+  - date: ISO YYYY-MM-DD (ET-local day)
+  - submitted_at: ISO 8601 ET-local datetime, or NULL = pending reimbursement
+  - rate_cents: snapshot of settings.reimbursement_rate_cents at entry time
+  - miles: REAL, server stores whatever the form computes (round-trip math
+    happens client-side; server doesn't recompute — trusts the client)
+  - project_id: nullable in schema, required in v1 API (UI enforces)
+
+Privacy:
+  Default excludes is_private projects. Client opens with ?include_private=1
+  after PIN unlock (same convention as reports).
+"""
+from datetime import date as _date, datetime
+import io
+import os
+import pytz
+
+from flask import (
+	Blueprint, jsonify, redirect, render_template, request, send_file, url_for,
+)
+
+from helpers.auth import cd_auth_required, is_authenticated
+from helpers.db import et_now, get_db
+
+
+PRIVATE_PROJECTS_PIN = os.environ.get('PRIVATE_PROJECTS_PIN', '')
+
+
+mileage_bp = Blueprint('mileage', __name__)
+
+
+# ---- Helpers ----
+
+
+def _parse_iso_date(s):
+	"""Validate ISO YYYY-MM-DD; return the string if valid, else None."""
+	if not s:
+		return None
+	try:
+		_date.fromisoformat(s.strip())
+		return s.strip()
+	except (ValueError, TypeError, AttributeError):
+		return None
+
+
+def _to_int(v, default=None):
+	if v in (None, '', 'null'):
+		return default
+	try:
+		return int(v)
+	except (ValueError, TypeError):
+		return default
+
+
+def _to_float(v, default=None):
+	if v in (None, '', 'null'):
+		return default
+	try:
+		return float(v)
+	except (ValueError, TypeError):
+		return default
+
+
+def _to_bool(v):
+	"""Form sends '1' / 'true' / 'on' for true; everything else false."""
+	if v is None:
+		return 0
+	s = str(v).strip().lower()
+	return 1 if s in ('1', 'true', 'on', 'yes', 'y') else 0
+
+
+def _serialize_entry(row):
+	d = dict(row)
+	# Convenience derived fields for UI
+	d['reimbursement_cents'] = int(round((d.get('miles') or 0) * (d.get('rate_cents') or 0)))
+	d['is_submitted'] = bool(d.get('submitted_at'))
+	return d
+
+
+def _filters_from_request(args):
+	"""Extract date/project/status/include-private filters from query string.
+	Returns (clauses, params) for the WHERE clause + filter metadata."""
+	clauses = []
+	params = []
+
+	start = _parse_iso_date(args.get('start'))
+	end = _parse_iso_date(args.get('end'))
+	if start:
+		clauses.append('me.date >= ?')
+		params.append(start)
+	if end:
+		clauses.append('me.date <= ?')
+		params.append(end)
+
+	project = args.get('project')
+	if project:
+		project_id = _to_int(project)
+		if project_id:
+			clauses.append('me.project_id = ?')
+			params.append(project_id)
+
+	status = args.get('status')
+	if status == 'submitted':
+		clauses.append('me.submitted_at IS NOT NULL')
+	elif status == 'unsubmitted':
+		clauses.append('me.submitted_at IS NULL')
+
+	include_private = args.get('include_private') == '1'
+	if not include_private:
+		# Treat NULL project_id (future personal-trip rows) as non-private.
+		clauses.append('(p.is_private IS NULL OR p.is_private = 0)')
+
+	meta = {
+		'start': start,
+		'end': end,
+		'project': project,
+		'status': status or 'all',
+		'include_private': include_private,
+	}
+	return clauses, params, meta
+
+
+def _query_entries(conn, clauses, params):
+	where_sql = ('WHERE ' + ' AND '.join(clauses)) if clauses else ''
+	rows = conn.execute(f'''
+		SELECT me.*,
+		       p.title       AS project_title,
+		       p.slug        AS project_slug,
+		       p.is_private  AS project_is_private
+		FROM mileage_entries me
+		LEFT JOIN projects p ON me.project_id = p.id
+		{where_sql}
+		ORDER BY me.date DESC, me.id DESC
+	''', params).fetchall()
+	return rows
+
+
+# ---- Index page ----
+
+
+@mileage_bp.route('/command-deck/mileage/', methods=['GET'])
+@mileage_bp.route('/command-deck/mileage', methods=['GET'])
+@cd_auth_required
+def mileage_index():
+	conn = get_db()
+
+	# Trackable projects for the form picker
+	projects = conn.execute('''
+		SELECT id, title, slug, is_private
+		FROM projects
+		WHERE project_type IN ('work_subproject', 'personal')
+		  AND is_private = 0
+		ORDER BY title ASC
+	''').fetchall()
+
+	settings_row = conn.execute('SELECT * FROM settings WHERE id = 1').fetchone()
+	settings = dict(settings_row) if settings_row else {}
+
+	conn.close()
+	return render_template(
+		'command_deck_mileage.html',
+		projects=[dict(p) for p in projects],
+		settings=settings,
+		private_projects_enabled=bool(PRIVATE_PROJECTS_PIN),
+	)
+
+
+@mileage_bp.route('/command-deck/mileage/data', methods=['GET'])
+def mileage_data():
+	if not is_authenticated():
+		return jsonify({'error': 'unauthorized'}), 403
+	conn = get_db()
+	clauses, params, meta = _filters_from_request(request.args)
+	rows = _query_entries(conn, clauses, params)
+
+	entries = [_serialize_entry(r) for r in rows]
+
+	# Aggregate totals — overall, plus per-project and per-status splits.
+	total_miles = sum((e.get('miles') or 0) for e in entries)
+	total_cents = sum(e.get('reimbursement_cents', 0) for e in entries)
+	unsubmitted_miles = sum((e.get('miles') or 0) for e in entries if not e.get('is_submitted'))
+	unsubmitted_cents = sum(e.get('reimbursement_cents', 0) for e in entries if not e.get('is_submitted'))
+
+	by_project = {}
+	for e in entries:
+		key = str(e.get('project_id') or 0)
+		if key not in by_project:
+			by_project[key] = {
+				'title': e.get('project_title') or '(no project)',
+				'miles': 0.0,
+				'cents': 0,
+				'count': 0,
+			}
+		by_project[key]['miles'] += (e.get('miles') or 0)
+		by_project[key]['cents'] += e.get('reimbursement_cents', 0)
+		by_project[key]['count'] += 1
+
+	conn.close()
+	return jsonify({
+		'meta': meta,
+		'entries': entries,
+		'totals': {
+			'count': len(entries),
+			'miles': total_miles,
+			'cents': total_cents,
+			'unsubmitted_miles': unsubmitted_miles,
+			'unsubmitted_cents': unsubmitted_cents,
+			'by_project': by_project,
+		},
+	})
+
+
+# ---- Edit page ----
+
+
+@mileage_bp.route('/command-deck/mileage/<int:entry_id>/edit', methods=['GET'])
+@cd_auth_required
+def mileage_edit(entry_id):
+	conn = get_db()
+	row = conn.execute('''
+		SELECT me.*, p.title AS project_title, p.slug AS project_slug
+		FROM mileage_entries me
+		LEFT JOIN projects p ON me.project_id = p.id
+		WHERE me.id = ?
+	''', (entry_id,)).fetchone()
+	if not row:
+		conn.close()
+		return "Mileage entry not found", 404
+
+	projects = conn.execute('''
+		SELECT id, title, slug, is_private
+		FROM projects
+		WHERE project_type IN ('work_subproject', 'personal')
+		  AND is_private = 0
+		ORDER BY title ASC
+	''').fetchall()
+	settings_row = conn.execute('SELECT * FROM settings WHERE id = 1').fetchone()
+
+	conn.close()
+	return render_template(
+		'command_deck_mileage_edit.html',
+		entry=_serialize_entry(row),
+		projects=[dict(p) for p in projects],
+		settings=dict(settings_row) if settings_row else {},
+	)
+
+
+# ---- Create ----
+
+
+@mileage_bp.route('/command-deck/mileage/new', methods=['POST'])
+def mileage_new():
+	if not is_authenticated():
+		return jsonify({'error': 'unauthorized'}), 403
+
+	data = request.form
+
+	date_iso = _parse_iso_date(data.get('date'))
+	if not date_iso:
+		return jsonify({'error': 'invalid_date'}), 400
+
+	miles = _to_float(data.get('miles'))
+	if miles is None or miles < 0:
+		return jsonify({'error': 'invalid_miles'}), 400
+
+	conn = get_db()
+
+	# Rate snapshot — caller can override (rare), otherwise use current setting
+	override_rate = _to_int(data.get('rate_cents'))
+	if override_rate is not None and override_rate >= 0:
+		rate_cents = override_rate
+	else:
+		s = conn.execute('SELECT reimbursement_rate_cents FROM settings WHERE id = 1').fetchone()
+		rate_cents = int(s['reimbursement_rate_cents']) if s else 67
+
+	project_id = _to_int(data.get('project_id'))
+	round_trip = _to_bool(data.get('round_trip'))
+	odometer_start = _to_float(data.get('odometer_start'))
+	odometer_end = _to_float(data.get('odometer_end'))
+	vehicle = (data.get('vehicle') or 'a').strip().lower()
+	if vehicle not in ('a', 'b'):
+		vehicle = 'a'
+
+	now = et_now()
+	cur = conn.execute('''
+		INSERT INTO mileage_entries
+			(project_id, date, description, from_location, to_location,
+			 round_trip, odometer_start, odometer_end, miles, rate_cents,
+			 vehicle, notes, created, updated)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	''', (
+		project_id,
+		date_iso,
+		(data.get('description') or '').strip() or None,
+		(data.get('from_location') or '').strip() or None,
+		(data.get('to_location') or '').strip() or None,
+		round_trip,
+		odometer_start,
+		odometer_end,
+		miles,
+		rate_cents,
+		vehicle,
+		(data.get('notes') or '').strip() or None,
+		now, now,
+	))
+	new_id = cur.lastrowid
+	conn.commit()
+	row = conn.execute('''
+		SELECT me.*, p.title AS project_title, p.slug AS project_slug
+		FROM mileage_entries me
+		LEFT JOIN projects p ON me.project_id = p.id
+		WHERE me.id = ?
+	''', (new_id,)).fetchone()
+	conn.close()
+
+	# Form posts can ask for a redirect (HTML flow) or JSON (XHR flow). The
+	# mileage form does both — XHR for in-page submit, HTML POST for the
+	# /log-miles shortcut path.
+	if data.get('return') == 'redirect':
+		return redirect(url_for('mileage.mileage_index'))
+	return jsonify({'success': True, 'entry': _serialize_entry(row)})
+
+
+# ---- Update ----
+
+
+@mileage_bp.route('/command-deck/mileage/<int:entry_id>/update', methods=['POST'])
+def mileage_update(entry_id):
+	if not is_authenticated():
+		return jsonify({'error': 'unauthorized'}), 403
+	data = request.get_json(silent=True) or request.form
+
+	conn = get_db()
+	row = conn.execute('SELECT * FROM mileage_entries WHERE id = ?', (entry_id,)).fetchone()
+	if not row:
+		conn.close()
+		return jsonify({'error': 'not_found'}), 404
+
+	updates = {}
+
+	if 'date' in data:
+		date_iso = _parse_iso_date(data.get('date'))
+		if not date_iso:
+			conn.close()
+			return jsonify({'error': 'invalid_date'}), 400
+		updates['date'] = date_iso
+
+	if 'project_id' in data:
+		val = data.get('project_id')
+		updates['project_id'] = _to_int(val)  # None clears
+
+	if 'description' in data:
+		v = (data.get('description') or '').strip()
+		updates['description'] = v or None
+
+	if 'from_location' in data:
+		v = (data.get('from_location') or '').strip()
+		updates['from_location'] = v or None
+
+	if 'to_location' in data:
+		v = (data.get('to_location') or '').strip()
+		updates['to_location'] = v or None
+
+	if 'round_trip' in data:
+		updates['round_trip'] = _to_bool(data.get('round_trip'))
+
+	if 'odometer_start' in data:
+		updates['odometer_start'] = _to_float(data.get('odometer_start'))
+
+	if 'odometer_end' in data:
+		updates['odometer_end'] = _to_float(data.get('odometer_end'))
+
+	if 'miles' in data:
+		miles = _to_float(data.get('miles'))
+		if miles is None or miles < 0:
+			conn.close()
+			return jsonify({'error': 'invalid_miles'}), 400
+		updates['miles'] = miles
+
+	if 'rate_cents' in data:
+		rate = _to_int(data.get('rate_cents'))
+		if rate is None or rate < 0:
+			conn.close()
+			return jsonify({'error': 'invalid_rate'}), 400
+		updates['rate_cents'] = rate
+
+	if 'vehicle' in data:
+		v = (data.get('vehicle') or '').strip().lower()
+		if v not in ('a', 'b'):
+			conn.close()
+			return jsonify({'error': 'invalid_vehicle'}), 400
+		updates['vehicle'] = v
+
+	if 'notes' in data:
+		v = (data.get('notes') or '').strip()
+		updates['notes'] = v or None
+
+	if not updates:
+		conn.close()
+		return jsonify({'error': 'no_fields'}), 400
+
+	updates['updated'] = et_now()
+	set_sql = ', '.join(f'{k} = ?' for k in updates)
+	conn.execute(
+		f'UPDATE mileage_entries SET {set_sql} WHERE id = ?',
+		list(updates.values()) + [entry_id],
+	)
+	conn.commit()
+	row = conn.execute('''
+		SELECT me.*, p.title AS project_title, p.slug AS project_slug
+		FROM mileage_entries me
+		LEFT JOIN projects p ON me.project_id = p.id
+		WHERE me.id = ?
+	''', (entry_id,)).fetchone()
+	conn.close()
+	return jsonify({'success': True, 'entry': _serialize_entry(row)})
+
+
+# ---- Delete ----
+
+
+@mileage_bp.route('/command-deck/mileage/<int:entry_id>/delete', methods=['POST'])
+def mileage_delete(entry_id):
+	if not is_authenticated():
+		return jsonify({'error': 'unauthorized'}), 403
+	conn = get_db()
+	row = conn.execute('SELECT id FROM mileage_entries WHERE id = ?', (entry_id,)).fetchone()
+	if not row:
+		conn.close()
+		return jsonify({'error': 'not_found'}), 404
+	conn.execute('DELETE FROM mileage_entries WHERE id = ?', (entry_id,))
+	conn.commit()
+	conn.close()
+	return jsonify({'success': True, 'deleted_id': entry_id})
+
+
+# ---- Submit toggle ----
+
+
+@mileage_bp.route('/command-deck/mileage/<int:entry_id>/submit', methods=['POST'])
+def mileage_submit_toggle(entry_id):
+	if not is_authenticated():
+		return jsonify({'error': 'unauthorized'}), 403
+
+	data = request.get_json(silent=True) or request.form
+	conn = get_db()
+	row = conn.execute('SELECT * FROM mileage_entries WHERE id = ?', (entry_id,)).fetchone()
+	if not row:
+		conn.close()
+		return jsonify({'error': 'not_found'}), 404
+
+	# Allow explicit value (submitted=1/0) or implicit toggle.
+	if 'submitted' in data:
+		want = _to_bool(data.get('submitted'))
+	else:
+		want = 0 if row['submitted_at'] else 1
+
+	new_submitted_at = et_now() if want else None
+	conn.execute(
+		'UPDATE mileage_entries SET submitted_at = ?, updated = ? WHERE id = ?',
+		(new_submitted_at, et_now(), entry_id),
+	)
+	conn.commit()
+	row = conn.execute('''
+		SELECT me.*, p.title AS project_title, p.slug AS project_slug
+		FROM mileage_entries me
+		LEFT JOIN projects p ON me.project_id = p.id
+		WHERE me.id = ?
+	''', (entry_id,)).fetchone()
+	conn.close()
+	return jsonify({'success': True, 'entry': _serialize_entry(row)})
+
+
+# ---- Bulk submit ----
+
+
+@mileage_bp.route('/command-deck/mileage/bulk-submit', methods=['POST'])
+def mileage_bulk_submit():
+	if not is_authenticated():
+		return jsonify({'error': 'unauthorized'}), 403
+	data = request.get_json(silent=True) or {}
+	ids = data.get('ids') or []
+	if not isinstance(ids, list) or not ids:
+		return jsonify({'error': 'ids_required'}), 400
+	want = _to_bool(data.get('submitted', 1))
+
+	int_ids = [int(x) for x in ids if str(x).isdigit()]
+	if not int_ids:
+		return jsonify({'error': 'ids_required'}), 400
+
+	now = et_now()
+	new_submitted_at = now if want else None
+
+	conn = get_db()
+	placeholders = ','.join('?' * len(int_ids))
+	conn.execute(
+		f'UPDATE mileage_entries '
+		f'SET submitted_at = ?, updated = ? '
+		f'WHERE id IN ({placeholders})',
+		[new_submitted_at, now] + int_ids,
+	)
+	conn.commit()
+	conn.close()
+	return jsonify({'success': True, 'count': len(int_ids), 'submitted': bool(want)})
+
+
+# ---- xlsx export ----
+
+
+@mileage_bp.route('/command-deck/mileage/export.xlsx', methods=['GET'])
+@cd_auth_required
+def mileage_export_xlsx():
+	# openpyxl is the only Phase-3 dependency added on top of the existing
+	# stack. Imported lazily so the rest of the blueprint stays importable
+	# on a server that hasn't installed it yet (logs a clear error instead
+	# of failing at app startup).
+	try:
+		from openpyxl import Workbook
+		from openpyxl.styles import Font, Alignment
+	except ImportError:
+		return (
+			"openpyxl not installed on this server. "
+			"On PythonAnywhere bash: pip3.10 install --user openpyxl",
+			500,
+		)
+
+	conn = get_db()
+	clauses, params, meta = _filters_from_request(request.args)
+	rows = _query_entries(conn, clauses, params)
+	conn.close()
+
+	wb = Workbook()
+	ws = wb.active
+	ws.title = 'Mileage'
+
+	headers = [
+		'Date', 'Project', 'Description', 'From', 'To', 'Round Trip',
+		'Odometer Start', 'Odometer End', 'Miles', 'Rate ($/mi)',
+		'Reimbursement ($)', 'Vehicle', 'Notes', 'Submitted',
+	]
+	ws.append(headers)
+	for cell in ws[1]:
+		cell.font = Font(bold=True)
+		cell.alignment = Alignment(horizontal='left')
+
+	for r in rows:
+		miles = float(r['miles'] or 0)
+		rate_cents = int(r['rate_cents'] or 0)
+		reimbursement = round(miles * rate_cents / 100.0, 2)
+		ws.append([
+			r['date'] or '',
+			r['project_title'] or '',
+			r['description'] or '',
+			r['from_location'] or '',
+			r['to_location'] or '',
+			'Yes' if r['round_trip'] else 'No',
+			r['odometer_start'] if r['odometer_start'] is not None else '',
+			r['odometer_end'] if r['odometer_end'] is not None else '',
+			miles,
+			round(rate_cents / 100.0, 4),
+			reimbursement,
+			r['vehicle'] or '',
+			r['notes'] or '',
+			(r['submitted_at'][:10] if r['submitted_at'] else ''),
+		])
+
+	# Best-effort column widths so the file isn't ugly on first open.
+	widths = [12, 24, 32, 22, 22, 10, 14, 14, 8, 10, 14, 8, 32, 12]
+	for i, w in enumerate(widths, start=1):
+		ws.column_dimensions[chr(64 + i) if i <= 26 else 'A' + chr(64 + i - 26)].width = w
+
+	buf = io.BytesIO()
+	wb.save(buf)
+	buf.seek(0)
+
+	# Filename reflects the active filter for "did I export the right month?"
+	if meta['start'] and meta['end']:
+		fname = f"mileage-{meta['start']}-to-{meta['end']}.xlsx"
+	elif meta['start']:
+		fname = f"mileage-from-{meta['start']}.xlsx"
+	elif meta['end']:
+		fname = f"mileage-to-{meta['end']}.xlsx"
+	elif meta['status'] == 'unsubmitted':
+		fname = 'mileage-unsubmitted.xlsx'
+	else:
+		fname = 'mileage-all.xlsx'
+
+	return send_file(
+		buf,
+		mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+		as_attachment=True,
+		download_name=fname,
+	)

--- a/blueprints/settings.py
+++ b/blueprints/settings.py
@@ -1,0 +1,146 @@
+"""
+Settings blueprint — Phase 3 of the time-tracking spec.
+
+Routes:
+
+  GET   /command-deck/settings/         -- settings page
+  POST  /command-deck/settings/update   -- per-field patch
+
+Editable fields (all in the singleton `settings` row, id = 1):
+
+  - reimbursement_rate_cents     -- IRS-style $/mi (form shows as 0.67)
+  - vehicle_a_label              -- "Honda Pilot", "Subaru", etc.
+  - vehicle_b_label
+  - default_vehicle              -- 'a' or 'b'
+  - default_mileage_project_id   -- which project the mileage form pre-selects
+  - idle_threshold_minutes       -- Phase 4 will read this; column ships in Phase 1
+
+The settings row is auto-created if missing. Phase 1's migrate_to_sqlite.py
+already inserts a row at id=1, but defensive code here means a fresh DB or
+hand-edited DB still works.
+"""
+from flask import Blueprint, jsonify, render_template, request
+
+from helpers.auth import cd_auth_required, is_authenticated
+from helpers.db import et_now, get_db
+
+
+settings_bp = Blueprint('settings', __name__)
+
+
+def _ensure_settings_row(conn):
+	"""Insert the singleton settings row if missing. Returns the row."""
+	row = conn.execute('SELECT * FROM settings WHERE id = 1').fetchone()
+	if row:
+		return row
+	now = et_now()
+	conn.execute('''
+		INSERT INTO settings (id, idle_threshold_minutes, reimbursement_rate_cents,
+		                      vehicle_a_label, vehicle_b_label, default_vehicle,
+		                      created, updated)
+		VALUES (1, 15, 67, 'Vehicle A', 'Vehicle B', 'a', ?, ?)
+	''', (now, now))
+	conn.commit()
+	return conn.execute('SELECT * FROM settings WHERE id = 1').fetchone()
+
+
+@settings_bp.route('/command-deck/settings/', methods=['GET'])
+@settings_bp.route('/command-deck/settings', methods=['GET'])
+@cd_auth_required
+def settings_page():
+	conn = get_db()
+	settings_row = _ensure_settings_row(conn)
+	projects = conn.execute('''
+		SELECT id, title, slug
+		FROM projects
+		WHERE project_type IN ('work_subproject', 'personal')
+		  AND is_private = 0
+		ORDER BY title ASC
+	''').fetchall()
+	conn.close()
+	return render_template(
+		'command_deck_settings.html',
+		settings=dict(settings_row),
+		projects=[dict(p) for p in projects],
+	)
+
+
+@settings_bp.route('/command-deck/settings/update', methods=['POST'])
+def settings_update():
+	if not is_authenticated():
+		return jsonify({'error': 'unauthorized'}), 403
+
+	data = request.get_json(silent=True) or request.form
+	conn = get_db()
+	_ensure_settings_row(conn)
+
+	updates = {}
+
+	if 'reimbursement_rate_cents' in data:
+		try:
+			val = int(data.get('reimbursement_rate_cents'))
+		except (ValueError, TypeError):
+			conn.close()
+			return jsonify({'error': 'invalid_rate'}), 400
+		if val < 0 or val > 1000:
+			conn.close()
+			return jsonify({'error': 'invalid_rate'}), 400
+		updates['reimbursement_rate_cents'] = val
+
+	if 'vehicle_a_label' in data:
+		v = (data.get('vehicle_a_label') or '').strip()
+		if not v:
+			conn.close()
+			return jsonify({'error': 'invalid_vehicle_a_label'}), 400
+		updates['vehicle_a_label'] = v
+
+	if 'vehicle_b_label' in data:
+		v = (data.get('vehicle_b_label') or '').strip()
+		if not v:
+			conn.close()
+			return jsonify({'error': 'invalid_vehicle_b_label'}), 400
+		updates['vehicle_b_label'] = v
+
+	if 'default_vehicle' in data:
+		v = (data.get('default_vehicle') or '').strip().lower()
+		if v not in ('a', 'b'):
+			conn.close()
+			return jsonify({'error': 'invalid_default_vehicle'}), 400
+		updates['default_vehicle'] = v
+
+	if 'default_mileage_project_id' in data:
+		val = data.get('default_mileage_project_id')
+		if val in (None, '', 'null'):
+			updates['default_mileage_project_id'] = None
+		else:
+			try:
+				updates['default_mileage_project_id'] = int(val)
+			except (ValueError, TypeError):
+				conn.close()
+				return jsonify({'error': 'invalid_default_mileage_project'}), 400
+
+	if 'idle_threshold_minutes' in data:
+		try:
+			val = int(data.get('idle_threshold_minutes'))
+		except (ValueError, TypeError):
+			conn.close()
+			return jsonify({'error': 'invalid_idle_threshold'}), 400
+		if val < 1 or val > 480:
+			conn.close()
+			return jsonify({'error': 'invalid_idle_threshold'}), 400
+		updates['idle_threshold_minutes'] = val
+
+	if not updates:
+		conn.close()
+		return jsonify({'error': 'no_fields'}), 400
+
+	updates['updated'] = et_now()
+	set_sql = ', '.join(f'{k} = ?' for k in updates)
+	conn.execute(
+		f'UPDATE settings SET {set_sql} WHERE id = 1',
+		list(updates.values()),
+	)
+	conn.commit()
+	row = conn.execute('SELECT * FROM settings WHERE id = 1').fetchone()
+	conn.close()
+	return jsonify({'success': True, 'settings': dict(row)})

--- a/migrate_add_mileage.py
+++ b/migrate_add_mileage.py
@@ -1,0 +1,176 @@
+"""
+migrate_add_mileage.py
+Phase 3 of the time-tracking spec — see .kt/spec-phase-3-mileage.md.
+
+What it does (idempotent — safe to run multiple times):
+
+  + mileage_entries table:
+      id              INTEGER PRIMARY KEY AUTOINCREMENT
+      project_id      INTEGER REFERENCES projects(id) ON DELETE SET NULL
+                                       -- nullable; v1 UI requires, future
+                                       -- personal trips can leave NULL
+      date            TEXT NOT NULL    -- ISO YYYY-MM-DD (ET-local day)
+      description     TEXT
+      from_location   TEXT
+      to_location     TEXT
+      round_trip      INTEGER NOT NULL DEFAULT 0
+      odometer_start  REAL
+      odometer_end    REAL
+      miles           REAL NOT NULL    -- canonical; form calculates, server stores
+      rate_cents      INTEGER NOT NULL -- snapshot from settings at entry time
+      vehicle         TEXT NOT NULL DEFAULT 'a'
+      notes           TEXT
+      submitted_at    TEXT             -- ISO datetime; NULL = pending reimbursement
+      created         TEXT NOT NULL
+      updated         TEXT NOT NULL
+
+  + settings.default_mileage_project_id   INTEGER REFERENCES projects(id) ON DELETE SET NULL
+                                          -- which project the mileage form pre-selects
+
+  + indexes:
+      idx_mileage_project          mileage_entries(project_id)
+      idx_mileage_date             mileage_entries(date)
+      idx_mileage_unsubmitted      mileage_entries(submitted_at)
+                                       WHERE submitted_at IS NULL
+
+  The unsubmitted partial index supports the "what haven't I submitted
+  yet" query, which is the dashboard's primary mileage signal — Aaron
+  reviews this monthly to catch up on reimbursements.
+
+Cascade:
+  - project delete  → mileage_entries.project_id = NULL  (entry survives;
+                       it's a financial record, can't lose it just because
+                       a project got cleaned up)
+
+Prints a summary. Running it again prints "no changes."
+
+Run from PythonAnywhere bash:
+    cd /home/aaronaiken/status_update
+    python migrate_add_mileage.py
+"""
+
+import os
+import sqlite3
+
+DB_FILE = os.path.join(
+	os.environ.get('COCKPIT_REPO_ROOT', '/home/aaronaiken/status_update'),
+	'assets/data/command_deck.db'
+)
+
+
+def table_exists(cur, name):
+	row = cur.execute(
+		"SELECT name FROM sqlite_master WHERE type='table' AND name=?", (name,)
+	).fetchone()
+	return row is not None
+
+
+def column_exists(cur, table, col):
+	cols = [row[1] for row in cur.execute(f"PRAGMA table_info({table})").fetchall()]
+	return col in cols
+
+
+def index_exists(cur, name):
+	row = cur.execute(
+		"SELECT name FROM sqlite_master WHERE type='index' AND name=?", (name,)
+	).fetchone()
+	return row is not None
+
+
+CREATE_MILEAGE_SQL = """
+CREATE TABLE mileage_entries (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id      INTEGER REFERENCES projects(id) ON DELETE SET NULL,
+    date            TEXT NOT NULL,
+    description     TEXT,
+    from_location   TEXT,
+    to_location     TEXT,
+    round_trip      INTEGER NOT NULL DEFAULT 0,
+    odometer_start  REAL,
+    odometer_end    REAL,
+    miles           REAL NOT NULL,
+    rate_cents      INTEGER NOT NULL,
+    vehicle         TEXT NOT NULL DEFAULT 'a',
+    notes           TEXT,
+    submitted_at    TEXT,
+    created         TEXT NOT NULL,
+    updated         TEXT NOT NULL
+)
+"""
+
+COLUMNS = [
+	('settings', 'default_mileage_project_id',
+	 'INTEGER REFERENCES projects(id) ON DELETE SET NULL'),
+]
+
+INDEXES = [
+	(
+		'idx_mileage_project',
+		'CREATE INDEX IF NOT EXISTS idx_mileage_project ON mileage_entries(project_id)',
+	),
+	(
+		'idx_mileage_date',
+		'CREATE INDEX IF NOT EXISTS idx_mileage_date ON mileage_entries(date)',
+	),
+	(
+		'idx_mileage_unsubmitted',
+		'CREATE INDEX IF NOT EXISTS idx_mileage_unsubmitted '
+		'ON mileage_entries(submitted_at) WHERE submitted_at IS NULL',
+	),
+]
+
+
+def run():
+	if not os.path.exists(DB_FILE):
+		print(f"× DB not found at {DB_FILE}")
+		print("  Run migrate_to_sqlite.py first.")
+		return
+
+	conn = sqlite3.connect(DB_FILE)
+	cur = conn.cursor()
+
+	added = []
+	skipped = []
+
+	if table_exists(cur, 'mileage_entries'):
+		skipped.append('mileage_entries (table)')
+	else:
+		cur.execute(CREATE_MILEAGE_SQL)
+		added.append('mileage_entries (table)')
+
+	for table, col, sql_type in COLUMNS:
+		if column_exists(cur, table, col):
+			skipped.append(f'{table}.{col}')
+		else:
+			cur.execute(f'ALTER TABLE {table} ADD COLUMN {col} {sql_type}')
+			added.append(f'{table}.{col}')
+
+	for name, sql in INDEXES:
+		if index_exists(cur, name):
+			skipped.append(name)
+		else:
+			cur.execute(sql)
+			added.append(name)
+
+	conn.commit()
+	conn.close()
+
+	print()
+	print("Migration: migrate_add_mileage.py")
+	print(f"DB:        {DB_FILE}")
+	print()
+	if added:
+		print(f"✓ Added ({len(added)}):")
+		for item in added:
+			print(f"    + {item}")
+	if skipped:
+		print(f"— Already in place ({len(skipped)}):")
+		for item in skipped:
+			print(f"    · {item}")
+	if not added:
+		print("No changes — schema already up to date.")
+	print()
+
+
+if __name__ == '__main__':
+	run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,24 @@
+# Cockpit / Command Deck — Python dependencies.
+#
+# Local: source .venv/bin/activate && pip install -r requirements.txt
+# PA:    pip3.10 install --user -r requirements.txt
+#         (substitute whichever pip3.X matches the PA web app's Python)
+#
+# These are the third-party imports the Flask app reaches for. The standard
+# library is unpinned for obvious reasons. Versions are floors — newer is
+# fine — except where a known pin is documented. Anthropic SDK and openpyxl
+# are the two libraries with the loudest changelogs; bump deliberately.
+
+Flask>=3.1
+python-dotenv>=1.0
+pytz
+requests
+emoji
+Pillow
+
+# Anthropic API — Huyang + Cockpit assistant flows.
+anthropic>=0.97
+
+# Phase 3 — mileage xlsx export. Without this, /command-deck/mileage/export.xlsx
+# returns a 500 with install instructions; the rest of the app stays fine.
+openpyxl>=3.1

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -4498,3 +4498,104 @@ body[data-cd-tab="personal"] .cd-huyang-search-row { display: none; }
 @media (max-width: 540px) {
   .cd-mileage-field-pair { grid-template-columns: 1fr; }
 }
+
+/* Dashboard mileage quick-panel + project page mileage list — Phase 3 */
+
+.cd-mileage-quickpanel { background: rgba(212, 136, 10, 0.04); }
+.cd-mileage-quickpanel-body {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.cd-mileage-quickpanel-summary {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+.cd-mileage-quickpanel-pending {
+  font-family: var(--cd-font-ui);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  color: var(--cd-amber-hi);
+}
+.cd-mileage-quickpanel-pending.cd-mileage-quickpanel-clean {
+  color: rgba(80, 180, 100, 0.85);
+  font-style: italic;
+}
+
+/* Project page // Mileage section */
+
+.cd-project-mileage-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.cd-project-mileage-row { border-bottom: 1px solid var(--cd-border); }
+.cd-project-mileage-row:last-child { border-bottom: none; }
+
+.cd-project-mileage-link {
+  display: grid;
+  grid-template-columns: 8em 1fr 6em 6em;
+  gap: 0.75rem;
+  padding: 0.4rem 0.2rem;
+  align-items: baseline;
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.12s;
+}
+.cd-project-mileage-link:hover { background: rgba(212, 136, 10, 0.05); }
+
+.cd-project-mileage-date,
+.cd-project-mileage-miles {
+  font-family: var(--cd-font-ui);
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  color: var(--cd-text-dim);
+  white-space: nowrap;
+}
+.cd-project-mileage-miles {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.cd-project-mileage-trip {
+  font-size: 0.85rem;
+  color: var(--cd-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cd-project-mileage-status {
+  font-family: var(--cd-font-ui);
+  font-size: 0.55rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  text-align: right;
+  white-space: nowrap;
+}
+.cd-project-mileage-status.pending   { color: var(--cd-amber-hi); }
+.cd-project-mileage-status.submitted { color: rgba(80, 180, 100, 0.85); }
+
+.cd-mileage-project-summary {
+  font-family: var(--cd-font-ui);
+  font-size: 0.65rem;
+  letter-spacing: 0.08em;
+  color: var(--cd-text-dim);
+  margin-right: 0.6rem;
+}
+
+@media (max-width: 720px) {
+  .cd-project-mileage-link {
+    grid-template-columns: 6em 1fr 5em;
+    grid-template-areas:
+      "date miles  status"
+      "trip trip   trip";
+    row-gap: 0.15rem;
+  }
+  .cd-project-mileage-date   { grid-area: date; }
+  .cd-project-mileage-trip   { grid-area: trip; }
+  .cd-project-mileage-miles  { grid-area: miles; }
+  .cd-project-mileage-status { grid-area: status; }
+}

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -4212,3 +4212,289 @@ body[data-cd-tab="personal"] .cd-huyang-search-row { display: none; }
     gap: 0.3rem;
   }
 }
+
+/* ============================================================
+ * MILEAGE — Phase 3
+ * Index page (filters + entries table + bulk bar) + form page.
+ * ============================================================ */
+
+/* --- Index --- */
+
+.cd-mileage-controls {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+.cd-mileage-actions { display: flex; gap: 0.5rem; }
+
+.cd-mileage-filters {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  margin-bottom: 1rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--cd-border);
+}
+.cd-mileage-filter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.cd-mileage-filter > span {
+  font-family: var(--cd-font-ui);
+  font-size: 0.55rem;
+  letter-spacing: 0.18em;
+  color: var(--cd-text-dim);
+  text-transform: uppercase;
+}
+.cd-mileage-filter input,
+.cd-mileage-filter select { min-width: 10em; }
+
+.cd-mileage-status-pills {
+  display: flex;
+  gap: 0.25rem;
+  border: 1px solid var(--cd-border);
+  border-radius: 999px;
+  padding: 0.15rem;
+}
+.cd-mileage-status-pill {
+  background: transparent;
+  border: none;
+  color: var(--cd-text-dim);
+  font-family: var(--cd-font-ui);
+  font-size: 0.6rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.cd-mileage-status-pill.active {
+  background: rgba(212, 136, 10, 0.15);
+  color: var(--cd-amber-hi);
+}
+
+.cd-mileage-summary {
+  font-family: var(--cd-font-ui);
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  color: var(--cd-text-dim);
+  margin-bottom: 1rem;
+}
+.cd-mileage-summary-pending {
+  color: var(--cd-amber-hi);
+}
+.cd-mileage-summary-empty,
+.cd-mileage-summary-loading {
+  font-style: italic;
+}
+
+.cd-mileage-bulkbar {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: rgba(212, 136, 10, 0.06);
+  border: 1px solid var(--cd-border-amber, var(--cd-border));
+  border-radius: 4px;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 1rem;
+  font-family: var(--cd-font-ui);
+  font-size: 0.7rem;
+}
+
+.cd-mileage-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+.cd-mileage-table th,
+.cd-mileage-table td {
+  padding: 0.5rem 0.4rem;
+  border-bottom: 1px solid var(--cd-border);
+  text-align: left;
+  vertical-align: middle;
+}
+.cd-mileage-table th {
+  font-family: var(--cd-font-ui);
+  font-size: 0.55rem;
+  letter-spacing: 0.14em;
+  color: var(--cd-text-dim);
+  text-transform: uppercase;
+  font-weight: normal;
+  white-space: nowrap;
+}
+.cd-mileage-table .cd-num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.cd-mileage-table .cd-mileage-check-col { width: 2em; }
+.cd-mileage-table tr.is-submitted td {
+  color: var(--cd-text-dim);
+}
+
+.cd-mileage-trip { color: var(--cd-text); }
+.cd-mileage-roundtrip {
+  color: var(--cd-amber);
+  font-weight: bold;
+  margin-left: 0.3em;
+}
+
+.cd-mileage-status {
+  background: none;
+  border: 1px solid transparent;
+  font-family: var(--cd-font-ui);
+  font-size: 0.55rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.7rem;
+  border-radius: 999px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, border-color 0.15s;
+}
+.cd-mileage-status.pending {
+  background: rgba(212, 136, 10, 0.1);
+  border-color: var(--cd-amber);
+  color: var(--cd-amber-hi);
+}
+.cd-mileage-status.submitted {
+  background: rgba(60, 160, 80, 0.12);
+  border-color: rgba(60, 160, 80, 0.5);
+  color: rgba(80, 180, 100, 0.95);
+}
+.cd-mileage-status:hover { filter: brightness(1.1); }
+
+.cd-mileage-empty,
+.cd-mileage-loading {
+  text-align: center;
+  font-style: italic;
+  color: var(--cd-text-dim);
+  padding: 2rem 0;
+}
+
+@media (max-width: 720px) {
+  .cd-mileage-table th:nth-child(3),
+  .cd-mileage-table td:nth-child(3) { display: none; }  /* hide project on phone */
+  .cd-mileage-table th:nth-child(8),
+  .cd-mileage-table td:nth-child(8) { display: none; }  /* hide edit btn col — tap row */
+  .cd-mileage-filter input,
+  .cd-mileage-filter select { min-width: 0; width: 100%; }
+}
+
+/* --- Form page (mobile-first, big tap targets) --- */
+
+.cd-mileage-form {
+  max-width: 32rem;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cd-mileage-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.cd-mileage-field-label {
+  font-family: var(--cd-font-ui);
+  font-size: 0.6rem;
+  letter-spacing: 0.16em;
+  color: var(--cd-text-dim);
+  text-transform: uppercase;
+}
+
+.cd-mileage-input {
+  width: 100%;
+  padding: 0.7rem 0.75rem;
+  font-size: 1rem;
+  min-height: 44px;  /* iOS tap target floor */
+  background: transparent;
+  border: 1px solid var(--cd-border);
+  color: var(--cd-text);
+  border-radius: 3px;
+}
+.cd-mileage-input:focus {
+  outline: none;
+  border-color: var(--cd-amber);
+}
+
+.cd-mileage-input-miles {
+  font-size: 1.3rem;
+  font-weight: bold;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.05em;
+  color: var(--cd-amber-hi);
+}
+
+.cd-mileage-field-pair {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+.cd-mileage-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--cd-font-ui);
+  font-size: 0.75rem;
+  color: var(--cd-text);
+  letter-spacing: 0.05em;
+  padding: 0.4rem 0;
+}
+.cd-mileage-checkbox input {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--cd-amber);
+}
+.cd-mileage-hint {
+  color: var(--cd-text-dim);
+  font-size: 0.6rem;
+  letter-spacing: 0;
+  margin-left: 0.4em;
+  text-transform: none;
+}
+
+.cd-mileage-form-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  margin-top: 0.75rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--cd-border);
+}
+.cd-mileage-form-actions .cd-btn {
+  padding: 0.7rem 1.2rem;
+  font-size: 0.75rem;
+  min-height: 44px;
+}
+
+.cd-mileage-delete-btn {
+  color: rgba(204, 51, 34, 0.8);
+  border-color: rgba(204, 51, 34, 0.4);
+}
+.cd-mileage-delete-btn:hover {
+  color: rgb(204, 51, 34);
+  border-color: rgb(204, 51, 34);
+}
+
+.cd-mileage-submitted-note {
+  margin-top: 1rem;
+  padding: 0.5rem 0.75rem;
+  background: rgba(60, 160, 80, 0.08);
+  border-left: 3px solid rgba(60, 160, 80, 0.5);
+  color: var(--cd-text-dim);
+  font-size: 0.75rem;
+}
+
+@media (max-width: 540px) {
+  .cd-mileage-field-pair { grid-template-columns: 1fr; }
+}

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -4599,3 +4599,48 @@ body[data-cd-tab="personal"] .cd-huyang-search-row { display: none; }
   .cd-project-mileage-miles  { grid-area: miles; }
   .cd-project-mileage-status { grid-area: status; }
 }
+
+/* Reports Mileage tab — Phase 3 */
+
+.cd-reports-mileage-summary {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+  font-family: var(--cd-font-ui);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  color: var(--cd-text-dim);
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--cd-border);
+  margin-bottom: 1rem;
+}
+.cd-reports-mileage-summary .cd-mileage-summary-clean {
+  color: rgba(80, 180, 100, 0.85);
+  font-style: italic;
+}
+
+.cd-reports-mileage-rollup {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+.cd-reports-mileage-rollup th,
+.cd-reports-mileage-rollup td {
+  padding: 0.45rem 0.4rem;
+  border-bottom: 1px solid var(--cd-border);
+  text-align: left;
+}
+.cd-reports-mileage-rollup th {
+  font-family: var(--cd-font-ui);
+  font-size: 0.55rem;
+  letter-spacing: 0.14em;
+  color: var(--cd-text-dim);
+  text-transform: uppercase;
+  font-weight: normal;
+}
+.cd-reports-mileage-rollup .cd-num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -4116,3 +4116,99 @@ body[data-cd-tab="personal"] .cd-huyang-search-row { display: none; }
   .cd-project-meeting-title   { grid-area: title; }
   .cd-project-meeting-actions { grid-area: actions; }
 }
+
+/* ============================================================
+ * SETTINGS — Phase 3
+ * Editable defaults for mileage / vehicles / time tracking.
+ * ============================================================ */
+
+.cd-settings-intro {
+  font-size: 0.85rem;
+  color: var(--cd-text-dim);
+  max-width: 60ch;
+  margin: 0 0 1.5rem 0;
+}
+
+.cd-settings-form {
+  max-width: 640px;
+  margin: 0;
+}
+
+.cd-settings-section {
+  border-top: 1px solid var(--cd-border);
+  padding: 1rem 0;
+}
+.cd-settings-section:first-of-type { border-top: none; }
+
+.cd-settings-section-title {
+  font-family: var(--cd-font-ui);
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  color: var(--cd-text-dim);
+  text-transform: uppercase;
+  margin: 0 0 0.75rem 0;
+}
+
+.cd-settings-row {
+  display: grid;
+  grid-template-columns: 12em 1fr;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 0.6rem;
+}
+
+.cd-settings-label {
+  font-family: var(--cd-font-ui);
+  font-size: 0.65rem;
+  letter-spacing: 0.12em;
+  color: var(--cd-text-dim);
+  text-transform: uppercase;
+}
+
+.cd-settings-input {
+  background: transparent;
+  border: 1px solid var(--cd-border);
+  color: var(--cd-text);
+  font: inherit;
+  font-size: 0.85rem;
+  padding: 0.4rem 0.5rem;
+  border-radius: 2px;
+}
+.cd-settings-input:focus { outline: none; border-color: var(--cd-amber); }
+
+.cd-settings-input-narrow { max-width: 8em; }
+
+.cd-settings-input-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.cd-settings-prefix,
+.cd-settings-suffix {
+  font-family: var(--cd-font-ui);
+  font-size: 0.75rem;
+  color: var(--cd-text-dim);
+}
+
+.cd-settings-saved {
+  position: fixed;
+  bottom: 6rem;
+  right: 1rem;
+  background: var(--cd-bg-surface);
+  border: 1px solid var(--cd-border-amber, var(--cd-amber));
+  color: var(--cd-amber-hi);
+  font-family: var(--cd-font-ui);
+  font-size: 0.65rem;
+  letter-spacing: 0.18em;
+  padding: 0.4rem 0.75rem;
+  border-radius: 2px;
+  z-index: 9000;
+}
+
+@media (max-width: 720px) {
+  .cd-settings-row {
+    grid-template-columns: 1fr;
+    gap: 0.3rem;
+  }
+}

--- a/static/command_deck_nav.js
+++ b/static/command_deck_nav.js
@@ -16,6 +16,8 @@
 		'/command-deck/reports',
 		'/command-deck/templates',
 		'/command-deck/meetings',
+		'/command-deck/mileage',
+		'/command-deck/settings',
 	];
 	var underMenu = menuRoutes.some(function (r) { return path.indexOf(r) === 0; });
 

--- a/static/command_deck_reports.js
+++ b/static/command_deck_reports.js
@@ -8,8 +8,9 @@
 	'use strict';
 
 	const PRESETS = ['today', 'this-week', 'this-month', 'custom'];
-	const VALID_GROUPS = ['area', 'project', 'day', 'timesheet'];
+	const VALID_GROUPS = ['area', 'project', 'day', 'timesheet', 'mileage'];
 	const TIMESHEET_DAY_CAP = 31;
+	const MILEAGE_GROUP = 'mileage';
 
 	const state = {
 		preset: localStorage.getItem('reportsPeriod') || 'this-week',
@@ -489,9 +490,14 @@
 
 	async function load() {
 		try {
+			if (state.group === MILEAGE_GROUP) {
+				await loadMileage();
+				return;
+			}
 			const resp = await fetch(`/command-deck/reports/data?${buildQuery()}`);
 			if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
 			state.data = await resp.json();
+			state.dataKind = 'time';
 			renderHeader();
 			renderEmpty();
 			renderPrivacyNote();
@@ -502,6 +508,173 @@
 			document.getElementById('reportsRollup').innerHTML =
 				`<div class="cd-reports-error">// failed to load report — ${escapeHtml(e.message)}</div>`;
 		}
+	}
+
+	// Mileage view shares the period selector but pulls from a different
+	// endpoint and has its own rollup + entries shape. We compute start/end
+	// in JS (the time-reports endpoint normally resolves preset → dates on
+	// the server, but the mileage endpoint just takes start/end directly).
+	function resolveMileageDates() {
+		const today = new Date();
+		today.setHours(0, 0, 0, 0);
+		if (state.start && state.end) {
+			// state.end is exclusive in time-reports semantics; mileage filter
+			// uses inclusive end. Subtract one day to flip it.
+			const inclusive = addDays(parseISODate(state.end), -1);
+			return { start: state.start, end: fmtDate(inclusive) };
+		}
+		if (state.preset === 'today') {
+			return { start: fmtDate(today), end: fmtDate(today) };
+		}
+		if (state.preset === 'this-month') {
+			const first = startOfMonth(today);
+			const last = addDays(startOfNextMonth(today), -1);
+			return { start: fmtDate(first), end: fmtDate(last) };
+		}
+		// default: this-week (Sun-Sat)
+		const sun = startOfWeekSunday(today);
+		const sat = addDays(sun, 6);
+		return { start: fmtDate(sun), end: fmtDate(sat) };
+	}
+
+	async function loadMileage() {
+		const dates = resolveMileageDates();
+		const params = new URLSearchParams();
+		if (dates.start) params.set('start', dates.start);
+		if (dates.end) params.set('end', dates.end);
+		// Privacy: the mileage endpoint defaults to excluding private projects;
+		// the unlock state lives in localStorage same as time reports.
+		if (localStorage.getItem('cdPrivateUnlocked') === '1') {
+			params.set('include_private', '1');
+		}
+		const resp = await fetch(`/command-deck/mileage/data?${params.toString()}`, {
+			credentials: 'same-origin',
+		});
+		if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+		const data = await resp.json();
+		state.data = data;
+		state.dataKind = 'mileage';
+		// Inject meta.start/end so renderHeader's period label still works
+		state.data.meta = state.data.meta || {};
+		state.data.meta.start = dates.start;
+		state.data.meta.end = fmtDate(addDays(parseISODate(dates.end), 1));  // exclusive for label math
+		renderHeader();
+		renderMileageEmpty(data);
+		renderMileageRollup(data);
+		renderMileageEntries(data);
+	}
+
+	function renderMileageEmpty(data) {
+		const empty = document.getElementById('reportsEmpty');
+		empty.hidden = (data.entries.length > 0);
+		// Privacy note doesn't apply to mileage v1 (no hidden_private_count)
+		document.getElementById('reportsPrivacyNote').hidden = true;
+	}
+
+	function fmtMiles(m) {
+		const v = Math.round((m || 0) * 10) / 10;
+		return v.toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+	}
+	function fmtDollars(cents) {
+		return '$' + (cents / 100).toLocaleString(undefined, {
+			minimumFractionDigits: 2, maximumFractionDigits: 2,
+		});
+	}
+
+	function renderMileageRollup(data) {
+		const root = document.getElementById('reportsRollup');
+		const totals = data.totals || {};
+		if (!totals.count) {
+			root.innerHTML = '';
+			return;
+		}
+		// Project rollup — sorted by miles desc
+		const rows = Object.values(totals.by_project || {})
+			.sort((a, b) => b.miles - a.miles);
+		const totalCents = totals.cents || 0;
+		const totalMiles = totals.miles || 0;
+
+		const html = `
+			<div class="cd-reports-mileage-summary">
+				<span>${totals.count} trip${totals.count === 1 ? '' : 's'}</span>
+				<span>${fmtMiles(totalMiles)} mi</span>
+				<span>${fmtDollars(totalCents)}</span>
+				${totals.unsubmitted_cents > 0
+					? `<span class="cd-mileage-summary-pending">${fmtMiles(totals.unsubmitted_miles)} mi · ${fmtDollars(totals.unsubmitted_cents)} pending</span>`
+					: '<span class="cd-mileage-summary-clean">all submitted</span>'}
+				<a href="/command-deck/mileage/" class="cd-btn ghost sm">OPEN MILEAGE</a>
+				<button class="cd-btn sm" id="reportsMileageExport" type="button">EXPORT XLSX</button>
+			</div>
+			<table class="cd-reports-mileage-rollup">
+				<thead>
+					<tr><th>Project</th><th class="cd-num">Miles</th><th class="cd-num">$</th></tr>
+				</thead>
+				<tbody>
+					${rows.map((r) => `
+						<tr>
+							<td>${escapeHtml(r.title || '(no project)')}</td>
+							<td class="cd-num">${fmtMiles(r.miles)}</td>
+							<td class="cd-num">${fmtDollars(r.cents)}</td>
+						</tr>
+					`).join('')}
+				</tbody>
+			</table>
+		`;
+		root.innerHTML = html;
+		const expBtn = document.getElementById('reportsMileageExport');
+		if (expBtn) expBtn.addEventListener('click', () => {
+			const dates = resolveMileageDates();
+			const qs = new URLSearchParams();
+			if (dates.start) qs.set('start', dates.start);
+			if (dates.end) qs.set('end', dates.end);
+			if (localStorage.getItem('cdPrivateUnlocked') === '1') qs.set('include_private', '1');
+			window.location.href = '/command-deck/mileage/export.xlsx?' + qs.toString();
+		});
+	}
+
+	function renderMileageEntries(data) {
+		const body = document.getElementById('reportsEntriesBody');
+		// Replace the table headers when in mileage mode
+		const thead = document.querySelector('.cd-reports-entries-table thead');
+		thead.innerHTML = `
+			<tr>
+				<th>Date</th>
+				<th>Project</th>
+				<th>Trip</th>
+				<th class="cd-num">Miles</th>
+				<th class="cd-num">$</th>
+				<th>Status</th>
+				<th></th>
+			</tr>`;
+		const rows = data.entries.map((e) => {
+			const trip = e.from_location && e.to_location
+				? `${escapeHtml(e.from_location)} → ${escapeHtml(e.to_location)}${e.round_trip ? ' <span class="cd-mileage-roundtrip">↔</span>' : ''}`
+				: escapeHtml(e.description || '');
+			const status = e.is_submitted
+				? '<span class="cd-mileage-status submitted">submitted</span>'
+				: '<span class="cd-mileage-status pending">pending</span>';
+			return `
+				<tr data-id="${e.id}">
+					<td>${escapeHtml(e.date)}</td>
+					<td>${escapeHtml(e.project_title || '(no project)')}</td>
+					<td class="cd-mileage-trip">${trip}</td>
+					<td class="cd-num">${fmtMiles(e.miles)}</td>
+					<td class="cd-num">${fmtDollars(e.reimbursement_cents)}</td>
+					<td>${status}</td>
+					<td><a class="cd-btn ghost sm" href="/command-deck/mileage/${e.id}/edit">EDIT</a></td>
+				</tr>`;
+		}).join('');
+		body.innerHTML = rows || '<tr><td colspan="7" class="cd-reports-loading">No mileage in this range.</td></tr>';
+
+		// Replace the existing time-totals tfoot
+		const tfoot = document.querySelector('.cd-reports-entries-table tfoot tr');
+		const totals = data.totals || {};
+		tfoot.innerHTML = `
+			<td colspan="3" class="cd-reports-total-label">Total</td>
+			<td class="cd-num">${fmtMiles(totals.miles || 0)}</td>
+			<td class="cd-num">${fmtDollars(totals.cents || 0)}</td>
+			<td colspan="2"></td>
+		`;
 	}
 
 	// ---- Wiring ----
@@ -538,11 +711,41 @@
 		load();
 	}
 
+	function resetEntriesTableChrome() {
+		// Restore the time-mode thead/tfoot when leaving mileage mode.
+		const thead = document.querySelector('.cd-reports-entries-table thead');
+		thead.innerHTML = `
+			<tr>
+				<th>Day</th>
+				<th>Area</th>
+				<th>Project</th>
+				<th>Task / Item</th>
+				<th>Description</th>
+				<th>Start → End</th>
+				<th class="cd-num">Duration</th>
+			</tr>`;
+		const tfoot = document.querySelector('.cd-reports-entries-table tfoot tr');
+		tfoot.innerHTML = `
+			<td colspan="6" class="cd-reports-total-label">Total</td>
+			<td class="cd-num" id="reportsTotalDuration">—</td>
+		`;
+	}
+
 	function setGroup(group) {
 		if (!VALID_GROUPS.includes(group)) return;
+		const prevWasMileage = state.group === MILEAGE_GROUP;
 		state.group = group;
 		localStorage.setItem('reportsGroup', group);
-		// No re-fetch — the endpoint returns all four shapes.
+
+		// Mileage mode pulls from a different endpoint; switching to/from it
+		// requires a fresh fetch. The time tabs share one payload and just
+		// re-render client-side.
+		if (group === MILEAGE_GROUP || prevWasMileage) {
+			if (prevWasMileage && group !== MILEAGE_GROUP) resetEntriesTableChrome();
+			renderHeader();
+			load();
+			return;
+		}
 		renderHeader();
 		renderRollup();
 	}

--- a/templates/command_deck_area.html
+++ b/templates/command_deck_area.html
@@ -36,6 +36,8 @@
           <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
           <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
           <a href="/command-deck/meetings/" class="cd-nav-link">MEETINGS</a>
+          <a href="/command-deck/mileage/" class="cd-nav-link">MILEAGE</a>
+          <a href="/command-deck/settings/" class="cd-nav-link">SETTINGS</a>
         </div>
       </details>
       <span class="cd-nav-sep">·</span>

--- a/templates/command_deck_dashboard.html
+++ b/templates/command_deck_dashboard.html
@@ -33,6 +33,8 @@
           <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
           <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
           <a href="/command-deck/meetings/" class="cd-nav-link">MEETINGS</a>
+          <a href="/command-deck/mileage/" class="cd-nav-link">MILEAGE</a>
+          <a href="/command-deck/settings/" class="cd-nav-link">SETTINGS</a>
         </div>
       </details>
       <span class="cd-nav-sep">·</span>

--- a/templates/command_deck_dashboard.html
+++ b/templates/command_deck_dashboard.html
@@ -103,6 +103,17 @@
         </div>
       </div>
 
+      <!-- MILEAGE QUICK PANEL (Phase 3) -->
+      <div class="cd-panel cd-mb cd-mileage-quickpanel">
+        <div class="cd-panel-body cd-mileage-quickpanel-body">
+          <div class="cd-mileage-quickpanel-summary">
+            <span class="cd-panel-title">// Mileage</span>
+            <span class="cd-mileage-quickpanel-pending" id="mileageQuickPending">—</span>
+          </div>
+          <a href="/command-deck/mileage/new" class="cd-btn primary sm">+ LOG MILES</a>
+        </div>
+      </div>
+
       <!-- TODAY CALLOUT -->
       <div class="cd-panel cd-mb" id="todayCallout"
            data-today-count="{{ today_count }}"
@@ -397,6 +408,35 @@ function updateBadge() {
       else badge.classList.add('red');
     });
 }
+
+// ============================================================
+// MILEAGE QUICK PANEL (Phase 3) — show pending reimbursement count
+// ============================================================
+function updateMileageQuickPanel() {
+  const el = document.getElementById('mileageQuickPending');
+  if (!el) return;
+  fetch('/command-deck/mileage/data?status=unsubmitted', { credentials: 'same-origin' })
+    .then(r => r.ok ? r.json() : null)
+    .then(data => {
+      if (!data) return;
+      const t = data.totals || {};
+      if (!t.count) {
+        el.textContent = 'all caught up';
+        el.classList.add('cd-mileage-quickpanel-clean');
+        return;
+      }
+      const dollars = '$' + (t.cents / 100).toLocaleString(undefined, {
+        minimumFractionDigits: 2, maximumFractionDigits: 2
+      });
+      const miles = (Math.round(t.miles * 10) / 10).toLocaleString(undefined, {
+        minimumFractionDigits: 1, maximumFractionDigits: 1
+      });
+      el.textContent = `${t.count} pending · ${miles} mi · ${dollars}`;
+      el.classList.remove('cd-mileage-quickpanel-clean');
+    })
+    .catch(() => { el.textContent = ''; });
+}
+updateMileageQuickPanel();
 
 (function() {
   let selectedTag = null;

--- a/templates/command_deck_meeting.html
+++ b/templates/command_deck_meeting.html
@@ -34,6 +34,8 @@
           <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
           <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
           <a href="/command-deck/meetings/" class="cd-nav-link">MEETINGS</a>
+          <a href="/command-deck/mileage/" class="cd-nav-link">MILEAGE</a>
+          <a href="/command-deck/settings/" class="cd-nav-link">SETTINGS</a>
         </div>
       </details>
       <span class="cd-nav-sep">·</span>

--- a/templates/command_deck_meetings.html
+++ b/templates/command_deck_meetings.html
@@ -33,6 +33,8 @@
           <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
           <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
           <a href="/command-deck/meetings/" class="cd-nav-link">MEETINGS</a>
+          <a href="/command-deck/mileage/" class="cd-nav-link">MILEAGE</a>
+          <a href="/command-deck/settings/" class="cd-nav-link">SETTINGS</a>
         </div>
       </details>
       <span class="cd-nav-sep">·</span>

--- a/templates/command_deck_mileage.html
+++ b/templates/command_deck_mileage.html
@@ -1,0 +1,341 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <title>Mileage · Command Deck</title>
+  <link rel="stylesheet" href="/static/command_deck.css">
+</head>
+<body class="command-deck">
+<div class="cd-shell">
+
+  <!-- HEADER -->
+  <header class="cd-header">
+    <div class="cd-header-left">
+      <a href="/command-deck/" class="cd-wordmark">COMMAND DECK</a>
+      <span class="cd-ident">MILEAGE · LOG</span>
+    </div>
+    <nav class="cd-header-nav">
+      <a href="/command-deck/" class="cd-nav-link">BRIDGE</a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/command-deck/projects/" class="cd-nav-link">PROJECTS</a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/below-deck" class="cd-nav-link">
+        BELOW DECK
+        <span class="cd-bd-badge" id="bdBadge"></span>
+      </a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/today/" class="cd-nav-link">TODAY</a>
+      <span class="cd-nav-sep">·</span>
+      <details class="cd-nav-more">
+        <summary class="cd-nav-link cd-nav-more-trigger">MORE ▾</summary>
+        <div class="cd-nav-more-menu">
+          <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
+          <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+          <a href="/command-deck/meetings/" class="cd-nav-link">MEETINGS</a>
+          <a href="/command-deck/mileage/" class="cd-nav-link">MILEAGE</a>
+          <a href="/command-deck/settings/" class="cd-nav-link">SETTINGS</a>
+        </div>
+      </details>
+      <span class="cd-nav-sep">·</span>
+      <a href="/publish" class="cd-nav-link">COCKPIT</a>
+    </nav>
+  </header>
+
+  {% include 'includes/today_panel.html' %}
+  {% include 'includes/active_timer_strip.html' %}
+
+  <div class="cd-main full-width">
+
+    <!-- TITLE + ACTIONS -->
+    <section class="cd-mileage-controls">
+      <h1 class="cd-page-title">// Mileage</h1>
+      <div class="cd-mileage-actions">
+        <a href="/command-deck/mileage/new" class="cd-btn primary">+ LOG MILES</a>
+        <button class="cd-btn" id="exportXlsxBtn" type="button">EXPORT XLSX</button>
+      </div>
+    </section>
+
+    <!-- FILTERS -->
+    <section class="cd-mileage-filters">
+      <label class="cd-mileage-filter">
+        <span>From</span>
+        <input type="date" id="filterStart" class="cd-input">
+      </label>
+      <label class="cd-mileage-filter">
+        <span>To</span>
+        <input type="date" id="filterEnd" class="cd-input">
+      </label>
+      <label class="cd-mileage-filter">
+        <span>Project</span>
+        <select id="filterProject" class="cd-input">
+          <option value="">All</option>
+          {% for p in projects %}
+            <option value="{{ p.id }}">{{ p.title }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <div class="cd-mileage-status-pills" role="tablist" aria-label="Reimbursement status">
+        <button class="cd-mileage-status-pill active" data-status="all" type="button">All</button>
+        <button class="cd-mileage-status-pill" data-status="unsubmitted" type="button">Unsubmitted</button>
+        <button class="cd-mileage-status-pill" data-status="submitted" type="button">Submitted</button>
+      </div>
+    </section>
+
+    <!-- SUMMARY -->
+    <section class="cd-mileage-summary" id="mileageSummary">
+      <span class="cd-mileage-summary-loading">loading…</span>
+    </section>
+
+    <!-- BULK ACTIONS BAR (visible when entries selected) -->
+    <section class="cd-mileage-bulkbar" id="bulkBar" hidden>
+      <span id="bulkCount">0 selected</span>
+      <button class="cd-btn primary sm" id="bulkSubmitBtn" type="button">MARK SUBMITTED</button>
+      <button class="cd-btn ghost sm" id="bulkUnsubmitBtn" type="button">MARK UNSUBMITTED</button>
+      <button class="cd-btn ghost sm" id="bulkClearBtn" type="button">Clear</button>
+    </section>
+
+    <!-- ENTRIES TABLE -->
+    <section class="cd-mileage-entries">
+      <table class="cd-mileage-table">
+        <thead>
+          <tr>
+            <th class="cd-mileage-check-col"><input type="checkbox" id="selectAll" aria-label="Select all"></th>
+            <th>Date</th>
+            <th>Project</th>
+            <th>Trip</th>
+            <th class="cd-num">Miles</th>
+            <th class="cd-num">$</th>
+            <th>Status</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody id="mileageBody">
+          <tr><td colspan="8" class="cd-mileage-loading">loading…</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+  </div><!-- .cd-main -->
+
+  <!-- FOOTER -->
+  <footer class="cd-footer">
+    <div class="cd-footer-links">
+      <a href="/command-deck/" class="cd-footer-link">Bridge</a>
+      <a href="/command-deck/mileage/new" class="cd-footer-link">+ Log miles</a>
+      <a href="/command-deck/settings/" class="cd-footer-link">Settings</a>
+    </div>
+    {% include 'includes/cd_footer_status.html' %}
+    <span class="cd-footer-ident">YT-1300F · COMMAND DECK · SECURE</span>
+  </footer>
+
+</div><!-- .cd-shell -->
+
+<script>
+(function () {
+  fetch('/below-deck/count').then(r=>r.json()).then(d=>{
+    var b=document.getElementById('bdBadge');
+    if(!b||d.count===0)return;
+    b.classList.add(d.count<=3?'green':d.count<=6?'amber':'red');
+  });
+
+  var INCLUDE_PRIVATE = false;  // wired up by 🔒 unlock if needed; default off
+
+  function escHtml(s) {
+    var d = document.createElement('div');
+    d.appendChild(document.createTextNode(s == null ? '' : String(s)));
+    return d.innerHTML;
+  }
+  function fmtDollars(cents) {
+    return '$' + (cents / 100).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  }
+  function fmtMiles(m) {
+    var v = (Math.round((m || 0) * 10) / 10);
+    return v.toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+  }
+  function fmtDate(iso) {
+    if (!iso) return '';
+    var d = new Date(iso + 'T00:00:00');
+    if (isNaN(d.getTime())) return iso;
+    return d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+  }
+
+  var state = {
+    status: 'all',
+    project: '',
+    start: '',
+    end: '',
+    selected: new Set(),
+    entries: [],
+  };
+
+  function buildQuery() {
+    var qs = new URLSearchParams();
+    if (state.status && state.status !== 'all') qs.set('status', state.status);
+    if (state.project) qs.set('project', state.project);
+    if (state.start) qs.set('start', state.start);
+    if (state.end) qs.set('end', state.end);
+    if (INCLUDE_PRIVATE) qs.set('include_private', '1');
+    return qs.toString();
+  }
+
+  function renderSummary(totals) {
+    var sum = document.getElementById('mileageSummary');
+    if (!totals.count) {
+      sum.innerHTML = '<span class="cd-mileage-summary-empty">No mileage in this range.</span>';
+      return;
+    }
+    var parts = [
+      totals.count + ' trip' + (totals.count === 1 ? '' : 's'),
+      fmtMiles(totals.miles) + ' mi',
+      fmtDollars(totals.cents),
+    ];
+    if (totals.unsubmitted_cents > 0) {
+      parts.push('<span class="cd-mileage-summary-pending">' +
+        fmtMiles(totals.unsubmitted_miles) + ' mi · ' + fmtDollars(totals.unsubmitted_cents) +
+        ' pending</span>');
+    }
+    sum.innerHTML = parts.join(' · ');
+  }
+
+  function renderEntries(entries) {
+    state.entries = entries;
+    var body = document.getElementById('mileageBody');
+    if (!entries.length) {
+      body.innerHTML = '<tr><td colspan="8" class="cd-mileage-empty">No trips match these filters.</td></tr>';
+      return;
+    }
+    body.innerHTML = entries.map(function (e) {
+      var trip = '';
+      if (e.from_location && e.to_location) trip = escHtml(e.from_location) + ' → ' + escHtml(e.to_location);
+      else if (e.from_location) trip = escHtml(e.from_location);
+      else if (e.to_location) trip = '→ ' + escHtml(e.to_location);
+      else trip = escHtml(e.description || '');
+      if (e.round_trip) trip += ' <span class="cd-mileage-roundtrip">↔</span>';
+      var statusPill = e.is_submitted
+        ? '<button class="cd-mileage-status submitted" data-id="' + e.id + '" data-action="toggle" type="button">submitted</button>'
+        : '<button class="cd-mileage-status pending" data-id="' + e.id + '" data-action="toggle" type="button">pending</button>';
+      return '<tr data-id="' + e.id + '"' + (e.is_submitted ? ' class="is-submitted"' : '') + '>' +
+        '<td><input type="checkbox" class="cd-mileage-row-check" data-id="' + e.id + '"' + (state.selected.has(e.id) ? ' checked' : '') + '></td>' +
+        '<td>' + fmtDate(e.date) + '</td>' +
+        '<td>' + escHtml(e.project_title || '(no project)') + '</td>' +
+        '<td class="cd-mileage-trip">' + trip + '</td>' +
+        '<td class="cd-num">' + fmtMiles(e.miles) + '</td>' +
+        '<td class="cd-num">' + fmtDollars(e.reimbursement_cents) + '</td>' +
+        '<td>' + statusPill + '</td>' +
+        '<td><a class="cd-btn ghost sm" href="/command-deck/mileage/' + e.id + '/edit">EDIT</a></td>' +
+        '</tr>';
+    }).join('');
+  }
+
+  function refreshBulkBar() {
+    var bar = document.getElementById('bulkBar');
+    if (state.selected.size === 0) { bar.setAttribute('hidden', ''); return; }
+    bar.removeAttribute('hidden');
+    document.getElementById('bulkCount').textContent = state.selected.size + ' selected';
+  }
+
+  function load() {
+    fetch('/command-deck/mileage/data?' + buildQuery(), { credentials: 'same-origin' })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (data) {
+        if (!data) return;
+        renderSummary(data.totals);
+        renderEntries(data.entries);
+      });
+  }
+
+  // ---- Filter wires ----
+  document.getElementById('filterStart').addEventListener('change', function (e) { state.start = e.target.value; load(); });
+  document.getElementById('filterEnd').addEventListener('change', function (e) { state.end = e.target.value; load(); });
+  document.getElementById('filterProject').addEventListener('change', function (e) { state.project = e.target.value; load(); });
+  document.querySelectorAll('.cd-mileage-status-pill').forEach(function (p) {
+    p.addEventListener('click', function () {
+      document.querySelectorAll('.cd-mileage-status-pill').forEach(function (x) { x.classList.remove('active'); });
+      p.classList.add('active');
+      state.status = p.dataset.status;
+      load();
+    });
+  });
+
+  // ---- Row interactions (delegated) ----
+  document.getElementById('mileageBody').addEventListener('click', function (ev) {
+    var t = ev.target;
+    if (t.classList.contains('cd-mileage-status') && t.dataset.action === 'toggle') {
+      var id = parseInt(t.dataset.id, 10);
+      var entry = state.entries.find(function (e) { return e.id === id; });
+      var willBeSubmitted = !entry.is_submitted;
+      if (entry.is_submitted && !confirm('Un-submit this trip?')) return;
+      fetch('/command-deck/mileage/' + id + '/submit', {
+        method: 'POST', credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ submitted: willBeSubmitted ? 1 : 0 }),
+      }).then(function (r) { return r.json(); }).then(function (d) {
+        if (d.success) load();
+      });
+      return;
+    }
+  });
+  document.getElementById('mileageBody').addEventListener('change', function (ev) {
+    var t = ev.target;
+    if (t.classList.contains('cd-mileage-row-check')) {
+      var id = parseInt(t.dataset.id, 10);
+      if (t.checked) state.selected.add(id);
+      else state.selected.delete(id);
+      refreshBulkBar();
+    }
+  });
+
+  document.getElementById('selectAll').addEventListener('change', function (e) {
+    var checked = e.target.checked;
+    state.entries.forEach(function (entry) {
+      if (checked) state.selected.add(entry.id);
+      else state.selected.delete(entry.id);
+    });
+    document.querySelectorAll('.cd-mileage-row-check').forEach(function (cb) { cb.checked = checked; });
+    refreshBulkBar();
+  });
+
+  // ---- Bulk actions ----
+  function bulkSubmit(toState) {
+    if (state.selected.size === 0) return;
+    if (state.selected.size > 5) {
+      var verb = toState ? 'mark submitted' : 'mark unsubmitted';
+      if (!confirm('You are about to ' + verb + ' on ' + state.selected.size + ' trips. Continue?')) return;
+    }
+    fetch('/command-deck/mileage/bulk-submit', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: Array.from(state.selected), submitted: toState ? 1 : 0 }),
+    }).then(function (r) { return r.json(); }).then(function (d) {
+      if (d.success) {
+        state.selected.clear();
+        document.getElementById('selectAll').checked = false;
+        refreshBulkBar();
+        load();
+      }
+    });
+  }
+  document.getElementById('bulkSubmitBtn').addEventListener('click', function () { bulkSubmit(true); });
+  document.getElementById('bulkUnsubmitBtn').addEventListener('click', function () { bulkSubmit(false); });
+  document.getElementById('bulkClearBtn').addEventListener('click', function () {
+    state.selected.clear();
+    document.querySelectorAll('.cd-mileage-row-check').forEach(function (cb) { cb.checked = false; });
+    document.getElementById('selectAll').checked = false;
+    refreshBulkBar();
+  });
+
+  // ---- xlsx export — passes current filters through ----
+  document.getElementById('exportXlsxBtn').addEventListener('click', function () {
+    var qs = buildQuery();
+    var url = '/command-deck/mileage/export.xlsx' + (qs ? '?' + qs : '');
+    window.location.href = url;
+  });
+
+  load();
+})();
+</script>
+<script src="/static/command_deck_nav.js"></script>
+</body>
+</html>

--- a/templates/command_deck_mileage_form.html
+++ b/templates/command_deck_mileage_form.html
@@ -1,0 +1,271 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <title>{% if mode == 'edit' %}Edit trip{% else %}Log miles{% endif %} · Command Deck</title>
+  <link rel="stylesheet" href="/static/command_deck.css">
+</head>
+<body class="command-deck">
+<div class="cd-shell">
+
+  <!-- HEADER -->
+  <header class="cd-header">
+    <div class="cd-header-left">
+      <a href="/command-deck/" class="cd-wordmark">COMMAND DECK</a>
+      <span class="cd-ident">MILEAGE · {% if mode == 'edit' %}EDIT{% else %}LOG{% endif %}</span>
+    </div>
+    <nav class="cd-header-nav">
+      <a href="/command-deck/" class="cd-nav-link">BRIDGE</a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/command-deck/mileage/" class="cd-nav-link">MILEAGE</a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/command-deck/settings/" class="cd-nav-link">SETTINGS</a>
+    </nav>
+  </header>
+
+  <div class="cd-main full-width">
+
+    <div class="cd-breadcrumb">
+      <a href="/command-deck/mileage/">Mileage</a>
+      <span class="cd-breadcrumb-sep">›</span>
+      <span class="cd-breadcrumb-tail">{% if mode == 'edit' %}Edit trip{% else %}New trip{% endif %}</span>
+    </div>
+
+    <h1 class="cd-page-title">// {% if mode == 'edit' %}Edit trip{% else %}Log miles{% endif %}</h1>
+
+    <form id="mileageForm" class="cd-mileage-form" method="POST"
+          action="{% if mode == 'edit' %}/command-deck/mileage/{{ entry.id }}/update{% else %}/command-deck/mileage/new{% endif %}">
+
+      <!-- PROJECT -->
+      <label class="cd-mileage-field">
+        <span class="cd-mileage-field-label">Project</span>
+        <select name="project_id" class="cd-input cd-mileage-input" id="projectField" required>
+          <option value="">— pick a project —</option>
+          {% for p in projects %}
+            {% if mode == 'edit' %}
+              <option value="{{ p.id }}" {% if entry.project_id == p.id %}selected{% endif %}>{{ p.title }}</option>
+            {% else %}
+              <option value="{{ p.id }}"
+                {% if query_project_id and query_project_id == p.id %}selected
+                {% elif (not query_project_id) and settings.default_mileage_project_id == p.id %}selected{% endif %}>{{ p.title }}</option>
+            {% endif %}
+          {% endfor %}
+        </select>
+      </label>
+
+      <!-- DATE -->
+      <label class="cd-mileage-field">
+        <span class="cd-mileage-field-label">Date</span>
+        <input type="date" name="date" class="cd-input cd-mileage-input" id="dateField"
+               value="{% if mode == 'edit' %}{{ entry.date }}{% endif %}" required>
+      </label>
+
+      <!-- DESCRIPTION -->
+      <label class="cd-mileage-field">
+        <span class="cd-mileage-field-label">Description</span>
+        <input type="text" name="description" class="cd-input cd-mileage-input"
+               placeholder="Vendor sync at PennDOT HQ"
+               value="{% if mode == 'edit' %}{{ entry.description or '' }}{% endif %}">
+      </label>
+
+      <!-- FROM / TO -->
+      <div class="cd-mileage-field-pair">
+        <label class="cd-mileage-field">
+          <span class="cd-mileage-field-label">From</span>
+          <input type="text" name="from_location" class="cd-input cd-mileage-input"
+                 placeholder="Office"
+                 value="{% if mode == 'edit' %}{{ entry.from_location or '' }}{% endif %}">
+        </label>
+        <label class="cd-mileage-field">
+          <span class="cd-mileage-field-label">To</span>
+          <input type="text" name="to_location" class="cd-input cd-mileage-input"
+                 placeholder="Vendor HQ"
+                 value="{% if mode == 'edit' %}{{ entry.to_location or '' }}{% endif %}">
+        </label>
+      </div>
+
+      <!-- ROUND TRIP -->
+      <label class="cd-mileage-checkbox">
+        <input type="checkbox" name="round_trip" id="roundTripField" value="1"
+               {% if mode == 'edit' and entry.round_trip %}checked{% endif %}>
+        <span>Round trip</span>
+        <span class="cd-mileage-hint">— odometer values are one-way; check to double miles</span>
+      </label>
+
+      <!-- ODOMETER -->
+      <div class="cd-mileage-field-pair">
+        <label class="cd-mileage-field">
+          <span class="cd-mileage-field-label">Odometer start</span>
+          <input type="number" name="odometer_start" inputmode="decimal" step="0.1"
+                 class="cd-input cd-mileage-input" id="odoStartField"
+                 value="{% if mode == 'edit' and entry.odometer_start is not none %}{{ entry.odometer_start }}{% endif %}">
+        </label>
+        <label class="cd-mileage-field">
+          <span class="cd-mileage-field-label">Odometer end</span>
+          <input type="number" name="odometer_end" inputmode="decimal" step="0.1"
+                 class="cd-input cd-mileage-input" id="odoEndField"
+                 value="{% if mode == 'edit' and entry.odometer_end is not none %}{{ entry.odometer_end }}{% endif %}">
+        </label>
+      </div>
+
+      <!-- MILES (calculated, overrideable) -->
+      <label class="cd-mileage-field">
+        <span class="cd-mileage-field-label">Miles</span>
+        <input type="number" name="miles" inputmode="decimal" step="0.1" min="0"
+               class="cd-input cd-mileage-input cd-mileage-input-miles" id="milesField"
+               value="{% if mode == 'edit' %}{{ entry.miles }}{% endif %}" required>
+        <span class="cd-mileage-hint" id="milesHint">— autocalculates from odometer; tap to override</span>
+      </label>
+
+      <!-- RATE + VEHICLE -->
+      <div class="cd-mileage-field-pair">
+        <label class="cd-mileage-field">
+          <span class="cd-mileage-field-label">Rate ($/mi)</span>
+          <input type="number" name="rate_cents" inputmode="decimal" step="0.001" min="0"
+                 class="cd-input cd-mileage-input"
+                 id="rateField"
+                 data-cents="1"
+                 value="{% if mode == 'edit' %}{{ '%.4f' % (entry.rate_cents / 100.0) }}{% else %}{{ '%.4f' % (settings.reimbursement_rate_cents / 100.0) }}{% endif %}">
+        </label>
+        <label class="cd-mileage-field">
+          <span class="cd-mileage-field-label">Vehicle</span>
+          <select name="vehicle" class="cd-input cd-mileage-input" id="vehicleField">
+            <option value="a"
+              {% if mode == 'edit' and entry.vehicle == 'a' %}selected
+              {% elif (not entry) and settings.default_vehicle == 'a' %}selected{% endif %}>{{ settings.vehicle_a_label or 'Vehicle A' }}</option>
+            <option value="b"
+              {% if mode == 'edit' and entry.vehicle == 'b' %}selected
+              {% elif (not entry) and settings.default_vehicle == 'b' %}selected{% endif %}>{{ settings.vehicle_b_label or 'Vehicle B' }}</option>
+          </select>
+        </label>
+      </div>
+
+      <!-- NOTES -->
+      <label class="cd-mileage-field">
+        <span class="cd-mileage-field-label">Notes</span>
+        <textarea name="notes" class="cd-input cd-mileage-input" rows="2"
+                  placeholder="(optional)">{% if mode == 'edit' %}{{ entry.notes or '' }}{% endif %}</textarea>
+      </label>
+
+      <!-- ACTIONS -->
+      <div class="cd-mileage-form-actions">
+        <a class="cd-btn ghost" href="/command-deck/mileage/">CANCEL</a>
+        {% if mode == 'edit' %}
+          <button type="button" class="cd-btn ghost cd-mileage-delete-btn" id="deleteBtn">DELETE</button>
+          <button type="submit" class="cd-btn primary">SAVE</button>
+        {% else %}
+          <button type="submit" class="cd-btn primary">LOG TRIP</button>
+        {% endif %}
+      </div>
+
+      <!-- Hidden flag so the new-entry POST redirects to the index -->
+      {% if mode == 'new' %}<input type="hidden" name="return" value="redirect">{% endif %}
+    </form>
+
+    {% if mode == 'edit' and entry.is_submitted %}
+      <p class="cd-mileage-submitted-note">
+        Submitted on {{ entry.submitted_at[:10] }}. Edits won't change the submitted state.
+      </p>
+    {% endif %}
+
+  </div><!-- .cd-main -->
+
+  <footer class="cd-footer">
+    <div class="cd-footer-links">
+      <a href="/command-deck/mileage/" class="cd-footer-link">Back to mileage</a>
+    </div>
+    {% include 'includes/cd_footer_status.html' %}
+    <span class="cd-footer-ident">YT-1300F · COMMAND DECK · SECURE</span>
+  </footer>
+
+</div><!-- .cd-shell -->
+
+<script>
+const FORM_MODE = {{ mode | tojson }};
+const ENTRY_ID = {{ (entry.id if entry else 0) | tojson }};
+{% if mode == 'edit' %}const ENTRY = {{ entry | tojson }};{% else %}const ENTRY = null;{% endif %}
+
+(function () {
+  // ---- Live miles calculation ----
+  var odoStart = document.getElementById('odoStartField');
+  var odoEnd = document.getElementById('odoEndField');
+  var miles = document.getElementById('milesField');
+  var roundTrip = document.getElementById('roundTripField');
+  var milesEdited = (FORM_MODE === 'edit');  // edit mode = trust the stored miles; new mode = autocalculate
+
+  function recalcMiles() {
+    if (milesEdited) return;
+    var s = parseFloat(odoStart.value);
+    var e = parseFloat(odoEnd.value);
+    if (isNaN(s) || isNaN(e)) return;
+    var diff = e - s;
+    if (diff < 0) return;
+    var calc = roundTrip.checked ? diff * 2 : diff;
+    miles.value = (Math.round(calc * 10) / 10).toString();
+  }
+  odoStart.addEventListener('input', recalcMiles);
+  odoEnd.addEventListener('input', recalcMiles);
+  roundTrip.addEventListener('change', recalcMiles);
+  miles.addEventListener('input', function () { milesEdited = true; });
+
+  // ---- Default date to today on new ----
+  var dateField = document.getElementById('dateField');
+  if (FORM_MODE === 'new' && !dateField.value) {
+    var d = new Date();
+    var pad = function (n) { return n < 10 ? '0' + n : '' + n; };
+    dateField.value = d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate());
+  }
+
+  // ---- Convert rate from $/mi (form) to cents (server) on submit ----
+  var form = document.getElementById('mileageForm');
+  var rateField = document.getElementById('rateField');
+  form.addEventListener('submit', function (ev) {
+    var dollars = parseFloat(rateField.value);
+    if (isNaN(dollars) || dollars < 0) {
+      ev.preventDefault();
+      alert('Rate must be a positive number.');
+      return;
+    }
+    rateField.value = Math.round(dollars * 100);
+
+    // For edit mode, hijack to JSON PATCH so we can stay on the page if needed
+    // — but for now just POST normally; server returns JSON 200 we ignore.
+    if (FORM_MODE === 'edit') {
+      ev.preventDefault();
+      var fd = new FormData(form);
+      var payload = {};
+      fd.forEach(function (val, key) {
+        if (key === 'round_trip') payload[key] = '1';
+        else payload[key] = val;
+      });
+      // Checkbox not in FormData when unchecked
+      if (!fd.has('round_trip')) payload.round_trip = '0';
+
+      fetch('/command-deck/mileage/' + ENTRY_ID + '/update', {
+        method: 'POST', credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      }).then(function (r) { return r.json(); }).then(function (d) {
+        if (d.success) window.location.href = '/command-deck/mileage/';
+        else alert('Save failed: ' + (d.error || 'unknown'));
+      });
+    }
+  });
+
+  // ---- Delete (edit mode only) ----
+  var deleteBtn = document.getElementById('deleteBtn');
+  if (deleteBtn) {
+    deleteBtn.addEventListener('click', function () {
+      if (!confirm('Delete this trip? This cannot be undone.')) return;
+      fetch('/command-deck/mileage/' + ENTRY_ID + '/delete', {
+        method: 'POST', credentials: 'same-origin',
+      }).then(function (r) { return r.json(); }).then(function (d) {
+        if (d.success) window.location.href = '/command-deck/mileage/';
+      });
+    });
+  }
+})();
+</script>
+</body>
+</html>

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -35,6 +35,8 @@
           <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
           <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
           <a href="/command-deck/meetings/" class="cd-nav-link">MEETINGS</a>
+          <a href="/command-deck/mileage/" class="cd-nav-link">MILEAGE</a>
+          <a href="/command-deck/settings/" class="cd-nav-link">SETTINGS</a>
         </div>
       </details>
       <span class="cd-nav-sep">·</span>

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -295,6 +295,44 @@
         </div>
       </div>
 
+      <!-- MILEAGE -->
+      <div class="cd-panel cd-mb">
+        <div class="cd-panel-header">
+          <span class="cd-panel-title">// Mileage</span>
+          <div class="cd-panel-actions">
+            {% if mileage_totals.count > 0 %}
+              <span class="cd-mileage-project-summary">
+                {{ '%.1f' % mileage_totals.miles }} mi · ${{ '%.2f' % (mileage_totals.cents / 100.0) }}{% if mileage_totals.unsubmitted_cents > 0 %} · <span class="cd-mileage-summary-pending">${{ '%.2f' % (mileage_totals.unsubmitted_cents / 100.0) }} pending</span>{% endif %}
+              </span>
+              <a href="/command-deck/mileage/?project={{ project.id }}" class="cd-btn ghost sm">VIEW ALL</a>
+            {% endif %}
+            <a href="/command-deck/mileage/new?project_id={{ project.id }}" class="cd-btn primary sm">+ LOG MILES</a>
+          </div>
+        </div>
+        <div class="cd-panel-body">
+          {% if mileage_recent %}
+            <ul class="cd-project-mileage-list">
+              {% for m in mileage_recent %}
+                <li class="cd-project-mileage-row">
+                  <a class="cd-project-mileage-link" href="/command-deck/mileage/{{ m.id }}/edit">
+                    <span class="cd-project-mileage-date">{{ m.date }}</span>
+                    <span class="cd-project-mileage-trip">
+                      {% if m.from_location and m.to_location %}{{ m.from_location }} → {{ m.to_location }}{% if m.round_trip %} <span class="cd-mileage-roundtrip">↔</span>{% endif %}{% else %}{{ m.description or 'Trip' }}{% endif %}
+                    </span>
+                    <span class="cd-project-mileage-miles">{{ '%.1f' % m.miles }} mi</span>
+                    <span class="cd-project-mileage-status {% if m.submitted_at %}submitted{% else %}pending{% endif %}">
+                      {% if m.submitted_at %}submitted{% else %}pending{% endif %}
+                    </span>
+                  </a>
+                </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <div class="cd-empty">No mileage logged for this project yet.</div>
+          {% endif %}
+        </div>
+      </div>
+
       <!-- FILES -->
       <div class="cd-panel cd-mb">
         <div class="cd-panel-header">

--- a/templates/command_deck_projects.html
+++ b/templates/command_deck_projects.html
@@ -33,6 +33,8 @@
           <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
           <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
           <a href="/command-deck/meetings/" class="cd-nav-link">MEETINGS</a>
+          <a href="/command-deck/mileage/" class="cd-nav-link">MILEAGE</a>
+          <a href="/command-deck/settings/" class="cd-nav-link">SETTINGS</a>
         </div>
       </details>
       <span class="cd-nav-sep">·</span>

--- a/templates/command_deck_reports.html
+++ b/templates/command_deck_reports.html
@@ -80,6 +80,7 @@
         <button class="cd-reports-group" data-group="project">Project</button>
         <button class="cd-reports-group" data-group="day">Day</button>
         <button class="cd-reports-group" data-group="timesheet">Timesheet</button>
+        <button class="cd-reports-group" data-group="mileage">Mileage</button>
       </div>
 
     </section>

--- a/templates/command_deck_reports.html
+++ b/templates/command_deck_reports.html
@@ -33,6 +33,8 @@
           <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
           <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
           <a href="/command-deck/meetings/" class="cd-nav-link">MEETINGS</a>
+          <a href="/command-deck/mileage/" class="cd-nav-link">MILEAGE</a>
+          <a href="/command-deck/settings/" class="cd-nav-link">SETTINGS</a>
         </div>
       </details>
       <span class="cd-nav-sep">·</span>

--- a/templates/command_deck_settings.html
+++ b/templates/command_deck_settings.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <title>Settings · Command Deck</title>
+  <link rel="stylesheet" href="/static/command_deck.css">
+</head>
+<body class="command-deck">
+<div class="cd-shell">
+
+  <!-- HEADER -->
+  <header class="cd-header">
+    <div class="cd-header-left">
+      <a href="/command-deck/" class="cd-wordmark">COMMAND DECK</a>
+      <span class="cd-ident">SETTINGS · CONFIG</span>
+    </div>
+    <nav class="cd-header-nav">
+      <a href="/command-deck/" class="cd-nav-link">BRIDGE</a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/command-deck/projects/" class="cd-nav-link">PROJECTS</a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/below-deck" class="cd-nav-link">
+        BELOW DECK
+        <span class="cd-bd-badge" id="bdBadge"></span>
+      </a>
+      <span class="cd-nav-sep">·</span>
+      <a href="/today/" class="cd-nav-link">TODAY</a>
+      <span class="cd-nav-sep">·</span>
+      <details class="cd-nav-more">
+        <summary class="cd-nav-link cd-nav-more-trigger">MORE ▾</summary>
+        <div class="cd-nav-more-menu">
+          <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
+          <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
+          <a href="/command-deck/meetings/" class="cd-nav-link">MEETINGS</a>
+          <a href="/command-deck/mileage/" class="cd-nav-link">MILEAGE</a>
+          <a href="/command-deck/settings/" class="cd-nav-link">SETTINGS</a>
+        </div>
+      </details>
+      <span class="cd-nav-sep">·</span>
+      <a href="/publish" class="cd-nav-link">COCKPIT</a>
+    </nav>
+  </header>
+
+  {% include 'includes/today_panel.html' %}
+  {% include 'includes/active_timer_strip.html' %}
+
+  <div class="cd-main full-width">
+
+    <h1 class="cd-page-title">// Settings</h1>
+
+    <p class="cd-settings-intro">
+      Defaults that flow into the mileage form, time tracking labels, and the
+      Phase 4 idle detector. Changes save on each field's blur or change event.
+    </p>
+
+    <form id="settingsForm" class="cd-settings-form" onsubmit="return false;">
+
+      <section class="cd-settings-section">
+        <h2 class="cd-settings-section-title">// Mileage</h2>
+
+        <label class="cd-settings-row">
+          <span class="cd-settings-label">Reimbursement rate</span>
+          <span class="cd-settings-input-row">
+            <span class="cd-settings-prefix">$</span>
+            <input type="number" inputmode="decimal" step="0.01" min="0"
+                   class="cd-input cd-settings-input cd-settings-input-narrow"
+                   id="rate"
+                   data-field="reimbursement_rate_cents"
+                   data-cents="1"
+                   value="{{ '%.4f' % (settings.reimbursement_rate_cents / 100.0) }}">
+            <span class="cd-settings-suffix">/ mi</span>
+          </span>
+        </label>
+
+        <label class="cd-settings-row">
+          <span class="cd-settings-label">Default mileage project</span>
+          <select class="cd-input cd-settings-input"
+                  id="defaultMileageProject"
+                  data-field="default_mileage_project_id">
+            <option value="">— none —</option>
+            {% for p in projects %}
+              <option value="{{ p.id }}" {% if settings.default_mileage_project_id == p.id %}selected{% endif %}>{{ p.title }}</option>
+            {% endfor %}
+          </select>
+        </label>
+      </section>
+
+      <section class="cd-settings-section">
+        <h2 class="cd-settings-section-title">// Vehicles</h2>
+
+        <label class="cd-settings-row">
+          <span class="cd-settings-label">Vehicle A label</span>
+          <input type="text" class="cd-input cd-settings-input"
+                 id="vehicleA"
+                 data-field="vehicle_a_label"
+                 value="{{ settings.vehicle_a_label }}">
+        </label>
+
+        <label class="cd-settings-row">
+          <span class="cd-settings-label">Vehicle B label</span>
+          <input type="text" class="cd-input cd-settings-input"
+                 id="vehicleB"
+                 data-field="vehicle_b_label"
+                 value="{{ settings.vehicle_b_label }}">
+        </label>
+
+        <label class="cd-settings-row">
+          <span class="cd-settings-label">Default vehicle</span>
+          <select class="cd-input cd-settings-input"
+                  id="defaultVehicle"
+                  data-field="default_vehicle">
+            <option value="a" {% if settings.default_vehicle == 'a' %}selected{% endif %}>{{ settings.vehicle_a_label }}</option>
+            <option value="b" {% if settings.default_vehicle == 'b' %}selected{% endif %}>{{ settings.vehicle_b_label }}</option>
+          </select>
+        </label>
+      </section>
+
+      <section class="cd-settings-section">
+        <h2 class="cd-settings-section-title">// Time Tracking</h2>
+
+        <label class="cd-settings-row">
+          <span class="cd-settings-label">Idle threshold</span>
+          <span class="cd-settings-input-row">
+            <input type="number" inputmode="numeric" step="1" min="1" max="480"
+                   class="cd-input cd-settings-input cd-settings-input-narrow"
+                   id="idleThreshold"
+                   data-field="idle_threshold_minutes"
+                   value="{{ settings.idle_threshold_minutes }}">
+            <span class="cd-settings-suffix">minutes (Phase 4)</span>
+          </span>
+        </label>
+      </section>
+
+      <div class="cd-settings-saved" id="settingsSaved" hidden>Saved.</div>
+
+    </form>
+
+  </div><!-- .cd-main -->
+
+  <!-- FOOTER -->
+  <footer class="cd-footer">
+    <div class="cd-footer-links">
+      <a href="/command-deck/" class="cd-footer-link">Bridge</a>
+      <a href="/command-deck/projects/" class="cd-footer-link">Projects</a>
+      <a href="/command-deck/mileage/" class="cd-footer-link">Mileage</a>
+    </div>
+    {% include 'includes/cd_footer_status.html' %}
+    <span class="cd-footer-ident">YT-1300F · COMMAND DECK · SECURE</span>
+  </footer>
+
+</div><!-- .cd-shell -->
+
+<script>
+(function () {
+  // Below-Deck badge
+  fetch('/below-deck/count').then(r=>r.json()).then(d=>{
+    var b=document.getElementById('bdBadge');
+    if(!b||d.count===0)return;
+    b.classList.add(d.count<=3?'green':d.count<=6?'amber':'red');
+  });
+
+  var savedEl = document.getElementById('settingsSaved');
+  var savedTimer;
+  function flashSaved() {
+    savedEl.removeAttribute('hidden');
+    clearTimeout(savedTimer);
+    savedTimer = setTimeout(function () { savedEl.setAttribute('hidden', ''); }, 1400);
+  }
+
+  function patch(field, value) {
+    var body = {};
+    body[field] = value;
+    return fetch('/command-deck/settings/update', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then(function (r) { return r.json(); });
+  }
+
+  // Wire all data-field elements: blur for text/number, change for selects
+  document.querySelectorAll('[data-field]').forEach(function (el) {
+    var field = el.dataset.field;
+    var isCents = el.dataset.cents === '1';
+    var isSelect = el.tagName === 'SELECT';
+    var ev = isSelect ? 'change' : 'blur';
+
+    el.addEventListener(ev, function () {
+      var raw = el.value;
+      var value = raw;
+      if (isCents) {
+        var dollars = parseFloat(raw);
+        if (isNaN(dollars) || dollars < 0) return;
+        value = Math.round(dollars * 100);
+      }
+      patch(field, value).then(function (data) {
+        if (data.success) flashSaved();
+      });
+    });
+  });
+
+  // When vehicle labels change, refresh the default-vehicle dropdown
+  // copy so the user can read the actual labels.
+  ['vehicleA', 'vehicleB'].forEach(function (id) {
+    var el = document.getElementById(id);
+    if (!el) return;
+    el.addEventListener('blur', function () {
+      var sel = document.getElementById('defaultVehicle');
+      if (!sel) return;
+      sel.options[0].textContent = document.getElementById('vehicleA').value || 'Vehicle A';
+      sel.options[1].textContent = document.getElementById('vehicleB').value || 'Vehicle B';
+    });
+  });
+})();
+</script>
+<script src="/static/command_deck_nav.js"></script>
+</body>
+</html>

--- a/templates/command_deck_templates.html
+++ b/templates/command_deck_templates.html
@@ -33,6 +33,8 @@
           <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
           <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
           <a href="/command-deck/meetings/" class="cd-nav-link">MEETINGS</a>
+          <a href="/command-deck/mileage/" class="cd-nav-link">MILEAGE</a>
+          <a href="/command-deck/settings/" class="cd-nav-link">SETTINGS</a>
         </div>
       </details>
       <span class="cd-nav-sep">·</span>

--- a/templates/today.html
+++ b/templates/today.html
@@ -33,6 +33,8 @@
           <a href="/command-deck/reports/" class="cd-nav-link">REPORTS</a>
           <a href="/command-deck/templates/" class="cd-nav-link">TEMPLATES</a>
           <a href="/command-deck/meetings/" class="cd-nav-link">MEETINGS</a>
+          <a href="/command-deck/mileage/" class="cd-nav-link">MILEAGE</a>
+          <a href="/command-deck/settings/" class="cd-nav-link">SETTINGS</a>
         </div>
       </details>
       <span class="cd-nav-sep">·</span>


### PR DESCRIPTION
## Summary

Seven commits, ~2.7k lines. Mileage as a first-class Command Deck domain — log trips with odometer + round-trip math, track which trips have been submitted for reimbursement, export an xlsx for the company expense system, and surface pending dollars on the dashboard so monthly catchup is visible.

- **Schema** — new `mileage_entries` table (date / project_id / description / from / to / round_trip / odometer_start+end / miles / rate_cents snapshot / vehicle / notes / submitted_at / created / updated). `settings.default_mileage_project_id` so "usually Onboarding" is data not code. Three indexes including a partial on unsubmitted for the dashboard's pending-count query. Migration is idempotent.
- **Backend** — `blueprints/mileage.py` with CRUD + single-row submit toggle + bulk-submit + xlsx export (lazy openpyxl import — returns a clear 500 with install instructions on a server that doesn't have it). `blueprints/settings.py` is a separate cross-cutting blueprint for editable defaults.
- **Mobile-first form** — full page (not a modal). 44px tap targets, numeric inputmodes, live miles calc from odometer with round-trip doubling. Form copy makes the round-trip semantics explicit: odometer values are one-way readings; check the box to double.
- **Surfaces** — dashboard LOG MILES quick-panel showing pending count + dollars; project pages get a // Mileage section between Meetings and Files; reports get a 5th Mileage tab with rollup + xlsx download from active filters; MILEAGE + SETTINGS join MORE ▾ across all 9 CD-styled templates.
- **Reimbursement workflow** — status pills (pending/submitted) flip on click; bulk-select + MARK SUBMITTED for monthly catchup; un-submit confirms; xlsx filename matches active filter (`mileage-2026-04-01-to-2026-04-30.xlsx`).

`requirements.txt` lands for the first time. openpyxl is the only new hard dep on top of the existing stack.

Privacy follows the reports convention — private-project mileage hidden by default, surfaces opt in via `?include_private=1` after PIN unlock.

## Test plan

- [ ] PA: `pip3.10 install --user -r requirements.txt` — should pull openpyxl + et_xmlfile.
- [ ] PA: `python migrate_add_mileage.py` — expect 5 added (table + column + 3 indexes); re-run shows "no changes."
- [ ] Open `/command-deck/settings/` — set Onboarding as default mileage project, confirm vehicle labels, save by tabbing out.
- [ ] Open `/command-deck/mileage/new` from the dashboard CTA — confirm Onboarding pre-selected, today's date pre-filled, current rate populated.
- [ ] Log a trip with odometer 12345 → 12362.5, check round trip — miles auto-fill 35.0; uncheck — miles drop to 17.5.
- [ ] Override miles manually after odometer edit — confirm server stores the override.
- [ ] On the index, click pending pill → flips to submitted; click again → confirm dialog → un-submit.
- [ ] Multi-select 6+ entries, MARK SUBMITTED — confirm bulk dialog fires.
- [ ] EXPORT XLSX from index with date + status filters — open file, confirm columns + values match.
- [ ] Open a project page — confirm // Mileage panel renders with totals + recent strip + LOG MILES button deep-linked to project.
- [ ] Open `/command-deck/reports/`, click Mileage tab — rollup loads + EXPORT XLSX downloads with active period applied.
- [ ] Mobile: open form on phone, confirm tap targets feel right, numeric keyboards trigger on miles/odometer/rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)