### PR TITLE
feat(tickets): tickets join Today as a starrable kind

### DIFF
--- a/blueprints/today.py
+++ b/blueprints/today.py
@@ -207,6 +207,17 @@ def _today_autoclear(conn):
 		      )
 		  )
 	''', (cutoff_utc,))
+	# Tickets — clear today when status='closed' AND closed_date < cutoff.
+	# Mirrors the task pattern (completed + completed_date). Closed tickets
+	# from earlier today survive until 4am the next morning so Aaron can
+	# review what landed today before they roll off the list.
+	conn.execute('''
+		UPDATE tickets SET today = 0
+		WHERE today = 1
+		  AND status = 'closed'
+		  AND closed_date IS NOT NULL
+		  AND closed_date < ?
+	''', (cutoff_et,))
 
 	# Phase 2.4 — recurrence-spawn pass. For each recurring block whose cycle
 	# boundary has passed since last_reset_at, archive the current cycle and
@@ -291,8 +302,11 @@ def today_count():
 	block_count = conn.execute(
 		"SELECT COUNT(*) as cnt FROM blocks WHERE today = 1"
 	).fetchone()['cnt']
+	ticket_count = conn.execute(
+		"SELECT COUNT(*) as cnt FROM tickets WHERE today = 1 AND status != 'closed'"
+	).fetchone()['cnt']
 	conn.close()
-	return jsonify({'count': task_count + item_count + block_count})
+	return jsonify({'count': task_count + item_count + block_count + ticket_count})
 
 
 @today_bp.route('/today/data')
@@ -386,6 +400,68 @@ def today_data():
 			today_blocks_done.append(d)
 		else:
 			today_blocks_open.append(d)
+
+	# Tickets — starred non-closed go in today_open; starred closed go in
+	# today_done (post-resolution limbo until 4am autoclear). The slim panel
+	# treats ticket rows as navigation-only (no inline complete button —
+	# closing requires a resolution prompt).
+	today_tickets_open = conn.execute('''
+		SELECT t.id, t.ticket_number, t.title, t.status, t.priority, t.today,
+		       t.project_id,
+		       p.title AS project_title, p.slug AS project_slug,
+		       parent.id AS area_id, parent.title AS area_title,
+		       parent.area_color AS area_color,
+		       cg.name AS customer_group_name,
+		       c.name AS customer_name,
+		       tt.name AS type_name, tt.color AS type_color
+		FROM tickets t
+		LEFT JOIN projects p             ON t.project_id = p.id
+		LEFT JOIN projects parent        ON p.parent_project_id = parent.id
+		LEFT JOIN customer_groups cg     ON t.customer_group_id = cg.id
+		LEFT JOIN customers c            ON t.customer_id = c.id
+		LEFT JOIN ticket_types tt        ON t.type_id = tt.id
+		WHERE t.today = 1 AND t.status != 'closed'
+		ORDER BY (t.priority = 'urgent') DESC, t.updated DESC
+	''').fetchall()
+	today_tickets_done = conn.execute('''
+		SELECT t.id, t.ticket_number, t.title, t.status, t.priority, t.today,
+		       t.project_id, t.closed_date,
+		       p.title AS project_title, p.slug AS project_slug,
+		       parent.id AS area_id, parent.title AS area_title,
+		       parent.area_color AS area_color,
+		       cg.name AS customer_group_name,
+		       c.name AS customer_name,
+		       tt.name AS type_name, tt.color AS type_color
+		FROM tickets t
+		LEFT JOIN projects p             ON t.project_id = p.id
+		LEFT JOIN projects parent        ON p.parent_project_id = parent.id
+		LEFT JOIN customer_groups cg     ON t.customer_group_id = cg.id
+		LEFT JOIN customers c            ON t.customer_id = c.id
+		LEFT JOIN ticket_types tt        ON t.type_id = tt.id
+		WHERE t.today = 1 AND t.status = 'closed'
+		ORDER BY t.closed_date DESC
+	''').fetchall()
+
+	# All non-closed tickets (browseable list for the master picker on /today/)
+	# — top-level group like Below Deck, sorted urgent-first then recency.
+	tickets_browse = conn.execute('''
+		SELECT t.id, t.ticket_number, t.title, t.status, t.priority, t.today,
+		       t.project_id,
+		       p.title AS project_title, p.slug AS project_slug,
+		       parent.title AS area_title,
+		       parent.area_color AS area_color,
+		       cg.name AS customer_group_name,
+		       c.name AS customer_name,
+		       tt.name AS type_name, tt.color AS type_color
+		FROM tickets t
+		LEFT JOIN projects p             ON t.project_id = p.id
+		LEFT JOIN projects parent        ON p.parent_project_id = parent.id
+		LEFT JOIN customer_groups cg     ON t.customer_group_id = cg.id
+		LEFT JOIN customers c            ON t.customer_id = c.id
+		LEFT JOIN ticket_types tt        ON t.type_id = tt.id
+		WHERE t.status != 'closed'
+		ORDER BY (t.priority = 'urgent') DESC, t.updated DESC
+	''').fetchall()
 
 	# Master browse — Below Deck (project_id NULL) +
 	# per-area groups for work sub-projects + Personal group.
@@ -489,18 +565,25 @@ def today_data():
 		d['kind'] = 'block'
 		return d
 
+	def _serialize_ticket(row):
+		d = dict(row)
+		d['kind'] = 'ticket'
+		return d
+
 	return jsonify({
-		# Mixed lists — kind='task' / 'item' / 'block' on each entry.
+		# Mixed lists — kind='task' / 'item' / 'block' / 'ticket' on each entry.
 		# Each carries area_title + area_color when under a sub-project.
 		'today_open': (
 			[_serialize_task(r) for r in today_tasks_open] +
 			[_serialize_item(r) for r in today_items_open] +
-			[_serialize_block(r) for r in today_blocks_open]
+			[_serialize_block(r) for r in today_blocks_open] +
+			[_serialize_ticket(r) for r in today_tickets_open]
 		),
 		'today_done': (
 			[_serialize_task(r) for r in today_tasks_done] +
 			[_serialize_item(r) for r in today_items_done] +
-			[_serialize_block(r) for r in today_blocks_done]
+			[_serialize_block(r) for r in today_blocks_done] +
+			[_serialize_ticket(r) for r in today_tickets_done]
 		),
 		'below_deck': [dict(t) for t in below_deck_tasks],
 		# Phase 2.2 — master browse grouped by parent area for sub-projects;
@@ -508,6 +591,10 @@ def today_data():
 		# top-level group above all of this.
 		'area_groups': area_groups,
 		'personal_projects': personal_projects,
+		# Tickets — top-level browseable list of non-closed tickets, parallel
+		# to below_deck. Surfaces in /today/ as its own panel with star buttons
+		# so Aaron can pick which tickets he intends to work on today.
+		'tickets_browse': [dict(t) for t in tickets_browse],
 		# Backward-compat: legacy 'projects' field kept for any consumer
 		# still expecting flat per-project shape. Equals area_groups
 		# flattened + personal_projects appended.
@@ -519,10 +606,11 @@ def today_data():
 
 @today_bp.route('/today/star', methods=['POST'])
 def today_star():
-	"""Toggle the today flag on a task OR a checklist item OR a checklist block.
+	"""Toggle the today flag on a task / checklist item / checklist block / ticket.
 
 	Phase 2.1: accepts task_id or item_id.
-	Phase 2.2: also accepts block_id. All three mutually exclusive.
+	Phase 2.2: also accepts block_id.
+	Tickets: also accepts ticket_id. All four mutually exclusive.
 	Form-encoded for parity with existing star UIs; fields picked up via
 	request.form. 400 if zero or 2+ fields, 404 if not found."""
 	if not is_authenticated():
@@ -531,12 +619,13 @@ def today_star():
 	task_id = request.form.get('task_id') or request.form.get('id')  # legacy fallback = task
 	item_id = request.form.get('item_id')
 	block_id = request.form.get('block_id')
+	ticket_id = request.form.get('ticket_id')
 
-	provided = [x for x in (task_id, item_id, block_id) if x]
+	provided = [x for x in (task_id, item_id, block_id, ticket_id) if x]
 	if len(provided) > 1:
-		return jsonify({'error': 'one_of_task_item_or_block_only'}), 400
+		return jsonify({'error': 'one_of_task_item_block_or_ticket_only'}), 400
 	if not provided:
-		return jsonify({'error': 'task_id_or_item_id_or_block_id_required'}), 400
+		return jsonify({'error': 'task_id_or_item_id_or_block_id_or_ticket_id_required'}), 400
 
 	conn = get_db()
 	if task_id:
@@ -553,8 +642,7 @@ def today_star():
 			return jsonify({'error': 'not_found'}), 404
 		new_today = 0 if row['today'] else 1
 		conn.execute('UPDATE checklist_items SET today = ? WHERE id = ?', (new_today, item_id))
-	else:
-		# block_id
+	elif block_id:
 		row = conn.execute(
 			"SELECT id, today, type FROM blocks WHERE id = ?", (block_id,)
 		).fetchone()
@@ -566,13 +654,24 @@ def today_star():
 			return jsonify({'error': 'block_not_checklist'}), 400
 		new_today = 0 if row['today'] else 1
 		conn.execute('UPDATE blocks SET today = ? WHERE id = ?', (new_today, block_id))
+	else:
+		# ticket_id
+		row = conn.execute(
+			'SELECT id, today FROM tickets WHERE id = ?', (ticket_id,)
+		).fetchone()
+		if not row:
+			conn.close()
+			return jsonify({'error': 'not_found'}), 404
+		new_today = 0 if row['today'] else 1
+		conn.execute('UPDATE tickets SET today = ? WHERE id = ?', (new_today, ticket_id))
 
 	conn.commit()
-	# Combined open count for the badge — tasks + items + blocks
+	# Combined open count for the badge — tasks + items + blocks + tickets
 	count = conn.execute(
 		"SELECT (SELECT COUNT(*) FROM tasks WHERE today = 1 AND status = 'open') + "
 		"       (SELECT COUNT(*) FROM checklist_items WHERE today = 1 AND checked = 0 AND archived_at IS NULL) + "
-		"       (SELECT COUNT(*) FROM blocks WHERE today = 1) "
+		"       (SELECT COUNT(*) FROM blocks WHERE today = 1) + "
+		"       (SELECT COUNT(*) FROM tickets WHERE today = 1 AND status != 'closed') "
 		"AS cnt"
 	).fetchone()['cnt']
 	conn.close()

--- a/migrate_add_ticket_today.py
+++ b/migrate_add_ticket_today.py
@@ -1,0 +1,51 @@
+"""
+migrate_add_ticket_today.py
+Tickets follow-on — see .kt/spec-tickets.md.
+
+What it does (idempotent):
+
+  + tickets.today   INTEGER NOT NULL DEFAULT 0
+
+Lets a ticket be ★-ed for Today the same way tasks / items / blocks
+already can. /today/data picks up starred non-closed tickets in
+today_open + closed-and-starred ones in today_done; autoclear
+clears the flag when a ticket has been closed past the 4am ET cutoff.
+
+Run from PythonAnywhere bash:
+    cd /home/aaronaiken/status_update
+    python migrate_add_ticket_today.py
+"""
+
+import os
+import sqlite3
+
+DB_FILE = os.path.join(
+	os.environ.get('COCKPIT_REPO_ROOT', '/home/aaronaiken/status_update'),
+	'assets/data/command_deck.db'
+)
+
+
+def column_exists(cur, table, col):
+	cols = [row[1] for row in cur.execute(f"PRAGMA table_info({table})").fetchall()]
+	return col in cols
+
+
+def run():
+	if not os.path.exists(DB_FILE):
+		print(f"× DB not found at {DB_FILE}")
+		return
+	conn = sqlite3.connect(DB_FILE)
+	cur = conn.cursor()
+	if column_exists(cur, 'tickets', 'today'):
+		print("— tickets.today already in place — no changes")
+	else:
+		cur.execute(
+			'ALTER TABLE tickets ADD COLUMN today INTEGER NOT NULL DEFAULT 0'
+		)
+		conn.commit()
+		print("✓ Added: tickets.today")
+	conn.close()
+
+
+if __name__ == '__main__':
+	run()

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -5372,3 +5372,45 @@ textarea.cd-ticket-input { min-height: auto; }
   .cd-lookup-section[data-kind="customer_groups"] .cd-lookup-archive,
   .cd-lookup-section[data-kind="customer_groups"] .cd-lookup-restore { grid-area: action; }
 }
+
+/* Tickets index — star column */
+.cd-tickets-table .cd-tickets-star-cell { width: 2em; text-align: center; }
+.cd-tickets-star {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px;
+  font-size: 1rem;
+  line-height: 1;
+  color: rgba(212,136,10,0.25);
+  transition: color 0.15s, transform 0.15s;
+}
+.cd-tickets-star:hover { color: rgba(212,136,10,0.7); transform: scale(1.15); }
+.cd-tickets-star.starred {
+  color: var(--cd-amber);
+  text-shadow: 0 0 8px rgba(212,136,10,0.4);
+}
+
+/* Ticket detail — ☆ TODAY button in the breadcrumb actions */
+.cd-ticket-today-btn {
+  background: none;
+  border: 1px solid var(--cd-border);
+  color: var(--cd-text-dim);
+  font-family: var(--cd-font-ui);
+  font-size: 0.55rem;
+  letter-spacing: 0.16em;
+  padding: 0.3rem 0.65rem;
+  border-radius: 2px;
+  cursor: pointer;
+  text-transform: uppercase;
+  transition: all 0.15s;
+}
+.cd-ticket-today-btn:hover {
+  border-color: var(--cd-amber);
+  color: var(--cd-amber-hi);
+}
+.cd-ticket-today-btn.starred {
+  background: rgba(212, 136, 10, 0.12);
+  border-color: var(--cd-amber);
+  color: var(--cd-amber-hi);
+}

--- a/templates/command_deck_ticket.html
+++ b/templates/command_deck_ticket.html
@@ -35,6 +35,11 @@
       <span class="cd-breadcrumb-sep">›</span>
       <span class="cd-breadcrumb-tail">{{ ticket.ticket_number }}</span>
       <span class="cd-breadcrumb-actions">
+        {% if ticket.status != 'closed' %}
+          <button class="cd-ticket-today-btn{% if ticket.today %} starred{% endif %}"
+                  id="ticketTodayBtn" type="button"
+                  title="{% if ticket.today %}Remove from Today{% else %}Add to Today{% endif %}">{% if ticket.today %}★ TODAY{% else %}☆ TODAY{% endif %}</button>
+        {% endif %}
         <button class="cd-btn ghost sm" id="ticketDeleteBtn" type="button">DELETE</button>
       </span>
     </div>
@@ -444,6 +449,26 @@ const TICKET_LIFETIME_SECONDS = {{ lifetime_seconds | tojson }};
       if (d.success) window.location.href = '/command-deck/tickets/';
     });
   });
+
+  // ---- TODAY toggle ----
+  var todayBtn = document.getElementById('ticketTodayBtn');
+  if (todayBtn) {
+    todayBtn.addEventListener('click', function () {
+      var was = todayBtn.classList.contains('starred');
+      todayBtn.classList.toggle('starred', !was);
+      todayBtn.textContent = !was ? '★ TODAY' : '☆ TODAY';
+      todayBtn.title = !was ? 'Remove from Today' : 'Add to Today';
+      var fd = new FormData(); fd.append('ticket_id', TICKET_ID);
+      fetch('/today/star', { method: 'POST', credentials: 'same-origin', body: fd })
+        .then(function (r) { return r.json(); })
+        .then(function (d) {
+          if (!d.success) {
+            todayBtn.classList.toggle('starred', was);
+            todayBtn.textContent = was ? '★ TODAY' : '☆ TODAY';
+          }
+        });
+    });
+  }
 
   // ---- ⏱ TIMER button + lifetime + today tag ----
   function fmtLifetime() {

--- a/templates/command_deck_tickets.html
+++ b/templates/command_deck_tickets.html
@@ -113,6 +113,7 @@
       <table class="cd-tickets-table">
         <thead>
           <tr>
+            <th></th>
             <th>TKT#</th>
             <th>Title</th>
             <th>Customer</th>
@@ -124,7 +125,7 @@
           </tr>
         </thead>
         <tbody id="ticketsBody">
-          <tr><td colspan="8" class="cd-tickets-loading">loading…</td></tr>
+          <tr><td colspan="9" class="cd-tickets-loading">loading…</td></tr>
         </tbody>
       </table>
     </section>
@@ -304,7 +305,7 @@
   function renderTickets(tickets) {
     var body = document.getElementById('ticketsBody');
     if (!tickets.length) {
-      body.innerHTML = '<tr><td colspan="8" class="cd-tickets-empty">No tickets match.</td></tr>';
+      body.innerHTML = '<tr><td colspan="9" class="cd-tickets-empty">No tickets match.</td></tr>';
       return;
     }
     body.innerHTML = tickets.map(function (t) {
@@ -330,8 +331,24 @@
         ? '<a href="/command-deck/projects/' + escHtml(t.project_slug) + '/">' + escHtml(t.project_title) + '</a>'
         : '<span class="cd-text-dim">—</span>';
 
+      // Star button: closed tickets show a disabled placeholder (★ wouldn't
+      // make sense on something already done). Active tickets get the toggle.
+      var starCell;
+      if (t.status === 'closed') {
+        starCell = '<td class="cd-tickets-star-cell"></td>';
+      } else {
+        var starred = !!t.today;
+        starCell = '<td class="cd-tickets-star-cell">' +
+          '<button class="cd-tickets-star' + (starred ? ' starred' : '') + '" ' +
+                  'data-id="' + t.id + '" ' +
+                  'title="' + (starred ? 'Remove from Today' : 'Add to Today') + '" type="button">' +
+            (starred ? '★' : '☆') +
+          '</button></td>';
+      }
+
       return '<tr data-id="' + t.id + '"' +
         (t.status === 'closed' ? ' class="is-closed"' : '') + '>' +
+        starCell +
         '<td><a class="cd-tickets-num" href="/command-deck/tickets/' + t.id + '/">' + escHtml(t.ticket_number) + '</a></td>' +
         '<td><a class="cd-tickets-title-link" href="/command-deck/tickets/' + t.id + '/">' + escHtml(t.title) + '</a></td>' +
         '<td>' + customerCell + '</td>' +
@@ -342,6 +359,26 @@
         '<td><a class="cd-btn ghost sm" href="/command-deck/tickets/' + t.id + '/">OPEN</a></td>' +
         '</tr>';
     }).join('');
+
+    // Wire star toggles
+    body.querySelectorAll('.cd-tickets-star').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var id = btn.getAttribute('data-id');
+        var was = btn.classList.contains('starred');
+        btn.classList.toggle('starred', !was);
+        btn.textContent = !was ? '★' : '☆';
+        btn.title = !was ? 'Remove from Today' : 'Add to Today';
+        var fd = new FormData(); fd.append('ticket_id', id);
+        fetch('/today/star', { method: 'POST', credentials: 'same-origin', body: fd })
+          .then(function (r) { return r.json(); })
+          .then(function (d) {
+            if (!d.success) {
+              btn.classList.toggle('starred', was);
+              btn.textContent = was ? '★' : '☆';
+            }
+          });
+      });
+    });
   }
 
   function load() {

--- a/templates/includes/today_panel.html
+++ b/templates/includes/today_panel.html
@@ -150,6 +150,11 @@
 }
 
 /* ---- TASK ROWS ---- */
+a.today-ticket-row {
+  text-decoration: none;
+  color: inherit;
+}
+a.today-ticket-row:hover { color: var(--cd-amber-hi); }
 .today-task-row {
   display: flex;
   align-items: center;
@@ -457,6 +462,9 @@
     // Phase 2.1: entry.kind is 'task' or 'item'.
     // Phase 2.2: also 'block' — rendered with progress (`3/8 done`)
     // and no checkbox (block completes implicitly via item checks).
+    // Tickets: kind 'ticket' — rendered as a navigation link (no inline
+    // checkbox — closing requires a resolution prompt that lives on the
+    // detail page).
     // Source line prefixes the area name when the entry sits under a
     // work sub-project, so the user sees PennDOT · Bridge 47 calc rather
     // than just Bridge 47 calc.
@@ -468,6 +476,22 @@
     var titleHtml;
     var btnHtml;
     var btnInner = '<svg viewBox="0 0 12 10"><polyline points="1.5,5 4.5,8.5 10.5,1.5"/></svg>';
+
+    if (kind === 'ticket') {
+      var num = entry.ticket_number || ('TKT-' + entry.id);
+      var custLabel = entry.customer_name || entry.customer_group_name || '';
+      var ticketSource = custLabel
+        ? custLabel + (projectTitle && projectTitle !== 'Below Deck' ? ' · ' + projectTitle : '')
+        : source;
+      titleHtml = '<span class="today-task-block-context">' + escHtml(num) + ' · </span>' + escHtml(entry.title);
+      // Spacer in the action slot; whole row is wrapped in a link below.
+      btnHtml = '<span class="today-block-spacer" aria-hidden="true">⌖</span>';
+      return '<a class="today-task-row today-ticket-row' + (isDone ? ' is-done' : '') + '" data-id="' + entry.id + '" data-kind="ticket" href="/command-deck/tickets/' + entry.id + '/">' +
+        btnHtml +
+        '<span class="today-task-title">' + titleHtml + '</span>' +
+        '<span class="today-task-source">' + escHtml(ticketSource) + '</span>' +
+        '</a>';
+    }
 
     if (kind === 'block') {
       // Block row: title + progress, no checkbox. Progress is the source-

--- a/templates/today.html
+++ b/templates/today.html
@@ -159,6 +159,31 @@
   text-transform: uppercase;
   letter-spacing: 0.18em;
 }
+/* Tickets — master row chips inline with the title */
+.today-master-ticket-row {
+  flex-wrap: wrap;
+  row-gap: 4px;
+}
+.today-master-ticket-link {
+  text-decoration: none;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+}
+.today-master-ticket-link:hover { color: var(--cd-amber-hi); }
+.today-master-ticket-num {
+  font-family: var(--cd-font-ui);
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+  color: var(--cd-amber);
+}
+.today-master-ticket-cust {
+  font-family: var(--cd-font-ui);
+  font-size: 0.55rem;
+  letter-spacing: 0.12em;
+  color: var(--cd-text-dim);
+  text-transform: uppercase;
+}
 .today-project-subsection {
   margin: 4px 0 10px;
 }
@@ -203,7 +228,8 @@
           data.below_deck || [],
           data.area_groups || [],
           data.personal_projects || [],
-          data.today_open || []
+          data.today_open || [],
+          data.tickets_browse || []
         );
         updateCountLabel((data.today_open || []).length);
       })
@@ -213,24 +239,26 @@
       });
   }
 
-  function renderMasterList(belowDeck, areaGroups, personalProjects, todayOpen) {
-    // Phase 2.1+2.2 — todayOpen mixes tasks/items/blocks. Build per-kind
-    // lookups so the starred-state on master rows is unambiguous.
+  function renderMasterList(belowDeck, areaGroups, personalProjects, todayOpen, ticketsBrowse) {
+    // Phase 2.1+2.2 — todayOpen mixes tasks/items/blocks/tickets. Build
+    // per-kind lookups so the starred-state on master rows is unambiguous.
     var todayTaskIds = {};
     var todayItemIds = {};
     var todayBlockIds = {};
+    var todayTicketIds = {};
     todayOpen.forEach(function(e) {
       var kind = e.kind || 'task';
       if (kind === 'task') todayTaskIds[e.id] = true;
       else if (kind === 'item') todayItemIds[e.id] = true;
       else if (kind === 'block') todayBlockIds[e.id] = true;
+      else if (kind === 'ticket') todayTicketIds[e.id] = true;
     });
 
     function projectHasContent(p) {
       return (p.tasks || []).length > 0 || (p.blocks || []).length > 0;
     }
 
-    var totalThings = belowDeck.length;
+    var totalThings = belowDeck.length + (ticketsBrowse || []).length;
     areaGroups.forEach(function(ag) {
       ag.projects.forEach(function(p) {
         totalThings += (p.tasks || []).length;
@@ -262,6 +290,20 @@
       belowDeck.forEach(function(t) {
         var starred = todayTaskIds[t.id] || t.today == 1;
         html += masterRow('task', t.id, t.title, starred, false);
+      });
+      html += '</div></div>';
+    }
+
+    // Tickets — top-level group of all non-closed tickets, browseable to pick
+    // which ones to work on today. Each row gets a star button + a quick
+    // hop to the ticket detail via the title link.
+    if ((ticketsBrowse || []).length > 0) {
+      html += '<div class="cd-panel cd-mb today-group">';
+      html += '<div class="cd-panel-header"><span class="cd-panel-title">// Tickets</span></div>';
+      html += '<div class="cd-panel-body" style="padding:4px 0;">';
+      ticketsBrowse.forEach(function(t) {
+        var starred = todayTicketIds[t.id] || t.today == 1;
+        html += ticketMasterRow(t, starred);
       });
       html += '</div></div>';
     }
@@ -344,6 +386,38 @@
       '</div>';
   }
 
+  function ticketMasterRow(t, starred) {
+    // Ticket browse row: star + TKT-NNNN + title (link to detail) + status/
+    // priority/customer chips. Title is clickable to navigate; star toggles
+    // today flag like other master rows.
+    var titleCls = 'today-master-title' + (starred ? ' is-starred' : '');
+    var num = t.ticket_number || ('TKT-' + t.id);
+    var status = (t.status || '').replace('_', ' ');
+    var statusCls = 'cd-pill ' + (t.status || 'open').replace('_', '-');
+    var urgentBadge = (t.priority === 'urgent' && t.status !== 'closed')
+      ? ' <span class="cd-pill urgent">urgent</span>' : '';
+    var custLabel = t.customer_name || t.customer_group_name || '';
+    var custBadge = custLabel
+      ? ' <span class="today-master-ticket-cust">' + escHtml(custLabel) + '</span>'
+      : '';
+    var typeBadge = t.type_name
+      ? ' <span class="cd-pill type"' + (t.type_color ? ' style="--type-color:' + t.type_color + '"' : '') + '>' + escHtml(t.type_name) + '</span>'
+      : '';
+    return '<div class="today-master-row today-master-ticket-row" data-id="' + t.id + '" data-kind="ticket">' +
+      '<button class="today-star-btn' + (starred ? ' starred' : '') + '" ' +
+              'data-id="' + t.id + '" data-kind="ticket" ' +
+              'title="' + (starred ? 'Remove from Today' : 'Add to Today') + '">' +
+        (starred ? '★' : '☆') +
+      '</button>' +
+      '<a class="' + titleCls + ' today-master-ticket-link" href="/command-deck/tickets/' + t.id + '/">' +
+        '<span class="today-master-ticket-num">' + escHtml(num) + '</span> ' +
+        escHtml(t.title) +
+      '</a>' +
+      '<span class="' + statusCls + '">' + escHtml(status) + '</span>' +
+      urgentBadge + typeBadge + custBadge +
+      '</div>';
+  }
+
   function starEntity(kind, id, btn) {
     var wasStarred = btn.classList.contains('starred');
     // Optimistic UI
@@ -353,6 +427,7 @@
     var fieldName = 'task_id';
     if (kind === 'item') fieldName = 'item_id';
     else if (kind === 'block') fieldName = 'block_id';
+    else if (kind === 'ticket') fieldName = 'ticket_id';
     fd.append(fieldName, id);
     fetch('/today/star', { method: 'POST', body: fd })
       .then(function(r) { return r.json(); })


### PR DESCRIPTION
## Summary

Tickets can now be ★'d for Today the same way tasks, checklist items, and blocks already can. `/today/` grows a // Tickets panel listing every non-closed ticket with a star button — pick what you intend to work on today the same way you already do for everything else.

- **Schema** — `tickets.today` INTEGER NOT NULL DEFAULT 0 via a small idempotent migration
- **Server** — `/today/star` accepts `ticket_id` (4-way mutex with task/item/block); `/today/count` and `/today/data` include starred non-closed tickets in `today_open` (closed → `today_done`) plus a new `tickets_browse` list of all non-closed tickets for the picker
- **Autoclear** — drops `tickets.today = 0` when status='closed' AND closed_date < today's 4am ET cutoff, mirroring the task pattern
- **/today/ master list** — // Tickets panel between Below Deck and area groups, with star buttons + clickable titles to the detail page
- **Slim today panel** — ticket rows render as navigation links (no inline complete — closing requires resolution)
- **Index page** — ★ column at position 1; closed tickets get a placeholder
- **Detail page** — ☆ TODAY button in the breadcrumb next to DELETE; hidden on closed tickets

## Test plan

- [ ] PA: `python migrate_add_ticket_today.py` — expect 1 added; idempotent
- [ ] Star a ticket from `/command-deck/tickets/` — appears in /today/'s top section
- [ ] Star from the detail page — toggle persists; refresh confirms
- [ ] Tickets panel on /today/ shows only non-closed tickets, sorted urgent-first
- [ ] Close a starred ticket → it disappears from today_open, appears in today_done if you peek; on the next 4am ET autoclear (or simulated past closed_date) the today flag drops
- [ ] Slim today bar count includes starred tickets
- [ ] Mobile: ticket rows in /today/ wrap chips cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)