### PR TITLE
feat: today bar drilldown + project archive

### DIFF
--- a/blueprints/command_deck.py
+++ b/blueprints/command_deck.py
@@ -44,17 +44,21 @@ command_deck_bp = Blueprint('command_deck', __name__)
 
 # ---- Project-query helpers (Phase 1 time-tracking) ----
 
-def _fetch_work_areas(conn):
-	"""Work areas with sub-project, open-task, and active-timer counts."""
-	return conn.execute('''
+def _fetch_work_areas(conn, include_archived=False):
+	"""Work areas with sub-project, open-task, and active-timer counts.
+	By default filters archived areas; pass include_archived=True to surface
+	them in the projects-list "show archived" view."""
+	sql = '''
 		SELECT a.id, a.title, a.slug, a.description, a.area_color,
-		       a.is_private, a.created, a.updated, a.is_favorite,
+		       a.is_private, a.created, a.updated, a.is_favorite, a.archived_at,
 		       (SELECT COUNT(*) FROM projects sp
 		        WHERE sp.parent_project_id = a.id
-		          AND sp.project_type = 'work_subproject') AS subproject_count,
+		          AND sp.project_type = 'work_subproject'
+		          AND sp.archived_at IS NULL) AS subproject_count,
 		       (SELECT COUNT(*) FROM tasks t
 		        JOIN projects sp ON t.project_id = sp.id
 		        WHERE sp.parent_project_id = a.id
+		          AND sp.archived_at IS NULL
 		          AND t.status = 'open') AS open_task_count,
 		       (SELECT COUNT(*) FROM time_entries te
 		        JOIN projects sp ON te.project_id = sp.id
@@ -62,12 +66,16 @@ def _fetch_work_areas(conn):
 		          AND te.ended_at IS NULL) AS active_timer_count
 		FROM projects a
 		WHERE a.project_type = 'work_area'
-		ORDER BY a.title ASC
-	''').fetchall()
+	'''
+	if not include_archived:
+		sql += ' AND a.archived_at IS NULL'
+	sql += ' ORDER BY a.title ASC'
+	return conn.execute(sql).fetchall()
 
 
-def _fetch_subprojects(conn, area_id=None, favorites_only=False):
-	"""Sub-projects with parent area joined. Optional filters by area or favorite."""
+def _fetch_subprojects(conn, area_id=None, favorites_only=False, include_archived=False):
+	"""Sub-projects with parent area joined. Optional filters by area or favorite.
+	include_archived=False (default) hides archived; True surfaces them."""
 	sql = '''
 		SELECT sp.*,
 		       parent.id         AS area_id,
@@ -87,6 +95,8 @@ def _fetch_subprojects(conn, area_id=None, favorites_only=False):
 		args.append(area_id)
 	if favorites_only:
 		sql += ' AND sp.is_favorite = 1'
+	if not include_archived:
+		sql += ' AND sp.archived_at IS NULL'
 	sql += ' ORDER BY sp.updated DESC'
 	return conn.execute(sql, args).fetchall()
 
@@ -318,6 +328,8 @@ def cd_dashboard():
 
 	# Personal projects only — work areas + sub-projects flow through
 	# work_areas / favorited_subprojects below. (§3.2 partitioning)
+	# Dashboard never shows archived; archived projects only appear via the
+	# /command-deck/projects/?archived=1 toggle.
 	projects = conn.execute('''
 		SELECT p.*,
 		       (SELECT COUNT(*) FROM tasks t WHERE t.project_id = p.id AND t.status = 'open') AS open_task_count,
@@ -325,6 +337,7 @@ def cd_dashboard():
 		       (SELECT id FROM time_entries WHERE project_id = p.id AND ended_at IS NULL LIMIT 1) AS active_timer_id
 		FROM projects p
 		WHERE p.project_type = 'personal'
+		  AND p.archived_at IS NULL
 		ORDER BY p.updated DESC
 	''').fetchall()
 
@@ -366,8 +379,12 @@ def cd_dashboard():
 @command_deck_bp.route('/command-deck/projects')
 @cd_auth_required
 def cd_projects():
+	"""Projects index. Hides archived by default; the page header has a
+	toggle that flips ?archived=1, which surfaces archived rows alongside
+	active so the user can browse + restore them."""
+	include_archived = request.args.get('archived') == '1'
 	conn = get_db()
-	projects = conn.execute('''
+	personal_sql = '''
 		SELECT p.*,
 		       (SELECT COUNT(*) FROM tasks t WHERE t.project_id = p.id AND t.status = 'open') AS open_task_count,
 		       (SELECT COUNT(*) FROM blocks b WHERE b.project_id = p.id) AS block_count,
@@ -375,10 +392,13 @@ def cd_projects():
 		       (SELECT id FROM time_entries WHERE project_id = p.id AND ended_at IS NULL LIMIT 1) AS active_timer_id
 		FROM projects p
 		WHERE p.project_type = 'personal'
-		ORDER BY p.updated DESC
-	''').fetchall()
-	work_areas = _fetch_work_areas(conn)
-	subprojects = _fetch_subprojects(conn)
+	'''
+	if not include_archived:
+		personal_sql += ' AND p.archived_at IS NULL'
+	personal_sql += ' ORDER BY p.updated DESC'
+	projects = conn.execute(personal_sql).fetchall()
+	work_areas = _fetch_work_areas(conn, include_archived=include_archived)
+	subprojects = _fetch_subprojects(conn, include_archived=include_archived)
 	conn.close()
 	return render_template(
 		'command_deck_projects.html',
@@ -386,6 +406,7 @@ def cd_projects():
 		work_areas=[dict(a) for a in work_areas],
 		subprojects=[dict(s) for s in subprojects],
 		private_projects_enabled=bool(PRIVATE_PROJECTS_PIN),
+		include_archived=include_archived,
 	)
 
 
@@ -725,6 +746,33 @@ def cd_project_delete(slug):
 		conn.commit()
 	conn.close()
 	return redirect(url_for('command_deck.cd_projects'))
+
+
+@command_deck_bp.route('/command-deck/projects/<slug>/archive', methods=['POST'])
+@cd_auth_required
+def cd_project_archive(slug):
+	"""Toggle the project's archive state. Soft-delete pattern — projects
+	with archived_at set are filtered out of active views (dashboard,
+	pickers, etc.) but their data persists. Time entries, tickets, meetings,
+	mileage all keep working with the archived project as a passive parent."""
+	conn = get_db()
+	project = conn.execute('SELECT * FROM projects WHERE slug = ?', (slug,)).fetchone()
+	if not project:
+		conn.close()
+		return jsonify({'error': 'not_found'}), 404
+	now = et_now()
+	new_state = None if project['archived_at'] else now
+	conn.execute(
+		'UPDATE projects SET archived_at = ?, updated = ? WHERE id = ?',
+		(new_state, now, project['id'])
+	)
+	conn.commit()
+	conn.close()
+	return jsonify({
+		'success': True,
+		'archived': bool(new_state),
+		'archived_at': new_state,
+	})
 
 
 @command_deck_bp.route('/command-deck/areas/<slug>/')

--- a/blueprints/meetings.py
+++ b/blueprints/meetings.py
@@ -156,6 +156,7 @@ def meeting_detail(meeting_id):
 		FROM projects
 		WHERE project_type IN ('work_subproject', 'personal')
 		  AND is_private = 0
+		  AND archived_at IS NULL
 		ORDER BY title ASC
 	''').fetchall()
 

--- a/blueprints/mileage.py
+++ b/blueprints/mileage.py
@@ -165,6 +165,7 @@ def mileage_index():
 		FROM projects
 		WHERE project_type IN ('work_subproject', 'personal')
 		  AND is_private = 0
+		  AND archived_at IS NULL
 		ORDER BY title ASC
 	''').fetchall()
 
@@ -235,6 +236,7 @@ def _form_context(conn, entry=None):
 		FROM projects
 		WHERE project_type IN ('work_subproject', 'personal')
 		  AND is_private = 0
+		  AND archived_at IS NULL
 		ORDER BY title ASC
 	''').fetchall()
 	settings_row = conn.execute('SELECT * FROM settings WHERE id = 1').fetchone()

--- a/blueprints/settings.py
+++ b/blueprints/settings.py
@@ -55,6 +55,7 @@ def settings_page():
 		FROM projects
 		WHERE project_type IN ('work_subproject', 'personal')
 		  AND is_private = 0
+		  AND archived_at IS NULL
 		ORDER BY title ASC
 	''').fetchall()
 	conn.close()

--- a/blueprints/tickets.py
+++ b/blueprints/tickets.py
@@ -113,6 +113,7 @@ def tickets_index():
 		FROM projects
 		WHERE project_type IN ('work_subproject', 'personal')
 		  AND is_private = 0
+		  AND archived_at IS NULL
 		ORDER BY title ASC
 	''').fetchall()
 	conn.close()
@@ -264,6 +265,7 @@ def ticket_detail(ticket_id):
 		FROM projects
 		WHERE project_type IN ('work_subproject', 'personal')
 		  AND is_private = 0
+		  AND archived_at IS NULL
 		ORDER BY title ASC
 	''').fetchall()
 	time_categories = conn.execute(

--- a/blueprints/time_tracking.py
+++ b/blueprints/time_tracking.py
@@ -228,7 +228,7 @@ def time_start():
 
 	conn = get_db()
 	project = conn.execute(
-		'SELECT id, project_type FROM projects WHERE id = ?', (project_id,)
+		'SELECT id, project_type, archived_at FROM projects WHERE id = ?', (project_id,)
 	).fetchone()
 	if not project:
 		conn.close()
@@ -239,6 +239,12 @@ def time_start():
 			'error': 'project_not_trackable',
 			'project_type': project['project_type'],
 		}), 400
+	# Don't allow new timers on archived projects. Existing running timers
+	# keep ticking (we don't auto-stop them on archive); the user just can't
+	# start a fresh one.
+	if project['archived_at']:
+		conn.close()
+		return jsonify({'error': 'project_archived'}), 400
 
 	# Phase 1.5 — task_id must point to a task on this project
 	if task_id:
@@ -699,6 +705,7 @@ def time_projects():
 		FROM projects
 		WHERE project_type = 'work_area'
 		  AND is_private = 0
+		  AND archived_at IS NULL
 		ORDER BY title ASC
 	''').fetchall()
 	out = {'areas': [], 'personal': []}
@@ -709,6 +716,7 @@ def time_projects():
 			WHERE project_type = 'work_subproject'
 			  AND parent_project_id = ?
 			  AND is_private = 0
+			  AND archived_at IS NULL
 			ORDER BY updated DESC, title ASC
 		''', (a['id'],)).fetchall()
 		out['areas'].append({
@@ -724,6 +732,7 @@ def time_projects():
 		WHERE project_type = 'personal'
 		  AND is_private = 0
 		  AND tracking_enabled = 1
+		  AND archived_at IS NULL
 		ORDER BY updated DESC, title ASC
 	''').fetchall()
 	out['personal'] = [dict(p) for p in personals]

--- a/helpers/db.py
+++ b/helpers/db.py
@@ -80,6 +80,7 @@ def fetch_assign_picker_groups(conn):
 		LEFT JOIN projects parent ON p.parent_project_id = parent.id
 		WHERE p.is_private = 0
 		  AND p.project_type IN ('personal', 'work_subproject')
+		  AND p.archived_at IS NULL
 		ORDER BY p.project_type ASC, parent.title ASC, p.title ASC
 	''').fetchall()
 	work_groups = {}

--- a/migrate_add_project_archive.py
+++ b/migrate_add_project_archive.py
@@ -1,0 +1,58 @@
+"""
+migrate_add_project_archive.py
+Project archive — soft-delete pattern.
+
+What it does (idempotent):
+
+  + projects.archived_at   TEXT   -- ISO 8601 ET-local datetime; NULL = active
+
+Archived projects:
+  - Hide from active views by default (dashboard, projects list, area pages,
+    project pickers everywhere — tickets / meetings / mileage / time tracking).
+  - Time entries continue to surface in reports — that's the whole point.
+    Your timesheet history stays intact while the project clears out of the
+    workspace.
+  - Are reachable via the projects page's "Show archived" toggle, where a
+    one-click UNARCHIVE button restores them.
+
+Hard-delete still exists; archive is the gentler primary action. If a
+project ever does get hard-deleted, time_entries currently CASCADE — that
+question is deferred until Aaron actually wants to use hard-delete on a
+project with history.
+
+Run from PythonAnywhere bash:
+    cd /home/aaronaiken/status_update
+    python migrate_add_project_archive.py
+"""
+
+import os
+import sqlite3
+
+DB_FILE = os.path.join(
+	os.environ.get('COCKPIT_REPO_ROOT', '/home/aaronaiken/status_update'),
+	'assets/data/command_deck.db'
+)
+
+
+def column_exists(cur, table, col):
+	cols = [row[1] for row in cur.execute(f"PRAGMA table_info({table})").fetchall()]
+	return col in cols
+
+
+def run():
+	if not os.path.exists(DB_FILE):
+		print(f"× DB not found at {DB_FILE}")
+		return
+	conn = sqlite3.connect(DB_FILE)
+	cur = conn.cursor()
+	if column_exists(cur, 'projects', 'archived_at'):
+		print("— projects.archived_at already in place — no changes")
+	else:
+		cur.execute('ALTER TABLE projects ADD COLUMN archived_at TEXT')
+		conn.commit()
+		print("✓ Added: projects.archived_at")
+	conn.close()
+
+
+if __name__ == '__main__':
+	run()

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -5428,3 +5428,49 @@ textarea.cd-ticket-input { min-height: auto; }
   animation: cd-target-pulse 1.6s ease-out;
   scroll-margin-top: 80px;  /* stay clear of the fixed top bars */
 }
+
+/* Project archive — banner on the detail page + page-title styling */
+.cd-archived-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.65rem 0.9rem;
+  margin-bottom: 1rem;
+  border: 1px solid rgba(170, 170, 170, 0.35);
+  border-left: 3px solid var(--cd-text-dim);
+  background: rgba(150, 150, 150, 0.06);
+  font-family: var(--cd-font-ui);
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  color: var(--cd-text-dim);
+  border-radius: 2px;
+}
+.cd-archived-banner strong {
+  color: var(--cd-text-dim);
+  letter-spacing: 0.18em;
+  margin-right: 0.4rem;
+}
+.cd-page-title.is-archived {
+  color: var(--cd-text-dim);
+}
+.cd-project-edit-actions { align-items: center; }
+.cd-project-edit-spacer { flex: 1; }
+.cd-project-archive-btn {
+  margin-right: auto;
+}
+
+/* Projects index — show-archived link + mode label */
+.cd-projects-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+.cd-projects-archived-mode {
+  font-family: var(--cd-font-ui);
+  font-size: 0.6rem;
+  letter-spacing: 0.16em;
+  color: var(--cd-text-dim);
+  text-transform: uppercase;
+  margin-left: 0.5rem;
+}

--- a/static/command_deck.css
+++ b/static/command_deck.css
@@ -5414,3 +5414,17 @@ textarea.cd-ticket-input { min-height: auto; }
   border-color: var(--cd-amber);
   color: var(--cd-amber-hi);
 }
+
+/* Today bar drilldown — landing pulse on :target rows */
+@keyframes cd-target-pulse {
+  0%   { background: rgba(212, 136, 10, 0.32); }
+  60%  { background: rgba(212, 136, 10, 0.18); }
+  100% { background: transparent; }
+}
+.cd-task-item:target,
+.cd-checklist-item:target,
+.cd-block:target,
+.bd-item:target {
+  animation: cd-target-pulse 1.6s ease-out;
+  scroll-margin-top: 80px;  /* stay clear of the fixed top bars */
+}

--- a/templates/below_deck.html
+++ b/templates/below_deck.html
@@ -120,7 +120,7 @@
         {% set open_tasks = tasks | selectattr('status', 'equalto', 'open') | list %}
         {% if open_tasks %}
             {% for task in open_tasks %}
-            <li class="bd-item" data-id="{{ task.id }}" draggable="true">
+            <li class="bd-item" id="task-{{ task.id }}" data-id="{{ task.id }}" draggable="true">
                 <div class="bd-drop-indicator"></div>
                 <span class="bd-handle" title="Hold to reorder">⠿</span>
                 <button class="bd-check" onclick="bdComplete('{{ task.id }}')" title="Done"></button>

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -64,10 +64,17 @@
       </div>
       {% endif %}
 
+      {% if project.archived_at %}
+      <div class="cd-archived-banner">
+        <span><strong>// ARCHIVED</strong> — this project is hidden from active views. Time entries, tickets, meetings, and mileage still work.</span>
+        <button type="button" class="cd-btn ghost sm" id="unarchiveBannerBtn">UNARCHIVE</button>
+      </div>
+      {% endif %}
+
       <!-- PROJECT TITLE + META -->
       <div class="cd-flex-between cd-mb-sm">
         <div>
-          <h1 class="cd-page-title" id="projectTitle">
+          <h1 class="cd-page-title{% if project.archived_at %} is-archived{% endif %}" id="projectTitle">
             {{ project.title }}
             {% if project.tracking_enabled %}
               <span class="cd-tracking-icon cd-title-icon" title="Time tracking enabled">⏱</span>
@@ -564,7 +571,9 @@
             ⏱ TIME TRACKING
           </label>
         </div>
-    <div class="cd-modal-actions">
+    <div class="cd-modal-actions cd-project-edit-actions">
+      <button class="cd-btn ghost cd-project-archive-btn" id="editArchiveBtn">{% if project.archived_at %}UNARCHIVE PROJECT{% else %}ARCHIVE PROJECT{% endif %}</button>
+      <span class="cd-project-edit-spacer"></span>
       <button class="cd-btn ghost" id="editCancelBtn">CANCEL</button>
       <button class="cd-btn primary" id="editConfirmBtn">SAVE</button>
     </div>
@@ -1266,6 +1275,20 @@ document.getElementById('blocksContainer').addEventListener('click', function(e)
   document.getElementById('editModal').addEventListener('click',function(e){
     if(e.target===this) this.classList.remove('open');
   });
+  // Archive toggle — same endpoint handles archive + unarchive
+  function toggleArchive() {
+    if (!confirm({% if project.archived_at %}'Restore this project to active?'{% else %}'Archive this project? It will hide from active views; data is preserved and can be restored.'{% endif %})) return;
+    fetch(`/command-deck/projects/${PROJECT_SLUG}/archive`, {
+      method: 'POST', credentials: 'same-origin'
+    }).then(r => r.json()).then(d => {
+      if (d.success) window.location.reload();
+    });
+  }
+  var archiveBtn = document.getElementById('editArchiveBtn');
+  if (archiveBtn) archiveBtn.addEventListener('click', toggleArchive);
+  var unarchiveBanner = document.getElementById('unarchiveBannerBtn');
+  if (unarchiveBanner) unarchiveBanner.addEventListener('click', toggleArchive);
+
   document.getElementById('editConfirmBtn').addEventListener('click', async function(){
     const title=document.getElementById('editTitle').value.trim();
     const desc=document.getElementById('editDesc').value.trim();

--- a/templates/command_deck_project.html
+++ b/templates/command_deck_project.html
@@ -121,7 +121,7 @@
       <div class="cd-blocks" id="blocksContainer">
 
         {% for block in blocks %}
-          <div class="cd-block" data-block-id="{{ block.id }}" data-type="{{ block.type }}">
+          <div class="cd-block" id="block-{{ block.id }}" data-block-id="{{ block.id }}" data-type="{{ block.type }}">
             <div class="cd-block-header" data-block-id="{{ block.id }}">
               <span class="cd-block-drag-handle" title="Drag to reorder">⠿</span>
               <span class="cd-block-title-display"
@@ -169,7 +169,7 @@
               {% elif block.type == 'checklist' %}
                 <ul class="cd-checklist" data-block-id="{{ block.id }}">
                   {% for item in block['items'] %}
-                    <li class="cd-checklist-item {% if item.checked %}checked{% endif %}" data-item-id="{{ item.id }}" data-item-text="{{ item.text }}">
+                    <li class="cd-checklist-item {% if item.checked %}checked{% endif %}" id="item-{{ item.id }}" data-item-id="{{ item.id }}" data-item-text="{{ item.text }}">
                       <input type="checkbox"
                         {% if item.checked %}checked{% endif %}
                         data-item-id="{{ item.id }}"
@@ -235,7 +235,7 @@
           {% if project_tasks %}
             <ul class="cd-task-list" id="projectTaskList">
               {% for task in project_tasks %}
-                <li class="cd-task-item" data-id="{{ task.id }}" data-task-title="{{ task.title }}">
+                <li class="cd-task-item" id="task-{{ task.id }}" data-id="{{ task.id }}" data-task-title="{{ task.title }}">
                   <input type="checkbox" class="cd-task-check project-task-check" data-id="{{ task.id }}" data-slug="{{ project.slug }}">
                   <span class="cd-task-title">{{ task.title }}</span>
                   <span class="cd-due-wrapper"

--- a/templates/command_deck_projects.html
+++ b/templates/command_deck_projects.html
@@ -48,8 +48,15 @@
     <div class="cd-content">
 
       <div class="cd-flex-between cd-mb">
-        <h1 class="cd-page-title">Projects</h1>
-        <button class="cd-btn primary" id="newProjectBtn">+ NEW PROJECT</button>
+        <h1 class="cd-page-title">Projects{% if include_archived %} <span class="cd-projects-archived-mode">// archived view</span>{% endif %}</h1>
+        <div class="cd-projects-actions">
+          {% if include_archived %}
+            <a class="cd-btn ghost sm" href="/command-deck/projects/">← back to active</a>
+          {% else %}
+            <a class="cd-btn ghost sm" href="/command-deck/projects/?archived=1">show archived</a>
+            <button class="cd-btn primary" id="newProjectBtn">+ NEW PROJECT</button>
+          {% endif %}
+        </div>
       </div>
 
       <!-- WORK / PERSONAL TABS -->

--- a/templates/includes/today_panel.html
+++ b/templates/includes/today_panel.html
@@ -150,11 +150,13 @@
 }
 
 /* ---- TASK ROWS ---- */
-a.today-ticket-row {
+a.today-ticket-row,
+a.today-row-link {
   text-decoration: none;
   color: inherit;
 }
-a.today-ticket-row:hover { color: var(--cd-amber-hi); }
+a.today-ticket-row:hover,
+a.today-row-link:hover { color: var(--cd-amber-hi); }
 .today-task-row {
   display: flex;
   align-items: center;
@@ -452,7 +454,11 @@ a.today-ticket-row:hover { color: var(--cd-amber-hi); }
     });
     body.innerHTML = html;
     body.querySelectorAll('.today-check-btn:not([disabled])').forEach(function(btn) {
-      btn.addEventListener('click', function() {
+      btn.addEventListener('click', function(ev) {
+        // Stop the click from bubbling to the parent <a> row — checkbox is
+        // mark-complete-in-place; the row link is for navigation.
+        ev.preventDefault();
+        ev.stopPropagation();
         completeRow(btn.getAttribute('data-kind'), btn.getAttribute('data-id'), btn);
       });
     });
@@ -493,6 +499,23 @@ a.today-ticket-row:hover { color: var(--cd-amber-hi); }
         '</a>';
     }
 
+    // Compute the navigation target — clicking the row body lands the user
+    // on the right page anchored at the right element so they can hit ⏱.
+    function hrefForEntry(e, k) {
+      if (k === 'task') {
+        if (e.project_slug) return '/command-deck/projects/' + encodeURIComponent(e.project_slug) + '/#task-' + e.id;
+        return '/below-deck#task-' + e.id;
+      }
+      if (k === 'item') {
+        if (e.project_slug) return '/command-deck/projects/' + encodeURIComponent(e.project_slug) + '/#item-' + e.id;
+      }
+      if (k === 'block') {
+        if (e.project_slug) return '/command-deck/projects/' + encodeURIComponent(e.project_slug) + '/#block-' + e.id;
+      }
+      return '#';
+    }
+    var rowHref = hrefForEntry(entry, kind);
+
     if (kind === 'block') {
       // Block row: title + progress, no checkbox. Progress is the source-
       // line content; project title shifts to a small dim suffix line.
@@ -507,11 +530,11 @@ a.today-ticket-row:hover { color: var(--cd-amber-hi); }
       // Use a non-clickable spacer in the checkbox slot so the row layout
       // stays aligned with task and item rows.
       btnHtml = '<span class="today-block-spacer" aria-hidden="true">▣</span>';
-      return '<div class="today-task-row today-block-row' + (isDone ? ' is-done' : '') + '" data-id="' + entry.id + '" data-kind="block">' +
+      return '<a class="today-task-row today-block-row today-row-link' + (isDone ? ' is-done' : '') + '" data-id="' + entry.id + '" data-kind="block" href="' + rowHref + '">' +
         btnHtml +
         '<span class="today-task-title">' + titleHtml + '</span>' +
         '<span class="today-task-source">' + escHtml(progressText) + ' · ' + escHtml(source) + '</span>' +
-        '</div>';
+        '</a>';
     }
 
     if (kind === 'item') {
@@ -525,12 +548,15 @@ a.today-ticket-row:hover { color: var(--cd-amber-hi); }
     var btnAttrs = 'data-id="' + entry.id + '" data-kind="' + kind + '"';
     btnHtml = isDone
       ? '<button class="today-check-btn checked" disabled title="Completed">' + btnInner + '</button>'
-      : '<button class="today-check-btn" ' + btnAttrs + ' title="Mark complete">' + btnInner + '</button>';
-    return '<div class="today-task-row' + (isDone ? ' is-done' : '') + '" data-id="' + entry.id + '" data-kind="' + kind + '">' +
+      : '<button class="today-check-btn today-row-stop-prop" ' + btnAttrs + ' title="Mark complete">' + btnInner + '</button>';
+    // Wrap the row body in an anchor so tapping anywhere except the checkbox
+    // navigates to the source. The checkbox button stops propagation in JS so
+    // a click there fires the complete action without also navigating.
+    return '<a class="today-task-row today-row-link' + (isDone ? ' is-done' : '') + '" data-id="' + entry.id + '" data-kind="' + kind + '" href="' + rowHref + '">' +
       btnHtml +
       '<span class="today-task-title">' + titleHtml + '</span>' +
       '<span class="today-task-source">' + escHtml(source) + '</span>' +
-      '</div>';
+      '</a>';
   }
 
   function completeRow(kind, id, btn) {


### PR DESCRIPTION
## Summary

Two refinements that surfaced from real usage:

**1. Today bar drilldown** — tapping a row in the slim today panel dropdown now navigates to the source page anchored at the matching element so you can hit ⏱ in one tap. Tasks/items/blocks land on `/command-deck/projects/<slug>/#task-NNN` (or `#item-NNN` / `#block-NNN`). Below Deck tasks land on `/below-deck#task-NNN`. Tickets already navigated. The checkbox stays as complete-in-place; row body navigates. A small 1.6s amber pulse on `:target` rows + 80px `scroll-margin-top` makes the landing obvious past the fixed top bars.

**2. Project archive** — soft-delete pattern. Projects gain a nullable `archived_at` column. Archive button on the edit modal (toggles to UNARCHIVE for archived projects); banner on the detail page when archived. Active surfaces filter archived (dashboard / projects list / area pages / `/time/projects` / ticket+meeting+mileage+settings pickers / Below Deck assign). Reports + Huyang stay unfiltered — timesheet history persists, memory stays searchable. `/time/start` rejects new timers on archived projects. `/command-deck/projects/?archived=1` surfaces them for browsing + one-click restore.

## Test plan

- [ ] PA: `python migrate_add_project_archive.py` — expect 1 added; idempotent
- [ ] Slim today bar dropdown: tap a task row → lands on project page with the row pulsing amber; tap a Below Deck task → lands on /below-deck pulsing
- [ ] Star a checklist item, tap row → lands on project page with item highlighted
- [ ] Archive a project from the edit modal → banner appears; project disappears from dashboard / projects list / `/time/projects`
- [ ] Try to start a timer from the floating panel on an archived project → rejected
- [ ] `/command-deck/projects/?archived=1` shows archived alongside active with the mode label
- [ ] Reports still show entries from archived project's history
- [ ] Huyang on an archived-project context still answers from its content
- [ ] Unarchive → project reappears in default views; timers work again

🤖 Generated with [Claude Code](https://claude.com/claude-code)